### PR TITLE
Simple matches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Configuration
 
 BUILD_OVERLAYS ?= 1
-BUILD_SCREENS  ?= 0
+BUILD_SCREENS  ?= 1
 BUILD_MAPS     ?= 0
 NON_MATCHING   ?= 0
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An in-progress decompilation of the 1.1 US release of Silent Hill on the Playstation 1.
 
-## Building (Linux)
+## Building (Linux/Windows)
 
 ### Install build dependencies
 The build process has the following package requirements:
@@ -14,14 +14,14 @@ The build process has the following package requirements:
 - bchunk
 - 7z
 
-Under a Debian-based distribution, you can install these with the following commands:
+Under a Debian-based distribution (or Windows with a Debian-based WSL2 setup), you can install these with the following commands:
 ```
 sudo apt update
 sudo apt install git build-essential binutils-mips-linux-gnu cpp-mips-linux-gnu python3 bchunk p7zip-full p7zip-rar
 ```
 
 ### Clone the repository
-Clone `https://github.com/Vatuu/silent-hill-decomp` in whatever directory you wish. Make sure to clone recursively!
+Clone `https://github.com/Vatuu/silent-hill-decomp` to your desired directory. Make sure to clone recursively!
 ```
 git clone --recursive https://github.com/Vatuu/silent-hill-decomp.git && cd silent-hill-decomp
 ```
@@ -29,24 +29,25 @@ git clone --recursive https://github.com/Vatuu/silent-hill-decomp.git && cd sile
 ### Install Python3 requirements
 Run `pip3 install -r requirements.txt`
 
-### Placing the ROM
-Obviously, you will need to provide your own rom dump of the game. The required version is Silent Hill NTSC-U 1.1.
-If done correctly, you will end up with a .BIN and a .CUE file. These need to be placed inside the `rom/image` folder and renamed to SLUS-00707.bin/.cue respectively.
+### Place the ROM
+Obviously, you will need to provide your own ROM dump of the game. The required version is Silent Hill NTSC-U 1.1.
+If done correctly, you will end up with a .BIN and a .CUE file. These must be placed in the `rom/image` folder and renamed to SLUS-00707.bin/.cue, respectively.
 SHA1 Hashes:
 - .cue: `299D08DCB44E7516F394C3DD5BA40690AE33FD22` 84 Bytes
 - .bin: `34278D31D9B9B12B3B5DB5E45BCBE548991ECBC7` 616,494,480 Bytes / 587 MiB
 
 ### Build the code
-Run `make setup` to extract needed assets/code from the bin.
+Run `make setup` to extract needed assets and code from the binary.
 If setup was successful, run `make` to build.
 Once the build has finished, a folder will be produced with the name `build`. Inside this, you will find the output.
 
-Additional Make Commands:
-* `check`: builds the executable/overlays and makes a checksums comprobation comparing it with the original file
-* `build-c`: clears the configuration of the project without deleting files
-* `build-C`: clears the configuration of the project without deleting files and, after compilation, makes a checksums comprobation comparing it with the original file
+Additional Make commands:
+* `check`: Builds the executable and overlays. After compilation, it compares checksums with the original files.
+* `build-c`: Clears the configuration of the project without deleting files.
+* `build-C`: Clears the configuration of the project without deleting files. After compilation, it compares checksums with the original files.
 
-`build-c/build-C` are obligatory in case of modifing the configuration in the `Makefile` in case of wanting to work on screen overlays and the maps overlays
+NOTE: `build-c/build-C` are obligatory if the configuration in the `Makefile` has been modified when intending to work on different overlays.
 
 ## Contributing
-Contributions are welcome. If you would like to reserve a function, open a PR with the function or file name(s).
+Contributions are welcome. Join us in the PS1/PS2 Decompolation server in the `#silent-hill` channel:
+https://discord.gg/VwCPdfbxgm

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ Additional Make commands:
 NOTE: `build-c/build-C` are obligatory if the configuration in the `Makefile` has been modified when intending to work on different overlays.
 
 ## Contributing
-Contributions are welcome. Join us in the PS1/PS2 Decompolation server in the `#silent-hill` channel:
+Contributions are welcome. Join us on the PS1/PS2 Decompolation server in the `#silent-hill` channel:
 https://discord.gg/VwCPdfbxgm

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -22,7 +22,10 @@ extern s_800A90FC D_800A90FC[];
 /** Unknown bodyprog var. Set in `Fs_DoQueueThingWhenEmpty`. */
 extern s32 D_800C489C;
 
-/** Bodyprog function that fades the screen out? Called by `main`. */
+/** Bodyprog function that fades the screen out?
+ * Called by:
+ * - `main` in main.c
+ * - 'func_801E709C' in saveload.c */
 void func_800314EC(s_FsImageDesc* arg0);
 
 /** Bodyprog entrypoint. Called by `main`. */

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -13,7 +13,7 @@ typedef struct
     s16 field_02;
     u32 field_04;
     u32 field_08;
-    u32 field_0c;
+    u32 field_0C;
 } s_800A90FC;
 
 /** Unknown bodyprog var. Used in `Fs_StartQueueReadAnm`. */

--- a/include/main/fsqueue.h
+++ b/include/main/fsqueue.h
@@ -83,6 +83,7 @@ enum FsQueueOperation
 /**
  * @brief Extra queue entry data describing where to upload a TIM after reading.
  * See `FsQueueExtra`.
+ * 
  * @note `tPage` seems to be byte swapped.
  */
 typedef struct

--- a/include/main/rng.h
+++ b/include/main/rng.h
@@ -10,7 +10,7 @@
 extern u32 g_RngSeed;
 
 /**
- * @brief Generates a new random 32-bit unsigned integer and updates the
+ * @brief Generates a new random 32-bit unsigned integer and updates
  * `g_RngSeed`.
  *
  * This function implements a Linear Congruential Generator (LCG) Random Number
@@ -23,15 +23,15 @@ extern u32 g_RngSeed;
 u32 Rng_Rand32(void);
 
 /**
- * @brief Generates a new random positive 16-bit short integer.
+ * @brief Generates a new random 16-bit unsigned integer.
  * 
  * This function calls `Rng_Rand32` to generate a random number, then
  * shifts the result right to produce a value within the range
- * of 0 to 0x7FFF (16-bit - sign).
+ * of [0, 0x7FFF].
  *
- * @return A random positive 16-bit short integer (0 to 0x7FFF).
+ * @return A random positive 16-bit unsigned integer (u16).
  */
-s16 Rng_Rand16(void);
+u16 Rng_Rand16(void);
 
 /**
  * @brief Returns the current random seed value.

--- a/include/main/rng.h
+++ b/include/main/rng.h
@@ -29,9 +29,9 @@ u32 Rng_Rand32(void);
  * shifts the result right to produce a value within the range
  * of [0, 0x7FFF].
  *
- * @return A random positive 16-bit unsigned integer (u16).
+ * @return A random positive 16-bit unsigned integer (u32).
  */
-u16 Rng_Rand16(void);
+u32 Rng_Rand16(void);
 
 /**
  * @brief Returns the current random seed value.

--- a/include/screens/b_konami/b_konami.h
+++ b/include/screens/b_konami/b_konami.h
@@ -1,0 +1,11 @@
+#ifndef B_KONAMI_H
+#define B_KONAMI_H
+
+#include "common.h"
+
+void func_800CA234(void);
+s32  func_800CA240(s32* arg0);
+void func_800CA24C(s32 arg0, s32 arg1, s32 arg2);
+s32  func_800CA2B8(void);
+
+#endif

--- a/include/screens/credits/credits.h
+++ b/include/screens/credits/credits.h
@@ -7,6 +7,8 @@ void func_801E3DD0(void);
 
 s32 func_801E3DF8(s32 arg0);
 
+void func_801E42F8(s16 arg0, s16 arg1);
+
 /**
  * @brief Sets the current RGB+command color for D_800AFE10.
  *

--- a/include/screens/credits/credits.h
+++ b/include/screens/credits/credits.h
@@ -1,0 +1,13 @@
+#ifndef CREDITS_H
+#define CREDITS_H
+
+#include "common.h"
+
+s32 func_801E3DF8(s32 arg0);
+
+void func_801E4310(s32 r, s32 g, s32 b);
+void func_801E4340(s8 arg0);
+
+void func_801E4BC8(s8 arg0);
+
+#endif

--- a/include/screens/credits/credits.h
+++ b/include/screens/credits/credits.h
@@ -12,7 +12,8 @@ s32 func_801E3DF8(s32 arg0);
  *
  * This function sets the packed RGB+command color for D_800AFE10 with
  * the fourth component hard set to 0x64, possibly a graphics command.
- * RGB order only assumed.
+ * 
+ * @note RGB order only assumed.
  *
  * @param r Red component.
  * @param g Green component.
@@ -27,7 +28,8 @@ void func_801E4340(s8 arg0);
  *
  * This function sets the packed RGB+command color for D_800AFE10 with
  * the fourth component hard set to 0x2C, possibly a graphics command.
- * RGB order only assumed.
+ * 
+ * @note RGB order only assumed.
  *
  * @param r Red component.
  * @param g Green component.

--- a/include/screens/credits/credits.h
+++ b/include/screens/credits/credits.h
@@ -11,7 +11,7 @@ s32 func_801E3DF8(s32 arg0);
  * @brief Sets the current RGB+command color for D_800AFE10.
  *
  * This function sets the packed RGB+command color for D_800AFE10 with
- * the forth component hard set to 0x64, possibly a graphics command.
+ * the fourth component hard set to 0x64, possibly a graphics command.
  * RGB order only assumed.
  *
  * @param r Red component.
@@ -26,7 +26,7 @@ void func_801E4340(s8 arg0);
  * @brief Sets the current RGB+command color for D_800AFE2C.
  *
  * This function sets the packed RGB+command color for D_800AFE10 with
- * the forth component hard set to 0x2C, possibly a graphics command.
+ * the fourth component hard set to 0x2C, possibly a graphics command.
  * RGB order only assumed.
  *
  * @param r Red component.

--- a/include/screens/credits/credits.h
+++ b/include/screens/credits/credits.h
@@ -3,10 +3,37 @@
 
 #include "common.h"
 
+void func_801E3DD0(void);
+
 s32 func_801E3DF8(s32 arg0);
 
+/**
+ * @brief Sets the current RGB+command color for D_800AFE10.
+ *
+ * This function sets the packed RGB+command color for D_800AFE10 with
+ * the forth component hard set to 0x64, possibly a graphics command.
+ * RGB order only assumed.
+ *
+ * @param r Red component.
+ * @param g Green component.
+ * @param b Blue component.
+ */
 void func_801E4310(s32 r, s32 g, s32 b);
+
 void func_801E4340(s8 arg0);
+
+/**
+ * @brief Sets the current RGB+command color for D_800AFE2C.
+ *
+ * This function sets the packed RGB+command color for D_800AFE10 with
+ * the forth component hard set to 0x2C, possibly a graphics command.
+ * RGB order only assumed.
+ *
+ * @param r Red component.
+ * @param g Green component.
+ * @param b Blue component.
+ */
+void func_801E4B98(s32 r, s32 g, s32 b);
 
 void func_801E4BC8(s8 arg0);
 

--- a/include/screens/credits/credits.h
+++ b/include/screens/credits/credits.h
@@ -3,6 +3,8 @@
 
 #include "common.h"
 
+void func_801E2E28(s32 idx);
+
 void func_801E3DD0(void);
 
 s32 func_801E3DF8(s32 arg0);
@@ -24,6 +26,7 @@ void func_801E42F8(s16 arg0, s16 arg1);
 void func_801E4310(s32 r, s32 g, s32 b);
 
 void func_801E4340(s8 arg0);
+void func_801E434C(u32 arg0, u32 arg1);
 
 /**
  * @brief Sets the current RGB+command color for D_800AFE2C.
@@ -40,5 +43,8 @@ void func_801E4340(s8 arg0);
 void func_801E4B98(s32 r, s32 g, s32 b);
 
 void func_801E4BC8(s8 arg0);
+
+/** Identical to func_801E434C except for the global variable it modifies. */
+void func_801E4BD4(u32 arg0, u32 arg1);
 
 #endif

--- a/include/screens/options/options.h
+++ b/include/screens/options/options.h
@@ -1,0 +1,11 @@
+#ifndef OPTIONS_H
+#define OPTIONS_H
+
+#include "common.h"
+
+void func_801E3F68(void);
+
+//** Called by func_801E3F68. */
+void func_801E3FB8(s32 arg0, u8 arg1);
+
+#endif

--- a/include/screens/options/options.h
+++ b/include/screens/options/options.h
@@ -4,8 +4,7 @@
 #include "common.h"
 
 void func_801E3F68(void);
-
-//** Called by func_801E3F68. */
-void func_801E3FB8(s32 arg0, u8 arg1);
+void func_801E3F90(void);
+void func_801E3FB8(s32 arg0, s32 arg1);
 
 #endif

--- a/include/screens/saveload/saveload.h
+++ b/include/screens/saveload/saveload.h
@@ -3,12 +3,15 @@
 
 #include "common.h"
 
-struct s_UnkSaveLoad0;
+struct s_UnkSaveload0;
 
-s32 func_801E3078(s_UnkSaveLoad0* arg0);
+void func_801E2F90(s32 idx);
+
+s32 func_801E3078(s_UnkSaveload0* arg0);
 
 void func_801E709C(void);
 
+void func_801E7244(void);
 void func_801E72DC(void);
 
 #endif

--- a/include/screens/saveload/saveload.h
+++ b/include/screens/saveload/saveload.h
@@ -1,0 +1,14 @@
+#ifndef SAVELOAD_H
+#define SAVELOAD_H
+
+#include "common.h"
+
+struct s_UnkSaveLoad0;
+
+s32 func_801E3078(s_UnkSaveLoad0* arg0);
+
+void func_801E709C(void);
+
+void func_801E72DC(void);
+
+#endif

--- a/src/main/rng.c
+++ b/src/main/rng.c
@@ -12,7 +12,7 @@ u32 Rng_Rand32(void)
     return nextSeed;
 }
 
-u16 Rng_Rand16(void)
+u32 Rng_Rand16(void)
 {
     return Rng_Rand32() >> 17;
 }

--- a/src/main/rng.c
+++ b/src/main/rng.c
@@ -12,9 +12,9 @@ u32 Rng_Rand32(void)
     return nextSeed;
 }
 
-s16 Rng_Rand16(void)
+u16 Rng_Rand16(void)
 {
-    return Rng_Rand32() >> 0x11;
+    return Rng_Rand32() >> 17;
 }
 
 u32 Rng_GetSeed(void)
@@ -29,5 +29,5 @@ void Rng_SetSeed(u32 nextSeed)
 
 u16 Rng_Rand12(void)
 {
-    return Rng_Rand32() >> 0x14;
+    return Rng_Rand32() >> 20;
 }

--- a/src/screens/b_konami/b_konami.c
+++ b/src/screens/b_konami/b_konami.c
@@ -1,4 +1,15 @@
 #include "common.h"
+#include "screens/b_konami/b_konami.h"
+
+#include <libetc.h>
+
+extern s32 D_800CA4F4;
+extern s32 D_800CA4FC;
+extern s32 D_800CA500;
+extern s32 D_800CA504;
+extern s32 D_800CA508;
+extern s32 D_800CA50C;
+extern s32 D_800CA510;
 
 INCLUDE_ASM("asm/screens/b_konami/nonmatchings/b_konami", func_800C95AC);
 
@@ -12,12 +23,42 @@ INCLUDE_ASM("asm/screens/b_konami/nonmatchings/b_konami", func_800C9FB8);
 
 INCLUDE_ASM("asm/screens/b_konami/nonmatchings/b_konami", func_800CA120);
 
-INCLUDE_ASM("asm/screens/b_konami/nonmatchings/b_konami", func_800CA234);
+void func_800CA234(void)
+{
+    D_800CA4FC = 0;
+}
 
-INCLUDE_ASM("asm/screens/b_konami/nonmatchings/b_konami", func_800CA240);
+s32 func_800CA240(s32* arg0)
+{
+    return *arg0;
+}
 
-INCLUDE_ASM("asm/screens/b_konami/nonmatchings/b_konami", func_800CA24C);
+void func_800CA24C(s32 arg0, s32 arg1, s32 arg2)
+{
+    s32 var_a3;
+    s32* temp_v0;
 
-INCLUDE_ASM("asm/screens/b_konami/nonmatchings/b_konami", func_800CA2B8);
+    var_a3 = 0;
+    D_800CA4FC = 1;
+    D_800CA500 = arg0;
+    D_800CA504 = arg1;
+    D_800CA50C = arg0 + arg2;
+    D_800CA500 = arg0 + 4;
+    do
+    {
+        temp_v0 = D_800CA4F4 + var_a3;
+        var_a3 += 4;
+        *temp_v0 = 0;
+    }
+    while (var_a3 < 0x1000);
+    
+    D_800CA508 = 0xFEE;
+    D_800CA510 = 0;
+}
+
+s32 func_800CA2B8(void)
+{
+    return D_800CA4FC;
+}
 
 INCLUDE_ASM("asm/screens/b_konami/nonmatchings/b_konami", func_800CA2C8);

--- a/src/screens/credits/credits.c
+++ b/src/screens/credits/credits.c
@@ -1,15 +1,20 @@
 #include "common.h"
 #include "screens/credits/credits.h"
 
+// Padding added for now, but other unknown fields might exist.
 typedef struct UnkStruct0
 {
     s16 field_0;
     s16 field_2;
     s16 field_4;
-    u8  field_7; // Used as bool.
-
-    // Contains more unknown fields.
-    
+    s8  unk_6;
+    s8  field_7; // bool
+    s32 unk_8;
+    s32 unk_C;
+    s32 unk_10;
+    s16 field_14;
+    s16 unk_16;
+    s32 field_18;
 } UnkStruct0;
 
 extern s8  D_800AFE0E;

--- a/src/screens/credits/credits.c
+++ b/src/screens/credits/credits.c
@@ -1,9 +1,24 @@
 #include "common.h"
 #include "screens/credits/credits.h"
 
+typedef struct UnkStruct0
+{
+    s16 field_0;
+    s16 field_2;
+    s16 field_4;
+    u8  field_7; // Used as bool.
+
+    // Contains more unknown fields.
+    
+} UnkStruct0;
+
 extern s8  D_800AFE0E;
 extern s32 D_800AFE10; // Packed RGB+command color?
 extern s8  D_800AFE2A;
+extern s32 D_800AFE2C; // Packed RGB+command color?
+extern s32 D_801E600C;
+
+extern UnkStruct0 D_800AFE08;
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2E28);
 
@@ -25,7 +40,12 @@ INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E386C);
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E3970);
 
+// TODO: Should be a match.
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E3DD0);
+/*void func_801E3DD0(void)
+{
+    D_801E600C = Rng_Rand16();
+}*/
 
 s32 func_801E3DF8(s32 arg0)
 {
@@ -34,23 +54,16 @@ s32 func_801E3DF8(s32 arg0)
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E3E18);
 
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E42F8);
+void func_801E42F8(s16 arg0, s16 arg1)
+{
+    D_800AFE08.field_0 = arg0;
+    D_800AFE08.field_2 = arg1;
+    D_800AFE08.field_4 = arg0;
+}
 
-/**
- * @brief Set the current opaque RGB+command color for an unknown purpose.
- *
- * This function sets the packed RGB+command color of D_800AFE10.
- * The hard set component is either a graphics command code for a textured
- * rectangle, or an alpha, though the latter is unlikely given the PS1's
- * lack of proper alpha blending.
- *
- * @param r Red component.
- * @param g Green component.
- * @param b Blue component.
- */
 void func_801E4310(s32 r, s32 g, s32 b)
 {
-    D_800AFE10 = (r & 0xFF) | ((g & 0xFF) << 8) | ((b & 0xFF) << 16) | (100 << 24);
+    D_800AFE10 = (r & 0xFF) | ((g & 0xFF) << 8) | ((b & 0xFF) << 16) | (0x64 << 24);
 }
 
 void func_801E4340(s8 arg0)
@@ -64,7 +77,10 @@ INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4394);
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E47E0);
 
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4B98);
+void func_801E4B98(s32 r, s32 g, s32 b)
+{
+    D_800AFE2C = (r & 0xFF) | ((g & 0xFF) << 8) | ((b & 0xFF) << 16) | (0x2C << 24);
+}
 
 void func_801E4BC8(s8 arg0)
 {

--- a/src/screens/credits/credits.c
+++ b/src/screens/credits/credits.c
@@ -1,38 +1,64 @@
 #include "common.h"
+#include "main/rng.h"
 #include "screens/credits/credits.h"
 
-// Used by func_801E434C
+void func_8004729C(u16);
+
 typedef struct
 {
-    s16 field_0;
-    s16 field_2;
-    s16 field_4;
-    s8  unk_6;
-    s8  field_7; // bool
-    s32 unk_8;
-    s32 unk_C;
+    s16 field_00;
+    s16 field_02;
+    s16 field_04;
+    s8  unk_06;
+    s8  field_07; // bool
+    s32 unk_08;
+    s32 unk_0C;
     s32 unk_10;
-    s16 field_14;
+    u16 field_14;
     s16 unk_16;
-    s32 field_18;
+    u32 field_18;
 } s_UnkCredits0; // Size: unknown
 
 // Used by func_801E2E28.
 typedef struct
 {
-    s32 field_0;
-    s16 field_4;
+    s16 field_00;
+    s16 field_02;
+    s16 field_04;
 } s_UnkCredits1; // Size: 6
 
-extern s8  D_800AFE0E;
-extern s32 D_800AFE10; // Packed RGB+command color?
-extern s8  D_800AFE2A;
-extern s32 D_800AFE2C; // Packed RGB+command color?
-extern s32 D_801E600C;
-
 extern s_UnkCredits0 D_800AFE08;
+extern s8            D_800AFE0E;
+extern s32           D_800AFE10; // Packed RGB+command color? Command is 0x64.
+extern s_UnkCredits0 D_800AFE24;
+extern s8            D_800AFE2A;
+extern s32           D_800AFE2C; // Packed RGB+command color? Command is 0x2C.
+extern s_UnkCredits1 D_801E5558[];
+extern s32           D_801E5C20;
+extern s32           D_801E5E7C;
+extern s32           D_801E5E80;
+extern s32           D_801E5E84;
+extern s32           D_801E5E88;
+extern s32           D_801E5E8C; // Index for some array used by most recent func_801E2E28 call.
+extern s32           D_801E600C;
 
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2E28);
+void func_801E2E28(s32 idx)
+{
+    s32 temp_lo;
+    s32 temp_v1;
+
+    D_801E5E8C = idx;
+    
+    func_8004729C(D_801E5558[idx].field_00);
+    temp_v1 = (D_801E5558[idx].field_04 * 2) - 0x1F8;
+    temp_lo = temp_v1 / (s32)D_801E5C20;
+    
+    D_801E5E7C = temp_v1;
+    D_801E5E88 = 1;
+    D_801E5E7C = temp_lo;
+    D_801E5E84 = (temp_lo * D_801E5C20) + 0x1E0;
+    D_801E5E80 = 0x10000 / temp_lo;
+}
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2ED8);
 
@@ -52,30 +78,28 @@ INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E386C);
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E3970);
 
-// TODO: Should be a match.
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E3DD0);
-/*void func_801E3DD0(void)
+void func_801E3DD0(void)
 {
     D_801E600C = Rng_Rand16();
-}*/
+}
 
 s32 func_801E3DF8(s32 arg0)
 {
-    return ((u32)((arg0 & 0xFF) * 0x31) >> 6) | 0x38;
+    return ((u32)((arg0 & 0xff) * 0x31) >> 6) | 0x38;
 }
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E3E18);
 
 void func_801E42F8(s16 arg0, s16 arg1)
 {
-    D_800AFE08.field_0 = arg0;
-    D_800AFE08.field_2 = arg1;
-    D_800AFE08.field_4 = arg0;
+    D_800AFE08.field_00 = arg0;
+    D_800AFE08.field_02 = arg1;
+    D_800AFE08.field_04 = arg0;
 }
 
 void func_801E4310(s32 r, s32 g, s32 b)
 {
-    D_800AFE10 = (r & 0xFF) | ((g & 0xFF) << 8) | ((b & 0xFF) << 16) | (0x64 << 24);
+    D_800AFE10 = (r & 0xff) | ((g & 0xff) << 8) | ((b & 0xff) << 16) | (0x64 << 24);
 }
 
 void func_801E4340(s8 arg0)
@@ -83,7 +107,30 @@ void func_801E4340(s8 arg0)
     D_800AFE0E = arg0;
 }
 
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E434C);
+void func_801E434C(u32 arg0, u32 arg1)
+{
+    u32 shiftedArg1;
+    u32 shiftedField_18;
+    u32 maskedField_18;
+
+    D_800AFE08.field_07 = (arg0 != 0);
+
+    if (arg1 < 4)
+    {
+        maskedField_18 = D_800AFE08.field_18;
+        shiftedField_18 = (maskedField_18 << 4) & 0x100;
+        
+        maskedField_18 &= 0xf;
+        shiftedField_18 >>= 4;
+        
+        shiftedArg1 = arg1 & 3;
+        shiftedArg1 <<= 5;
+        shiftedArg1 |= shiftedField_18;
+        shiftedArg1 |= (u8)maskedField_18;
+        
+        D_800AFE08.field_14 = shiftedArg1;
+    }
+}
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4394);
 
@@ -91,7 +138,7 @@ INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E47E0);
 
 void func_801E4B98(s32 r, s32 g, s32 b)
 {
-    D_800AFE2C = (r & 0xFF) | ((g & 0xFF) << 8) | ((b & 0xFF) << 16) | (0x2C << 24);
+    D_800AFE2C = (r & 0xff) | ((g & 0xff) << 8) | ((b & 0xff) << 16) | (0x2c << 24);
 }
 
 void func_801E4BC8(s8 arg0)
@@ -99,7 +146,29 @@ void func_801E4BC8(s8 arg0)
     D_800AFE2A = arg0;
 }
 
-// Identical to func_801E434C except for the global variables it modifies.
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4BD4);
+void func_801E4BD4(u32 arg0, u32 arg1)
+{
+    u32 shiftedArg1;
+    u32 shiftedField_18;
+    u32 maskedField_18;
+
+    D_800AFE24.field_07 = (arg0 != 0);
+
+    if (arg1 < 4)
+    {
+        maskedField_18 = D_800AFE24.field_18;
+        shiftedField_18 = (maskedField_18 << 4) & 0x100;
+        
+        maskedField_18 &= 0xf;
+        shiftedField_18 >>= 4;
+        
+        shiftedArg1 = arg1 & 3;
+        shiftedArg1 <<= 5;
+        shiftedArg1 |= shiftedField_18;
+        shiftedArg1 |= (u8)maskedField_18;
+        
+        D_800AFE24.field_14 = shiftedArg1;
+    }
+}
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4C1C);

--- a/src/screens/credits/credits.c
+++ b/src/screens/credits/credits.c
@@ -51,7 +51,7 @@ void func_801E2E28(s32 idx)
     
     func_8004729C(D_801E5558[idx].field_00);
     temp_v1 = (D_801E5558[idx].field_04 * 2) - 0x1F8;
-    temp_lo = temp_v1 / (s32)D_801E5C20;
+    temp_lo = temp_v1 / D_801E5C20;
     
     D_801E5E7C = temp_v1;
     D_801E5E88 = 1;

--- a/src/screens/credits/credits.c
+++ b/src/screens/credits/credits.c
@@ -1,4 +1,9 @@
 #include "common.h"
+#include "screens/credits/credits.h"
+
+extern s8  D_800AFE0E;
+extern s32 D_800AFE10; // Packed RGB+command color?
+extern s8  D_800AFE2A;
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2E28);
 
@@ -22,15 +27,36 @@ INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E3970);
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E3DD0);
 
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E3DF8);
+s32 func_801E3DF8(s32 arg0)
+{
+    return ((u32)((arg0 & 0xFF) * 0x31) >> 6) | 0x38;
+}
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E3E18);
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E42F8);
 
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4310);
+/**
+ * @brief Set the current opaque RGB+command color for an unknown purpose.
+ *
+ * This function sets the packed RGB+command color of D_800AFE10.
+ * The hard set component is either a graphics command code for a textured
+ * rectangle, or an alpha, though the latter is unlikely given the PS1's
+ * lack of proper alpha blending.
+ *
+ * @param r Red component.
+ * @param g Green component.
+ * @param b Blue component.
+ */
+void func_801E4310(s32 r, s32 g, s32 b)
+{
+    D_800AFE10 = (r & 0xFF) | ((g & 0xFF) << 8) | ((b & 0xFF) << 16) | (100 << 24);
+}
 
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4340);
+void func_801E4340(s8 arg0)
+{
+    D_800AFE0E = arg0;
+}
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E434C);
 
@@ -40,7 +66,10 @@ INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E47E0);
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4B98);
 
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4BC8);
+void func_801E4BC8(s8 arg0)
+{
+    D_800AFE2A = arg0;
+}
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4BD4);
 

--- a/src/screens/credits/credits.c
+++ b/src/screens/credits/credits.c
@@ -1,8 +1,8 @@
 #include "common.h"
 #include "screens/credits/credits.h"
 
-// Padding added for now, but other unknown fields might exist.
-typedef struct UnkStruct0
+// Used by func_801E434C
+typedef struct
 {
     s16 field_0;
     s16 field_2;
@@ -15,7 +15,14 @@ typedef struct UnkStruct0
     s16 field_14;
     s16 unk_16;
     s32 field_18;
-} UnkStruct0;
+} s_Unk0; // Size: unknown
+
+// Used by func_801E2E28.
+typedef struct
+{
+    s32 field_0;
+    s16 field_4;
+} s_Unk1; // Size: 6
 
 extern s8  D_800AFE0E;
 extern s32 D_800AFE10; // Packed RGB+command color?
@@ -23,7 +30,7 @@ extern s8  D_800AFE2A;
 extern s32 D_800AFE2C; // Packed RGB+command color?
 extern s32 D_801E600C;
 
-extern UnkStruct0 D_800AFE08;
+extern s_Unk0 D_800AFE08;
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2E28);
 
@@ -92,6 +99,7 @@ void func_801E4BC8(s8 arg0)
     D_800AFE2A = arg0;
 }
 
+// Identical to func_801E434C except for the global variables it modifies.
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4BD4);
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4C1C);

--- a/src/screens/credits/credits.c
+++ b/src/screens/credits/credits.c
@@ -15,14 +15,14 @@ typedef struct
     s16 field_14;
     s16 unk_16;
     s32 field_18;
-} s_Unk0; // Size: unknown
+} s_UnkCredits0; // Size: unknown
 
 // Used by func_801E2E28.
 typedef struct
 {
     s32 field_0;
     s16 field_4;
-} s_Unk1; // Size: 6
+} s_UnkCredits1; // Size: 6
 
 extern s8  D_800AFE0E;
 extern s32 D_800AFE10; // Packed RGB+command color?
@@ -30,7 +30,7 @@ extern s8  D_800AFE2A;
 extern s32 D_800AFE2C; // Packed RGB+command color?
 extern s32 D_801E600C;
 
-extern s_Unk0 D_800AFE08;
+extern s_UnkCredits0 D_800AFE08;
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2E28);
 

--- a/src/screens/options/options.c
+++ b/src/screens/options/options.c
@@ -1,12 +1,17 @@
 #include "common.h"
 
+extern u8 D_800BC747;
+
 INCLUDE_ASM("asm/screens/options/nonmatchings/options", func_801E2D44);
 
 INCLUDE_ASM("asm/screens/options/nonmatchings/options", func_801E318C);
 
 INCLUDE_ASM("asm/screens/options/nonmatchings/options", func_801E3770);
 
-INCLUDE_ASM("asm/screens/options/nonmatchings/options", func_801E3F68);
+void func_801E3F68(void)
+{
+    func_801E3FB8(0, D_800BC747);
+}
 
 INCLUDE_ASM("asm/screens/options/nonmatchings/options", func_801E3F90);
 

--- a/src/screens/options/options.c
+++ b/src/screens/options/options.c
@@ -1,6 +1,7 @@
 #include "common.h"
 
 extern u8 D_800BC747;
+extern u8 D_800BC748;
 
 INCLUDE_ASM("asm/screens/options/nonmatchings/options", func_801E2D44);
 
@@ -13,7 +14,10 @@ void func_801E3F68(void)
     func_801E3FB8(0, D_800BC747);
 }
 
-INCLUDE_ASM("asm/screens/options/nonmatchings/options", func_801E3F90);
+void func_801E3F90(void)
+{
+    func_801E3FB8(1, D_800BC748);
+}
 
 INCLUDE_ASM("asm/screens/options/nonmatchings/options", func_801E3FB8);
 

--- a/src/screens/saveload/saveload.c
+++ b/src/screens/saveload/saveload.c
@@ -4,24 +4,35 @@
 
 typedef struct
 {
-    s32 unk_0;
-    s32 unk_4;
-    s32 field_8;
-} s_UnkSaveLoad0; // Size: >=12
+    s32 unk_00;
+    s32 unk_04;
+    s32 field_08;
+} s_UnkSaveload0; // Size: >=12
 
 extern s_FsImageDesc D_800A902C;
+extern u8            D_800A97D4[];
+extern u32           D_800BCD34;
+extern s8            D_800BCD40;
+extern s32           D_801E751C;
+extern s32           D_801E7520;
+extern s16           D_801E7570[];
+extern s16           D_801E7578[];
+extern s8            D_801E76D0;
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E2D8C);
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E2EBC);
 
-INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E2F90);
+void func_801E2F90(s32 idx)
+{
+    D_801E7578[idx] = D_800A97D4[idx] - D_801E7570[idx];
+}
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E2FCC);
 
-s32 func_801E3078(s_UnkSaveLoad0* arg0)
+s32 func_801E3078(s_UnkSaveload0* arg0)
 {
-    if (arg0 != NULL && (arg0->field_8 & 0x01000000))
+    if (arg0 != NULL && (arg0->field_08 & 0x01000000))
     {
         func_8004A8DC(0);
         return 1;
@@ -81,7 +92,26 @@ void func_801E709C(void)
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E70C8);
 
-INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E7244);
+void func_801E7244(void)
+{
+    if (D_801E7520 > 0)
+    {
+        D_801E76D0 = 0;
+        D_801E7520 -= 1;
+
+        switch (D_801E751C) 
+        {
+            case 1:
+                func_801E3910(D_801E751C, (D_800BCD34 >> (D_800BCD40 * 3)) & 7);
+                break;
+
+            case 2:
+            case 3:
+                func_801E3910(D_801E751C, func_8002E990());
+                break;
+        }
+    }
+}
 
 void func_801E72DC(void)
 {

--- a/src/screens/saveload/saveload.c
+++ b/src/screens/saveload/saveload.c
@@ -1,4 +1,14 @@
 #include "common.h"
+#include "bodyprog/bodyprog.h"
+
+typedef struct
+{
+    s32 unk_0;
+    s32 unk_4;
+    s32 field_8;
+} s_Unk0; // Size: >=12
+
+extern s_FsImageDesc D_800A902C;
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E2D8C);
 
@@ -8,7 +18,17 @@ INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E2F90);
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E2FCC);
 
-INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E3078);
+s32 func_801E3078(s_Unk0* arg0)
+{
+    if (arg0 != NULL && (arg0->field_8 & 0x01000000))
+    {
+        func_8004A8DC(0);
+        return 1;
+    }
+        
+    func_8004A8DC(7);
+    return 0;
+}
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E30C4);
 
@@ -52,13 +72,20 @@ INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E6DB0);
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E6F38);
 
-INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E709C);
+void func_801E709C(void)
+{
+    func_801E2EBC();
+    func_800314EC(&D_800A902C);
+}
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E70C8);
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E7244);
 
-INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E72DC);
+void func_801E72DC(void)
+{
+    func_801E3C44();
+}
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E72FC);
 

--- a/src/screens/saveload/saveload.c
+++ b/src/screens/saveload/saveload.c
@@ -1,12 +1,13 @@
 #include "common.h"
 #include "bodyprog/bodyprog.h"
+#include "screens/saveload/saveload.h"
 
 typedef struct
 {
     s32 unk_0;
     s32 unk_4;
     s32 field_8;
-} s_Unk0; // Size: >=12
+} s_UnkSaveLoad0; // Size: >=12
 
 extern s_FsImageDesc D_800A902C;
 
@@ -18,7 +19,7 @@ INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E2F90);
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E2FCC);
 
-s32 func_801E3078(s_Unk0* arg0)
+s32 func_801E3078(s_UnkSaveLoad0* arg0)
 {
     if (arg0 != NULL && (arg0->field_8 & 0x01000000))
     {


### PR DESCRIPTION
- Adds matches for simple functions in `screens` overlays from the group effort on decomp.me.
- Minor fix for `Rng_Rand16` return type.
- README housekeeping.

Please do a squash merge instead of a regular one.