### PR TITLE
bodyprog: add 28 vw matches

### DIFF
--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -107,18 +107,18 @@ vcGetXZSumDistFromLimArea = 0x80085c80; // type:func
 
 // vw globals from SH2
 vcNullRoadArray = 0x800A8F44; // _VC_ROAD_DATA[2]
-vcNullNearRoad = 0x800AFC94; // _VC_NEAR_ROAD_DATA
-deflt_watch_mv_prm = 0x800AFCB8; // _VC_WATCH_MV_PARAM
-self_view_watch_mv_prm = 0x800AFCC4; // _VC_WATCH_MV_PARAM
-cam_mv_prm_user = 0x800AFCD0; // _VC_CAM_MV_PARAM
+vcNullNearRoad = 0x800AFC94; // type:VC_NEAR_ROAD_DATA size:0x24
+deflt_watch_mv_prm = 0x800AFCB8; // type:VC_WATCH_MV_PARAM size:0xC
+self_view_watch_mv_prm = 0x800AFCC4; // type:VC_WATCH_MV_PARAM size:0xC
+cam_mv_prm_user = 0x800AFCD0; // type:VC_CAM_MV_PARAM size:0x10
 excl_r_ary = 0x800AFCE0; // int[9]
-vcWork = 0x800B9CD0; // _VC_WORK
-vcRefPosSt = 0x800BCDF8; // VECTOR3
-vcCameraInternalInfo = 0x800BE9F4; // _VC_CAMERA_INTINFO
-vwViewPointInfo = 0x800C37E0; // _VW_VIEW_WORK
-VbWvsMatrix = 0x800C3888; // MATRIX
-vcWatchMvPrmSt = 0x800C4630; // _VC_WATCH_MV_PARAM
-vcSelfViewTimer = 0x800C463C; // int
+vcWork = 0x800B9CD0; // type:VC_WORK size:0x2E8
+vcRefPosSt = 0x800BCDF8; // type:VECTOR3 size:0xC
+vcCameraInternalInfo = 0x800BE9F4; // type:VC_CAMERA_INTINFO size:8
+vwViewPointInfo = 0x800C37E0; // type:VW_VIEW_WORK size:0x84
+VbWvsMatrix = 0x800C3888; // type:MATRIX size:0x20
+vcWatchMvPrmSt = 0x800C4630; // type:VC_WATCH_MV_PARAM size:0xC
+vcSelfViewTimer = 0x800C463C; // type:s32
 
 g_SD_VolumeSE = 0x800C1684;
 g_SD_VolumeBGM = 0x800C1685;
@@ -705,7 +705,7 @@ PSDOFSX = 0x800C6E08;
 PSDOFSY = 0x800C6E0C;
 HWD0 = 0x800C6F28;
 VWD0 = 0x800C6F2C;
-GsIDMATRIX2 = 0x800C6FE0;
+GsIDMATRIX2 = 0x800C6FE0; // type:MATRIX size:0x20
 GsLIGHTWSMATRIX = 0x800C6F40;
 PSDBASEX = 0x800C6E10;
 PSDBASEY = 0x800C6E14;
@@ -788,7 +788,7 @@ gte_init = 0x80095CBC; // type:func
 // gs_123.o
 Gssub_make_matrix = 0x80095d0c; // type:func
 // gs_123.o globals
-GsIDMATRIX = 0x800C6FA0;
+GsIDMATRIX = 0x800C6FA0; // type:MATRIX size:0x20
 // symbols say these should be there, but other vars are inside the same space of them?
 // GsWSMATRIX = 0x800C6FA0 + 0x20; // unused
 // GsWSMATRIX_ORG = 0x800C6FA0 + 0x40; // unused

--- a/include/bodyprog/math.h
+++ b/include/bodyprog/math.h
@@ -1,0 +1,10 @@
+#ifndef _BODYPROG_MATH_H
+#define _BODYPROG_MATH_H
+
+void func_80096C94(SVECTOR*, MATRIX*); // custom vwRotMatrix*** ?
+void func_80096E78(SVECTOR*, MATRIX*); // another custom vwRotMatrix*** ?
+
+s32 shRcos(s16);
+s32 shRsin(s16);
+
+#endif /* _BODYPROG_MATH_H */

--- a/include/bodyprog/vw_system.h
+++ b/include/bodyprog/vw_system.h
@@ -304,6 +304,7 @@ void vcWorkSetFlags(VC_FLAGS enable, VC_FLAGS disable);
 void vcUserWatchTarget(VECTOR3 *watch_tgt_pos, VC_WATCH_MV_PARAM *watch_prm_p, int warp_watch_f);
 void vcUserCamTarget(VECTOR3 *cam_tgt_pos, VC_CAM_MV_PARAM *cam_prm_p, int warp_cam_f);
 void vcChangeProjectionValue(short scr_y);
+void func_80080D68();
 void vcGetNowWatchPos(VECTOR3 *watch_pos);
 void vcGetNowCamPos(VECTOR3 *cam_pos);
 void vcReturnPreAutoCamWork(int warp_f);

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -1,0 +1,245 @@
+#include "common.h"
+
+#include "bodyprog/vw_system.h"
+#include "bodyprog/math.h"
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcInitVCSystem);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcStartCameraSystem);
+
+// 0x80080A04
+void vcEndCameraSystem(void)
+{
+    vcWork.view_cam_active_f_0 = 0;
+}
+
+// 0x80080A10
+s32 func_80080A10(void)
+{
+    // TODO: bitfield access?
+    return (vcWork.cur_near_road_2B8.road_p_0->cam_mv_type_14 >> 8) & 0xF;
+}
+
+// 0x80080A30
+void func_80080A30(s32 arg0)
+{
+    vcWork.field_2E4 = arg0;
+}
+
+// 0x80080A3C
+s32 func_80080A3C(void)
+{
+    return vcWork.field_2E4;
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetFirstCamWork);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", func_80080B58);
+
+// 0x80080BF8
+void vcWorkSetFlags(VC_FLAGS enable, VC_FLAGS disable)
+{
+    vcWork.flags_8 = (vcWork.flags_8 | enable) & ~disable;
+}
+
+// 0x80080C18
+s32 func_80080C18(s32 arg0)
+{
+    s32 prev_val = vcWork.watch_tgt_max_y_88;
+    vcWork.watch_tgt_max_y_88 = arg0;
+    return prev_val;
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcUserWatchTarget);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcUserCamTarget);
+
+// 0x80080D5C
+void vcChangeProjectionValue(s16 scr_y)
+{
+    vcWork.geom_screen_dist_30 = scr_y;
+}
+
+// 0x80080D68
+void func_80080D68(void)
+{
+    vcWork.field_D8 = 1;
+}
+
+// 0x80080D78
+void vcGetNowWatchPos(VECTOR3* watch_pos)
+{
+    s32 temp_s1;
+    s32 temp_s4;
+    s32 temp_s5;
+    s32 temp_s6;
+    s32 temp_v0;
+
+    temp_s5 = shRcos(vcWork.cam_mat_ang_8E.vx);
+    temp_s6 = shRsin(vcWork.cam_mat_ang_8E.vx);
+    temp_s4 = shRcos(vcWork.cam_mat_ang_8E.vy);
+    temp_s1 = shRsin(vcWork.cam_mat_ang_8E.vy);
+    temp_v0 = Math_VectorMagnitude(vcWork.cam_pos_50.vx - vcWork.watch_tgt_pos_7C.vx, vcWork.cam_pos_50.vy - vcWork.watch_tgt_pos_7C.vy, vcWork.cam_pos_50.vz - vcWork.watch_tgt_pos_7C.vz);
+    watch_pos->vx = Math_MulFixed(Math_MulFixed(temp_v0, temp_s1, 0xC), temp_s5, 0xC) + vcWork.cam_pos_50.vx;
+    watch_pos->vz = Math_MulFixed(Math_MulFixed(temp_v0, temp_s4, 0xC), temp_s5, 0xC) + vcWork.cam_pos_50.vz;
+    watch_pos->vy = vcWork.cam_pos_50.vy - Math_MulFixed(temp_v0, temp_s6, 0xC);
+}
+
+// 0x80080EA8
+void vcGetNowCamPos(VECTOR3* cam_pos)
+{
+    *cam_pos = vcWork.cam_pos_50;
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcReturnPreAutoCamWork);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetSubjChara);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcExecCamera);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetAllNpcDeadTimer);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRetSmoothCamMvF);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRetCurCamMvType);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", func_8008150C);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRetThroughDoorCamEndF);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRetFarWatchRate);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRetSelfViewEffectRate);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetFlagsByCamMvType);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcPreSetDataInVC_WORK);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetTHROUGH_DOOR_CAM_PARAM_in_VC_WORK);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetNearestEnemyDataInVC_WORK);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetNearRoadAryByCharaPos);
+
+// 0x8008227C
+s32 vcRetRoadUsePriority(VC_ROAD_TYPE rd_type)
+{
+    switch (rd_type)
+    {
+        case VC_RD_TYPE_EVENT:
+            return 2;
+        case VC_RD_TYPE_EFFECT:
+            return 1;
+        case VC_RD_TYPE_ROAD:
+            return 0;
+        default:
+            return 0;
+    }
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetCurNearRoadInVC_WORK);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcGetBestNewCurNearRoad);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcGetNearestNEAR_ROAD_DATA);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdvantageDistOfOldCurRoad);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAutoRenewalWatchTgtPosAndAngZ);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeNormalWatchTgtPos);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMixSelfViewEffectToWatchTgtPos);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeFarWatchTgtPos);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetWatchTgtXzPos);
+
+// 0x800835C0
+void vcSetWatchTgtYParam(VECTOR3* watch_pos, VC_WORK* w_p, s32 cam_mv_type, s32 watch_y)
+{
+    if (cam_mv_type == VC_MV_SELF_VIEW)
+    {
+        watch_pos->vy = w_p->chara_center_y_128;
+    }
+    else
+    {
+        watch_pos->vy = watch_y;
+    }
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjustWatchYLimitHighWhenFarView);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAutoRenewalCamTgtPos);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRetMaxTgtMvXzLen);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeIdealCamPosByHeadPos);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeIdealCamPosForFixAngCam);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeIdealCamPosForThroughDoorCam);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeIdealCamPosUseVC_ROAD_DATA);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjustXzInLimAreaUsingMIN_IN_ROAD_DIST);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeBasicCamTgtMvVec);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjTgtMvVecYByCurNearRoad);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcCamTgtMvVecIsFlipedFromCharaFront);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcFlipFromCamExclusionArea);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcGetUseWatchAndCamMvParam);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRenewalCamData);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRenewalCamMatAng);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeNewBaseCamAng);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRenewalBaseCamAngAndAdjustOfsCamAng);
+
+// 0x800852C8
+void vcMakeOfsCamTgtAng(SVECTOR* ofs_tgt_ang, MATRIX* base_matT, VC_WORK* w_p)
+{
+    SVECTOR sp10;
+
+    sp10.vx = (w_p->watch_tgt_pos_7C.vx - w_p->cam_pos_50.vx) >> 4;
+    sp10.vy = (w_p->watch_tgt_pos_7C.vy - w_p->cam_pos_50.vy) >> 4;
+    sp10.vz = (w_p->watch_tgt_pos_7C.vz - w_p->cam_pos_50.vz) >> 4;
+    ApplyMatrixSV(base_matT, &sp10, &sp10);
+    vwVectorToAngle(ofs_tgt_ang, &sp10);
+    ofs_tgt_ang->vz = w_p->watch_tgt_ang_z_8C;
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeOfsCam2CharaBottomAndTopAngByBaseMatT);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjCamOfsAngByCharaInScreen);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjCamOfsAngByOfsAngSpd);
+
+// 0x800857EC
+void vcMakeCamMatAndCamAngByBaseAngAndOfsAng(SVECTOR* cam_mat_ang, MATRIX* cam_mat, SVECTOR* base_cam_ang, SVECTOR* ofs_cam_ang, VECTOR3* cam_pos)
+{
+    MATRIX sp10;
+    MATRIX sp30;
+
+    cam_mat->t[0] = cam_pos->vx >> 4;
+    cam_mat->t[1] = cam_pos->vy >> 4;
+    cam_mat->t[2] = cam_pos->vz >> 4;
+    func_80096C94(base_cam_ang, &sp10);
+    func_80096C94(ofs_cam_ang, &sp30);
+    MulMatrix0(&sp10, &sp30, cam_mat);
+    vwMatrixToAngleYXZ(cam_mat_ang, cam_mat);
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetDataToVwSystem);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcCamMatNoise);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", Math_VectorMagnitude);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcGetXZSumDistFromLimArea);

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -1,0 +1,55 @@
+#include "common.h"
+
+#include "bodyprog/vw_system.h"
+#include "bodyprog/math.h"
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcInitCamera);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcSetCameraUseWarp);
+
+// 0x80040190
+int vcRetCamMvSmoothF()
+{
+    return vcCameraInternalInfo.mv_smooth;
+}
+
+// 0x800401A0
+void func_800401A0(s32 arg0)
+{
+    if (arg0)
+    {
+        vcCameraInternalInfo.ev_cam_rate = 4096;
+    }
+    else
+    {
+        vcCameraInternalInfo.ev_cam_rate = 0;
+    }
+}
+
+// 0x800401C0
+void vcSetEvCamRate(s16 ev_cam_rate)
+{
+    vcCameraInternalInfo.ev_cam_rate = ev_cam_rate;
+}
+
+// 0x800401CC
+void func_800401CC()
+{
+    func_80080D68();
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcMoveAndSetCamera);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcMakeHeroHeadPos);
+
+// 0x80040518
+void vcAddOfsToPos(VECTOR3* out_pos, VECTOR3* in_pos, s16 ofs_xz_r, s16 ang_y, s32 ofs_y)
+{
+    out_pos->vx = in_pos->vx + ((ofs_xz_r * shRsin(ang_y)) >> 12);
+    out_pos->vz = in_pos->vz + ((ofs_xz_r * shRcos(ang_y)) >> 12);
+    out_pos->vy = in_pos->vy + ofs_y;
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcSetRefPosAndSysRef2CamParam);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcSetRefPosAndCamPosAngByPad);

--- a/src/bodyprog/view/vw_calc.c
+++ b/src/bodyprog/view/vw_calc.c
@@ -1,0 +1,92 @@
+#include "common.h"
+
+#include "bodyprog/vw_system.h"
+#include "bodyprog/math.h"
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwRenewalXZVelocityToTargetPos);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwLimitOverLimVector);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwDecreaseSideOfVector);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwRetNewVelocityToTargetVal);
+
+// 0x80049464
+s32 vwRetNewAngSpdToTargetAng(s32 now_ang_spd, s16 now_ang, s16 tgt_ang, s32 accel_spd, s32 total_max_ang_spd, s32 dec_val_lim_spd)
+{
+    return vwRetNewVelocityToTargetVal(now_ang_spd, 0, ((tgt_ang - now_ang) << 0x14) >> 0x14, accel_spd, total_max_ang_spd, dec_val_lim_spd);
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_800494B0);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049530);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwMatrixToAngleYXZ);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_800496AC);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vbSetWorldScreenMatrix);
+
+// 0x800498D8
+void vbSetRefView(VbRVIEW* rview)
+{
+    GsCOORDINATE2 sp10;
+    SVECTOR sp60;
+    SVECTOR sp68;
+
+    sp10.flg = 0;
+    sp10.super = rview->super;
+    sp68.vx = rview->vr.vx - rview->vp.vx;
+    sp68.vy = rview->vr.vy - rview->vp.vy;
+    sp68.vz = rview->vr.vz - rview->vp.vz;
+    vwVectorToAngle(&sp60, &sp68);
+    func_80096E78(&sp60, &sp10.coord);
+    
+    sp10.coord.t[0] = rview->vp.vx;
+    sp10.coord.t[1] = rview->vp.vy;
+    sp10.coord.t[2] = rview->vp.vz;
+    vbSetWorldScreenMatrix(&sp10);
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049984);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049AF8);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049B6C);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049C2C);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049D04);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049F38);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_8004A54C);
+
+// 0x8004A66C
+void vwAngleToVector(SVECTOR* vec, SVECTOR* ang, s32 r)
+{
+    s32 entou_r = (r * shRcos(ang->vx)) >> 12;
+    vec->vy = (-r * shRsin(ang->vx)) >> 12;
+    vec->vx = (entou_r * shRsin(ang->vy)) >> 12;
+    vec->vz = (entou_r * shRcos(ang->vy)) >> 12;
+}
+
+// 0x8004A714
+s32 vwVectorToAngle(SVECTOR* ang, SVECTOR* vec)
+{
+    VECTOR sp10;
+    s32 result;
+
+    sp10.vx = vec->vx;
+    sp10.vy = vec->vy;
+    sp10.vz = vec->vz;
+    Square0(&sp10, &sp10);
+    result = SquareRoot0(sp10.vx + sp10.vy + sp10.vz);
+    
+    ang->vx = ratan2(-vec->vy, SquareRoot0(sp10.vx + sp10.vz));
+    ang->vy = ratan2(vec->vx, vec->vz);
+    ang->vz = 0;
+    return result;
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwOresenHokan);

--- a/src/bodyprog/view/vw_main.c
+++ b/src/bodyprog/view/vw_main.c
@@ -1,0 +1,54 @@
+#include "common.h"
+
+#include "bodyprog/vw_system.h"
+
+// 0x80048A38
+void vwInitViewInfo()
+{
+    vwViewPointInfo.rview.vp.vz = 0;
+    vwViewPointInfo.rview.vp.vy = 0;
+    vwViewPointInfo.rview.vp.vx = 0;
+    vwViewPointInfo.rview.vr.vx = 0;
+    vwViewPointInfo.rview.vr.vy = 0;
+    vwViewPointInfo.rview.vr.vz = 4096;
+    vwViewPointInfo.rview.rz = 0;
+    vwViewPointInfo.rview.super = &vwViewPointInfo.vwcoord;
+    GsInitCoordinate2(NULL, &vwViewPointInfo.vwcoord);
+    vwSetViewInfo();
+}
+
+// 0x80048A90
+GsCOORDINATE2* vwGetViewCoord()
+{
+    return &vwViewPointInfo.vwcoord;
+}
+
+// 0x80048A9C
+void vwGetViewPosition(VECTOR3* pos)
+{
+    *pos = vwViewPointInfo.worldpos;
+}
+
+// 0x80048AC4
+void vwGetViewAngle(SVECTOR* ang)
+{
+    *ang = vwViewPointInfo.worldang;
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_main", func_80048AF4);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_main", vwSetCoordRefAndEntou);
+
+// 0x80048CF0
+void vwSetViewInfoDirectMatrix(GsCOORDINATE2* pcoord, MATRIX* cammat)
+{
+    vwViewPointInfo.vwcoord.flg = 0;
+    vwViewPointInfo.vwcoord.super = pcoord;
+    vwViewPointInfo.vwcoord.coord = *cammat;
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_main", vwSetViewInfo);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_main", func_80048DA8);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_main", func_80048E3C);


### PR DESCRIPTION
Some easy matches from m2c, and fixed up some symbol types, mainly just to get vw_system.h included.

Not sure about the func_80096C94 / func_80096E78 funcs in math.h, my DB has them both named the same vwRotMatrixYXZ name, guess one is a different order but not really sure which.