### PR TITLE
Add libsd matches, update clang-format, reformat view files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -133,5 +133,7 @@ StatementMacros:
 TabWidth:        8
 UseCRLF:         false
 UseTab:          Never
+WhitespaceSensitiveMacros:
+  - INCLUDE_ASM
 ...
 

--- a/.clang-format
+++ b/.clang-format
@@ -25,24 +25,24 @@ AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
-  AfterCaseLabel:  false
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    true
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
+BreakBeforeBraces: Allman
 BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
@@ -82,7 +82,7 @@ IncludeIsMainSourceRegex: ''
 IndentCaseLabels: false
 IndentGotoLabels: true
 IndentPPDirectives: None
-IndentWidth:     2
+IndentWidth:     4
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
@@ -92,7 +92,7 @@ MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
-ObjCBlockIndentWidth: 2
+ObjCBlockIndentWidth: 4
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PenaltyBreakAssignment: 2

--- a/include/bodyprog/libsd.h
+++ b/include/bodyprog/libsd.h
@@ -1,0 +1,85 @@
+#ifndef _LIBSD_H
+#define _LIBSD_H
+
+/*
+   libsd: konami-customized version of libsnd?
+   Majority of functions match up with the libsnd Ss versions
+   libref.pdf v4.4 may be useful, though was likely based on earlier SDK
+*/
+
+extern s32 sd_reverb_mode;
+extern s16 sd_keyoff_mode;
+extern s32 sd_interrupt_start_flag;
+extern s32 sd_tick_mode;
+extern u8  sd_vb_malloc_rec[];
+extern u32 sd_reserved_voice;
+extern s32 sd_mono_st_flag;
+extern s32 sd_int_flag;
+extern s32 sd_int_flag2;
+extern s32 sd_timer_sync;
+extern s32 smf_start_flag;
+
+/* sdmain.c */
+void SdWorkInit();
+void SdInit(void);
+void SdStart(void);
+void SdStart2(void);
+void SdSetTickMode(s32 tick_mode);
+void SdSeqCalledTbyT(void);
+void SdSetStereo(void);
+void SdSetMono(void);
+char SdSetReservedVoice(char voices);
+void SdSetTableSize(void);
+
+void SdEnd();
+void SdQuit(void);
+void SdSetSerialAttr(char s_num, char attr, char mode);
+void SdSetSerialVol(s16 s_num, s16 voll, s16 volr);
+void SdSetMVol(s16 left, s16 right);
+
+void SdSetAutoKeyOffMode(s16 mode);
+void SdAutoKeyOffCheck();
+
+void SdUtFlush(void);
+void SdUtReverbOn(void);
+void SdUtReverbOff(void);
+s16  SdUtSetReverbType(s16 type);
+void SdUtSetReverbDepth(s16 left, s16 right);
+void SdSetRVol(s16 left, s16 right);
+
+void SdUtAllKeyOff(s16 mode);
+
+/* sdmidi.c */
+void midi_vsync();
+
+void sound_off();
+void set_note_on_mb(void);
+
+void key_press(void);
+
+void chan_press(void);
+
+void control_code_set(void);
+
+/* sdmidi2.c */
+s32  smf_timer(void);
+void smf_timer_set();
+
+void smf_vsync(void);
+
+// to32bit/to16bit/len_add only seem used inside sdmidi2.c, can probably be
+// removed from header
+s32  to32bit(char arg0, char arg1, char arg2, char arg3);
+s32  to16bit(char arg0, char arg1);
+void len_add(s32 *ptr, s32 val);
+
+void midi_smf_main();
+
+/* ssmain.c */
+void SsSetMVol(s16 left, s16 right);
+void SsEnd(void);
+void SsSetSerialAttr(char s_num, char attr, char mode);
+void SsSetSerialVol(char s_num, s16 voll, s16 volr);
+void SsUtAllKeyOff(s16 mode);
+
+#endif /* _LIBSD_H */

--- a/include/bodyprog/vw_system.h
+++ b/include/bodyprog/vw_system.h
@@ -5,87 +5,89 @@
 #include <libgpu.h>
 #include <libgs.h>
 
-// TODO: 
+// TODO:
 // - change "struct SYS_W" to "SYS_W" below once SYS_W struct is added
-// - flags below are from SH2, most seem to match with SH but might be some differences
-// - code that accesses VC_ROAD_TYPE & VC_NEAR_ROAD_DATA is odd, might need extra work
+// - flags below are from SH2, most seem to match with SH but might be some
+// differences
+// - code that accesses VC_ROAD_TYPE & VC_NEAR_ROAD_DATA is odd, might need
+// extra work
 
 typedef enum _VC_ROAD_FLAGS
 {
-    VC_RD_NOFLAG = 0x0,
-    VC_RD_END_DATA_F = 0x1,
-    VC_RD_WARP_IN_F = 0x2,
-    VC_RD_WARP_OUT_F = 0x4,
-    VC_RD_WARP_IN_OUT_FS = 0x6,
-    VC_RD_NO_FRONT_FLIP_F = 0x8,
+    VC_RD_NOFLAG            = 0x0,
+    VC_RD_END_DATA_F        = 0x1,
+    VC_RD_WARP_IN_F         = 0x2,
+    VC_RD_WARP_OUT_F        = 0x4,
+    VC_RD_WARP_IN_OUT_FS    = 0x6,
+    VC_RD_NO_FRONT_FLIP_F   = 0x8,
     VC_RD_LIM_UP_FAR_VIEW_F = 0x10,
-    VC_RD_USE_NO_ENEMY_F = 0x20,
-    VC_RD_USE_NEAR_ENEMY_F = 0x40,
-    VC_RD_MARGE_ROAD_F = 0x80
+    VC_RD_USE_NO_ENEMY_F    = 0x20,
+    VC_RD_USE_NEAR_ENEMY_F  = 0x40,
+    VC_RD_MARGE_ROAD_F      = 0x80
 } VC_ROAD_FLAGS;
 STATIC_ASSERT_SIZEOF(VC_ROAD_FLAGS, 4);
 
 typedef enum _VC_FLAGS
 {
-    VC_USER_CAM_F = 0x1,
-    VC_USER_WATCH_F = 0x2,
-    VC_WARP_CAM_F = 0x4,
-    VC_WARP_WATCH_F = 0x8,
-    VC_WARP_CAM_TGT_F = 0x10,
+    VC_USER_CAM_F            = 0x1,
+    VC_USER_WATCH_F          = 0x2,
+    VC_WARP_CAM_F            = 0x4,
+    VC_WARP_WATCH_F          = 0x8,
+    VC_WARP_CAM_TGT_F        = 0x10,
     VC_SWITCH_NEAR_RD_DATA_F = 0x20,
-    VC_PROJ_MOMENT_CHANGE_F = 0x40,
-    VC_VISIBLE_CHARA_F = 0x80,
-    VC_INHIBIT_FAR_WATCH_F = 0x100,
-    VC_PRS_F_VIEW_F = 0x200,
-    VC_OLD_PRS_F_VIEW_F = 0x400
+    VC_PROJ_MOMENT_CHANGE_F  = 0x40,
+    VC_VISIBLE_CHARA_F       = 0x80,
+    VC_INHIBIT_FAR_WATCH_F   = 0x100,
+    VC_PRS_F_VIEW_F          = 0x200,
+    VC_OLD_PRS_F_VIEW_F      = 0x400
 } VC_FLAGS;
 STATIC_ASSERT_SIZEOF(VC_FLAGS, 4);
 
 typedef enum _VC_CAM_MV_TYPE
 {
-    VC_MV_CHASE = 0x0,
-    VC_MV_SETTLE = 0x1,
-    VC_MV_FIX_ANG = 0x2,
-    VC_MV_SELF_VIEW = 0x3,
+    VC_MV_CHASE        = 0x0,
+    VC_MV_SETTLE       = 0x1,
+    VC_MV_FIX_ANG      = 0x2,
+    VC_MV_SELF_VIEW    = 0x3,
     VC_MV_THROUGH_DOOR = 0x4,
-    VC_MV_SUU = 0x5
+    VC_MV_SUU          = 0x5
 } VC_CAM_MV_TYPE;
 STATIC_ASSERT_SIZEOF(VC_CAM_MV_TYPE, 4);
 
 typedef enum _VC_CAM_CHK_TYPE
 {
-    VC_CHK_NEAREST_ROAD_TYPE = 0x0,
+    VC_CHK_NEAREST_ROAD_TYPE   = 0x0,
     VC_CHK_NEAREST_SWITCH_TYPE = 0x1
 } VC_CAM_CHK_TYPE;
 STATIC_ASSERT_SIZEOF(VC_CAM_CHK_TYPE, 4);
 
 typedef enum _VC_ROAD_TYPE
 {
-    VC_RD_TYPE_ROAD = 0x0,
-    VC_RD_TYPE_EFFECT = 0x1,
-    VC_RD_TYPE_EVENT = 0x2,
-    VC_RD_TYPE_ROAD_PRIO_LOW = 0x3,
+    VC_RD_TYPE_ROAD           = 0x0,
+    VC_RD_TYPE_EFFECT         = 0x1,
+    VC_RD_TYPE_EVENT          = 0x2,
+    VC_RD_TYPE_ROAD_PRIO_LOW  = 0x3,
     VC_RD_TYPE_ROAD_PRIO_HIGH = 0x4,
-    VC_RD_TYPE_SV_ONLY = 0x5,
-    VC_RD_TYPE_SUU = 0x6
+    VC_RD_TYPE_SV_ONLY        = 0x5,
+    VC_RD_TYPE_SUU            = 0x6
 } VC_ROAD_TYPE;
 STATIC_ASSERT_SIZEOF(VC_ROAD_TYPE, 4);
 
 typedef enum _VC_AREA_SIZE_TYPE
 {
-    VC_AREA_TINY = 0x0,
-    VC_AREA_SMALL = 0x1,
-    VC_AREA_WIDE = 0x2,
+    VC_AREA_TINY    = 0x0,
+    VC_AREA_SMALL   = 0x1,
+    VC_AREA_WIDE    = 0x2,
     VC_AREA_OUTDOOR = 0x3,
-    VC_AREA_SUU = 0x4
+    VC_AREA_SUU     = 0x4
 } VC_AREA_SIZE_TYPE;
 STATIC_ASSERT_SIZEOF(VC_AREA_SIZE_TYPE, 4);
 
 typedef enum _THROUGH_DOOR_SET_CMD_TYPE
 {
     VC_TDSC_START = 0x0,
-    VC_TDSC_END = 0x1,
-    VC_TDSC_MAIN = 0x2
+    VC_TDSC_END   = 0x1,
+    VC_TDSC_MAIN  = 0x2
 } THROUGH_DOOR_SET_CMD_TYPE;
 STATIC_ASSERT_SIZEOF(THROUGH_DOOR_SET_CMD_TYPE, 4);
 
@@ -100,17 +102,17 @@ STATIC_ASSERT_SIZEOF(VC_LIMIT_AREA, 8);
 
 typedef struct _VC_CAMERA_INTINFO
 {
-    int mode;
+    int    mode;
     u_char mv_smooth;
-    char unk_5;
-    short ev_cam_rate;
+    char   unk_5;
+    short  ev_cam_rate;
 } VC_CAMERA_INTINFO;
 STATIC_ASSERT_SIZEOF(VC_CAMERA_INTINFO, 8);
 
 typedef struct _VC_WATCH_MV_PARAM
 {
-    int ang_accel_x;
-    int ang_accel_y;
+    int   ang_accel_x;
+    int   ang_accel_y;
     short max_ang_spd_x;
     short max_ang_spd_y;
 } VC_WATCH_MV_PARAM;
@@ -131,36 +133,37 @@ typedef struct _VC_ROAD_DATA
 {
     VC_LIMIT_AREA lim_sw_0;
     VC_LIMIT_AREA lim_rd_8;
-    char flags_10; // _VC_ROAD_FLAGS
-    char area_size_type_11;
-    char min_hy_12;
-    char max_hy_13;
-    u_int cam_mv_type_14;
+    char          flags_10; // _VC_ROAD_FLAGS
+    char          area_size_type_11;
+    char          min_hy_12;
+    char          max_hy_13;
+    u_int         cam_mv_type_14;
 } VC_ROAD_DATA;
 STATIC_ASSERT_SIZEOF(VC_ROAD_DATA, 0x18);
 
 typedef struct _VC_THROUGH_DOOR_CAM_PARAM
 {
-    u_char active_f_0;
-    char unk_1[3];
-    int timer_4;
+    u_char  active_f_0;
+    char    unk_1[3];
+    int     timer_4;
     u_short rail_ang_y_8;
-    char unk_A[2];
+    char    unk_A[2];
     VECTOR3 rail_sta_pos_C;
-    int rail_sta_to_chara_dist_18;
+    int     rail_sta_to_chara_dist_18;
 } VC_THROUGH_DOOR_CAM_PARAM;
 STATIC_ASSERT_SIZEOF(VC_THROUGH_DOOR_CAM_PARAM, 0x1C);
 
-// TODO: check if this struct is correct, some SH code seems to act like struct is only 0x10 bytes when iterating through it?
+// TODO: check if this struct is correct, some SH code seems to act like struct
+// is only 0x10 bytes when iterating through it?
 typedef struct _VC_NEAR_ROAD_DATA
 {
     VC_ROAD_DATA *road_p_0;
-    u_char rd_dir_type_4_mb; // unsure
-    u_char use_priority_5;
-    u_char unk_6[2];
-    int chara2road_sum_dist_8;
-    int chara2road_vec_x_C;
-    int chara2road_vec_z_10;
+    u_char        rd_dir_type_4_mb; // unsure
+    u_char        use_priority_5;
+    u_char        unk_6[2];
+    int           chara2road_sum_dist_8;
+    int           chara2road_vec_x_C;
+    int           chara2road_vec_z_10;
     VC_LIMIT_AREA rd_14;
     VC_LIMIT_AREA sw_1C;
 } VC_NEAR_ROAD_DATA;
@@ -168,130 +171,146 @@ STATIC_ASSERT_SIZEOF(VC_NEAR_ROAD_DATA, 0x24);
 
 typedef struct _VC_WORK
 {
-    u_char view_cam_active_f_0;
-    VC_ROAD_DATA *vc_road_ary_list_4;
-    VC_FLAGS flags_8;
-    u_char through_door_activate_init_f_C;
-    u_char unk_D[3];
+    u_char                    view_cam_active_f_0;
+    VC_ROAD_DATA             *vc_road_ary_list_4;
+    VC_FLAGS                  flags_8;
+    u_char                    through_door_activate_init_f_C;
+    u_char                    unk_D[3];
     VC_THROUGH_DOOR_CAM_PARAM through_door_10;
-    u_short scr_half_ang_wy_2C;
-    u_short scr_half_ang_wx_2E;
-    short geom_screen_dist_30; // related to GsSetProjection / g_GameSys.gs_y_res_58A
-    short field_32;
-    VC_CAM_MV_PARAM user_cam_mv_prm_34;
-    VECTOR3 cam_tgt_pos_44;
-    VECTOR3 cam_pos_50;
-    short cam_mv_ang_y_5C;
-    u_char unk_5E[2];
-    VECTOR3 cam_velo_60;
-    int old_cam_excl_area_r_6C;
-    VC_WATCH_MV_PARAM user_watch_mv_prm_70;
-    VECTOR3 watch_tgt_pos_7C;
-    int watch_tgt_max_y_88;
-    short watch_tgt_ang_z_8C;
-    SVECTOR cam_mat_ang_8E;
-    u_char unk_96[2];
-    MATRIX cam_mat_98;
-    SVECTOR ofs_cam_ang_B8;
-    SVECTOR ofs_cam_ang_spd_C0;
-    SVECTOR base_cam_ang_C8;
-    u_char unk_D0[8];
-    u_char field_D8;
-    u_char unk_D9[3];
-    MATRIX field_DC;
-    u_char field_FC;
-    u_char field_FD;
-    short cam_chara2ideal_ang_y_FE;
-    VECTOR3 cam_tgt_velo_100;
-    short cam_tgt_mv_ang_y_10C;
-    u_char unk_10E[2];
-    int cam_tgt_spd_110;
-    VECTOR3 chara_pos_114;
-    int chara_bottom_y_120;
-    int chara_top_y_124;
-    int chara_center_y_128;
-    int chara_grnd_y_12C;
-    VECTOR3 chara_head_pos_130;
-    int chara_mv_spd_13C;
-    short chara_mv_ang_y_140;
-    short chara_ang_spd_y_142;
-    short chara_eye_ang_y_144;
-    short chara_eye_ang_wy_146;
-    int chara_watch_xz_r_148;
-    VC_NEAR_ROAD_DATA near_road_ary_14C[10];
-    int near_road_suu_2B4;
-    VC_NEAR_ROAD_DATA cur_near_road_2B8;
+    u_short                   scr_half_ang_wy_2C;
+    u_short                   scr_half_ang_wx_2E;
+    short geom_screen_dist_30; // related to GsSetProjection /
+                               // g_GameSys.gs_y_res_58A
+    short                field_32;
+    VC_CAM_MV_PARAM      user_cam_mv_prm_34;
+    VECTOR3              cam_tgt_pos_44;
+    VECTOR3              cam_pos_50;
+    short                cam_mv_ang_y_5C;
+    u_char               unk_5E[2];
+    VECTOR3              cam_velo_60;
+    int                  old_cam_excl_area_r_6C;
+    VC_WATCH_MV_PARAM    user_watch_mv_prm_70;
+    VECTOR3              watch_tgt_pos_7C;
+    int                  watch_tgt_max_y_88;
+    short                watch_tgt_ang_z_8C;
+    SVECTOR              cam_mat_ang_8E;
+    u_char               unk_96[2];
+    MATRIX               cam_mat_98;
+    SVECTOR              ofs_cam_ang_B8;
+    SVECTOR              ofs_cam_ang_spd_C0;
+    SVECTOR              base_cam_ang_C8;
+    u_char               unk_D0[8];
+    u_char               field_D8;
+    u_char               unk_D9[3];
+    MATRIX               field_DC;
+    u_char               field_FC;
+    u_char               field_FD;
+    short                cam_chara2ideal_ang_y_FE;
+    VECTOR3              cam_tgt_velo_100;
+    short                cam_tgt_mv_ang_y_10C;
+    u_char               unk_10E[2];
+    int                  cam_tgt_spd_110;
+    VECTOR3              chara_pos_114;
+    int                  chara_bottom_y_120;
+    int                  chara_top_y_124;
+    int                  chara_center_y_128;
+    int                  chara_grnd_y_12C;
+    VECTOR3              chara_head_pos_130;
+    int                  chara_mv_spd_13C;
+    short                chara_mv_ang_y_140;
+    short                chara_ang_spd_y_142;
+    short                chara_eye_ang_y_144;
+    short                chara_eye_ang_wy_146;
+    int                  chara_watch_xz_r_148;
+    VC_NEAR_ROAD_DATA    near_road_ary_14C[10];
+    int                  near_road_suu_2B4;
+    VC_NEAR_ROAD_DATA    cur_near_road_2B8;
     struct SubCharacter *nearest_enemy_p_2DC;
-    int nearest_enemy_xz_dist_2E0;
-    int field_2E4;
+    int                  nearest_enemy_xz_dist_2E0;
+    int                  field_2E4;
 } VC_WORK;
 STATIC_ASSERT_SIZEOF(VC_WORK, 0x2E8);
 
 typedef struct _VbRVIEW
 {
-    VECTOR3 vp;
-    VECTOR3 vr;
-    int rz;
+    VECTOR3        vp;
+    VECTOR3        vr;
+    int            rz;
     GsCOORDINATE2 *super;
 } VbRVIEW;
 STATIC_ASSERT_SIZEOF(VbRVIEW, 0x20);
 
 typedef struct _VW_VIEW_WORK
 {
-    VbRVIEW rview;
+    VbRVIEW       rview;
     GsCOORDINATE2 vwcoord;
-    VECTOR3 worldpos;
-    SVECTOR worldang;
+    VECTOR3       worldpos;
+    SVECTOR       worldang;
 } VW_VIEW_WORK;
 STATIC_ASSERT_SIZEOF(VW_VIEW_WORK, 0x84);
 
-extern VC_ROAD_DATA vcNullRoadArray[2];
+extern VC_ROAD_DATA      vcNullRoadArray[2];
 extern VC_NEAR_ROAD_DATA vcNullNearRoad;
 extern VC_WATCH_MV_PARAM deflt_watch_mv_prm;
 extern VC_WATCH_MV_PARAM self_view_watch_mv_prm;
-extern VC_CAM_MV_PARAM cam_mv_prm_user;
-extern int excl_r_ary[9];
-extern VC_WORK vcWork;
-extern VECTOR3 vcRefPosSt;
+extern VC_CAM_MV_PARAM   cam_mv_prm_user;
+extern int               excl_r_ary[9];
+extern VC_WORK           vcWork;
+extern VECTOR3           vcRefPosSt;
 extern VC_CAMERA_INTINFO vcCameraInternalInfo; // debug camera info
-extern VW_VIEW_WORK vwViewPointInfo;
-extern MATRIX VbWvsMatrix;
+extern VW_VIEW_WORK      vwViewPointInfo;
+extern MATRIX            VbWvsMatrix;
 extern VC_WATCH_MV_PARAM vcWatchMvPrmSt;
-extern int vcSelfViewTimer;
+extern int               vcSelfViewTimer;
 
 // Function declarations
 // vc_util
 void vcInitCamera(void *map_overlay_ptr, VECTOR3 *chr_pos);
 void vcSetCameraUseWarp(VECTOR3 *chr_pos, short chr_ang_y);
-int vcRetCamMvSmoothF();
+int  vcRetCamMvSmoothF();
 void vcSetEvCamRate(short ev_cam_rate);
-void vcMoveAndSetCamera(int in_connect_f, int change_debug_mode, int for_f, int back_f, int right_f, int left_f, int up_f, int down_f);
+void vcMoveAndSetCamera(int in_connect_f, int change_debug_mode, int for_f,
+                        int back_f, int right_f, int left_f, int up_f,
+                        int down_f);
 void vcMakeHeroHeadPos(VECTOR3 *head_pos);
-void vcAddOfsToPos(VECTOR3 *out_pos, VECTOR3 *in_pos, short ofs_xz_r, short ang_y, int ofs_y);
-void vcSetRefPosAndSysRef2CamParam(VECTOR3 *ref_pos, struct SYS_W *sys_p, int for_f, int back_f, int right_f, int left_f, int up_f, int down_f);
+void vcAddOfsToPos(VECTOR3 *out_pos, VECTOR3 *in_pos, short ofs_xz_r,
+                   short ang_y, int ofs_y);
+void vcSetRefPosAndSysRef2CamParam(VECTOR3 *ref_pos, struct SYS_W *sys_p,
+                                   int for_f, int back_f, int right_f,
+                                   int left_f, int up_f, int down_f);
 void vcSetRefPosAndCamPosAngByPad(VECTOR3 *ref_pos, struct SYS_W *sys_p);
 
 // vw_main
-void vwInitViewInfo();
+void           vwInitViewInfo();
 GsCOORDINATE2 *vwGetViewCoord();
-void vwGetViewPosition(VECTOR3 *pos);
-void vwGetViewAngle(SVECTOR *ang);
-void vwSetCoordRefAndEntou(GsCOORDINATE2 *parent_p, int ref_x, int ref_y, int ref_z, short cam_ang_y, short cam_ang_z, int cam_y, int cam_xz_r);
+void           vwGetViewPosition(VECTOR3 *pos);
+void           vwGetViewAngle(SVECTOR *ang);
+void vwSetCoordRefAndEntou(GsCOORDINATE2 *parent_p, int ref_x, int ref_y,
+                           int ref_z, short cam_ang_y, short cam_ang_z,
+                           int cam_y, int cam_xz_r);
 void vwSetViewInfoDirectMatrix(GsCOORDINATE2 *pcoord, MATRIX *cammat);
 void vwSetViewInfo();
 
 // vw_calc
-void vwRenewalXZVelocityToTargetPos(int *velo_x, int *velo_z, VECTOR3 *now_pos, VECTOR3 *tgt_pos, int tgt_r, int accel, int total_max_spd, int dec_forwd_lim_spd, int dec_accel_side);
-void vwLimitOverLimVector(int *vec_x, int *vec_z, int lim_vec_len, short lim_vec_ang_y);
-void vwDecreaseSideOfVector(int *vec_x, int *vec_z, int dec_val, int max_side_vec_len, short dir_ang_y);
-int vwRetNewVelocityToTargetVal(int now_spd, int mv_pos, int tgt_pos, int accel, int total_max_spd, int dec_val_lim_spd);
-int vwRetNewAngSpdToTargetAng(int now_ang_spd, short now_ang, short tgt_ang, int accel_spd, int total_max_ang_spd, int dec_val_lim_spd);
+void vwRenewalXZVelocityToTargetPos(int *velo_x, int *velo_z, VECTOR3 *now_pos,
+                                    VECTOR3 *tgt_pos, int tgt_r, int accel,
+                                    int total_max_spd, int dec_forwd_lim_spd,
+                                    int dec_accel_side);
+void vwLimitOverLimVector(int *vec_x, int *vec_z, int lim_vec_len,
+                          short lim_vec_ang_y);
+void vwDecreaseSideOfVector(int *vec_x, int *vec_z, int dec_val,
+                            int max_side_vec_len, short dir_ang_y);
+int vwRetNewVelocityToTargetVal(int now_spd, int mv_pos, int tgt_pos, int accel,
+                                int total_max_spd, int dec_val_lim_spd);
+int vwRetNewAngSpdToTargetAng(int now_ang_spd, short now_ang, short tgt_ang,
+                              int accel_spd, int total_max_ang_spd,
+                              int dec_val_lim_spd);
 void vwMatrixToAngleYXZ(SVECTOR *ang, MATRIX *mat);
 void vbSetWorldScreenMatrix(GsCOORDINATE2 *coord);
 void vbSetRefView(VbRVIEW *rview);
 void vwAngleToVector(SVECTOR *vec, SVECTOR *ang, int r);
-int vwVectorToAngle(SVECTOR *ang, SVECTOR *vec);
-int vwOresenHokan(int *y_ary, int y_suu, int input_x, int min_x, int max_x);
+int  vwVectorToAngle(SVECTOR *ang, SVECTOR *vec);
+int  vwOresenHokan(int *y_ary, int y_suu, int input_x, int min_x, int max_x);
 
 int Math_MulFixed(int x, int y, char fractionalBits);
 
@@ -299,64 +318,125 @@ int Math_MulFixed(int x, int y, char fractionalBits);
 void vcInitVCSystem(VC_ROAD_DATA *vc_road_ary_list);
 void vcStartCameraSystem();
 void vcEndCameraSystem();
-void vcSetFirstCamWork(VECTOR3 *cam_pos, short chara_eye_ang_y, u_char use_through_door_cam_f);
+void vcSetFirstCamWork(VECTOR3 *cam_pos, short chara_eye_ang_y,
+                       u_char use_through_door_cam_f);
 void vcWorkSetFlags(VC_FLAGS enable, VC_FLAGS disable);
-void vcUserWatchTarget(VECTOR3 *watch_tgt_pos, VC_WATCH_MV_PARAM *watch_prm_p, int warp_watch_f);
-void vcUserCamTarget(VECTOR3 *cam_tgt_pos, VC_CAM_MV_PARAM *cam_prm_p, int warp_cam_f);
+void vcUserWatchTarget(VECTOR3 *watch_tgt_pos, VC_WATCH_MV_PARAM *watch_prm_p,
+                       int warp_watch_f);
+void vcUserCamTarget(VECTOR3 *cam_tgt_pos, VC_CAM_MV_PARAM *cam_prm_p,
+                     int warp_cam_f);
 void vcChangeProjectionValue(short scr_y);
 void func_80080D68();
 void vcGetNowWatchPos(VECTOR3 *watch_pos);
 void vcGetNowCamPos(VECTOR3 *cam_pos);
 void vcReturnPreAutoCamWork(int warp_f);
-void vcSetSubjChara(VECTOR3 *chara_pos, int chara_bottom_y, int chara_top_y, int chara_grnd_y, VECTOR3 *chara_head_pos, short chara_mv_spd, int chara_mv_ang_y, short chara_ang_spd_y, short chara_eye_ang_y, short chara_eye_ang_wy, int chara_watch_xz_r);
-int vcExecCamera();
+void vcSetSubjChara(VECTOR3 *chara_pos, int chara_bottom_y, int chara_top_y,
+                    int chara_grnd_y, VECTOR3 *chara_head_pos,
+                    short chara_mv_spd, int chara_mv_ang_y,
+                    short chara_ang_spd_y, short chara_eye_ang_y,
+                    short chara_eye_ang_wy, int chara_watch_xz_r);
+int  vcExecCamera();
 void vcSetAllNpcDeadTimer();
-int vcRetSmoothCamMvF(VECTOR3 *old_pos, VECTOR3 *now_pos, SVECTOR *old_ang, SVECTOR *now_ang);
+int  vcRetSmoothCamMvF(VECTOR3 *old_pos, VECTOR3 *now_pos, SVECTOR *old_ang,
+                       SVECTOR *now_ang);
 VC_CAM_MV_TYPE vcRetCurCamMvType(VC_WORK *w_p);
-int vcRetThroughDoorCamEndF(VC_WORK *w_p);
-int vcRetFarWatchRate(int far_watch_button_prs_f, VC_CAM_MV_TYPE cur_cam_mv_type, VC_WORK *w_p);
-int vcRetSelfViewEffectRate(VC_CAM_MV_TYPE cur_cam_mv_type, int far_watch_rate, VC_WORK *w_p);
-void vcSetFlagsByCamMvType(VC_CAM_MV_TYPE cam_mv_type, int far_watch_rate, int all_warp_f);
+int            vcRetThroughDoorCamEndF(VC_WORK *w_p);
+int            vcRetFarWatchRate(int            far_watch_button_prs_f,
+                                 VC_CAM_MV_TYPE cur_cam_mv_type, VC_WORK *w_p);
+int  vcRetSelfViewEffectRate(VC_CAM_MV_TYPE cur_cam_mv_type, int far_watch_rate,
+                             VC_WORK *w_p);
+void vcSetFlagsByCamMvType(VC_CAM_MV_TYPE cam_mv_type, int far_watch_rate,
+                           int all_warp_f);
 void vcPreSetDataInVC_WORK(VC_WORK *w_p, VC_ROAD_DATA *vc_road_ary_list);
-void vcSetTHROUGH_DOOR_CAM_PARAM_in_VC_WORK(VC_WORK *w_p, THROUGH_DOOR_SET_CMD_TYPE set_cmd_type);
+void vcSetTHROUGH_DOOR_CAM_PARAM_in_VC_WORK(
+    VC_WORK *w_p, THROUGH_DOOR_SET_CMD_TYPE set_cmd_type);
 void vcSetNearestEnemyDataInVC_WORK(VC_WORK *w_p);
-void vcSetNearRoadAryByCharaPos(VC_WORK *w_p, VC_ROAD_DATA *road_ary_list, int half_w, int unused, int near_enemy_f);
-int vcRetRoadUsePriority(VC_ROAD_TYPE rd_type);
-int vcSetCurNearRoadInVC_WORK(VC_WORK *w_p);
-int vcGetBestNewCurNearRoad(VC_NEAR_ROAD_DATA **new_cur_pp, VC_CAM_CHK_TYPE chk_type, VECTOR3 *pos, VC_WORK *w_p);
-int vcGetNearestNEAR_ROAD_DATA(VC_NEAR_ROAD_DATA **out_nearest_p_addr, VC_CAM_CHK_TYPE chk_type, VC_ROAD_TYPE rd_type, VECTOR3 *pos, VC_WORK *w_p, int chk_only_set_marge_f);
-int vcAdvantageDistOfOldCurRoad(VC_NEAR_ROAD_DATA *old_cur_p);
-void vcAutoRenewalWatchTgtPosAndAngZ(VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type, VC_AREA_SIZE_TYPE cur_rd_area_size, int far_watch_rate, short self_view_eff_rate);
-void vcMakeNormalWatchTgtPos(VECTOR3 *watch_tgt_pos, short *watch_tgt_ang_z_p, VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type, VC_AREA_SIZE_TYPE cur_rd_area_size);
-void vcMixSelfViewEffectToWatchTgtPos(VECTOR3 *watch_tgt_pos, short *watch_tgt_ang_z_p, short effect_rate, VC_WORK *w_p, MATRIX *head_mat, int anim_status);
-void vcMakeFarWatchTgtPos(VECTOR3 *watch_tgt_pos, VC_WORK *w_p, VC_AREA_SIZE_TYPE cur_rd_area_size);
-void vcSetWatchTgtXzPos(VECTOR3 *watch_pos, VECTOR3 *center_pos, VECTOR3 *cam_pos, int tgt_chara2watch_cir_dist, int tgt_watch_cir_r, short watch_cir_ang_y);
-void vcSetWatchTgtYParam(VECTOR3 *watch_pos, VC_WORK *w_p, int cam_mv_type, int watch_y);
-int vcAdjustWatchYLimitHighWhenFarView(VECTOR3 *watch_pos, VECTOR3 *cam_pos, short sy);
-void vcAutoRenewalCamTgtPos(VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type, VC_CAM_MV_PARAM *cam_mv_prm_p, VC_ROAD_FLAGS cur_rd_flags, VC_AREA_SIZE_TYPE cur_rd_area_size);
-int vcRetMaxTgtMvXzLen(VC_WORK *w_p, VC_CAM_MV_PARAM *cam_mv_prm_p);
+void vcSetNearRoadAryByCharaPos(VC_WORK *w_p, VC_ROAD_DATA *road_ary_list,
+                                int half_w, int unused, int near_enemy_f);
+int  vcRetRoadUsePriority(VC_ROAD_TYPE rd_type);
+int  vcSetCurNearRoadInVC_WORK(VC_WORK *w_p);
+int  vcGetBestNewCurNearRoad(VC_NEAR_ROAD_DATA **new_cur_pp,
+                             VC_CAM_CHK_TYPE chk_type, VECTOR3 *pos,
+                             VC_WORK *w_p);
+int  vcGetNearestNEAR_ROAD_DATA(VC_NEAR_ROAD_DATA **out_nearest_p_addr,
+                                VC_CAM_CHK_TYPE chk_type, VC_ROAD_TYPE rd_type,
+                                VECTOR3 *pos, VC_WORK *w_p,
+                                int chk_only_set_marge_f);
+int  vcAdvantageDistOfOldCurRoad(VC_NEAR_ROAD_DATA *old_cur_p);
+void vcAutoRenewalWatchTgtPosAndAngZ(VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type,
+                                     VC_AREA_SIZE_TYPE cur_rd_area_size,
+                                     int               far_watch_rate,
+                                     short             self_view_eff_rate);
+void vcMakeNormalWatchTgtPos(VECTOR3 *watch_tgt_pos, short *watch_tgt_ang_z_p,
+                             VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type,
+                             VC_AREA_SIZE_TYPE cur_rd_area_size);
+void vcMixSelfViewEffectToWatchTgtPos(VECTOR3 *watch_tgt_pos,
+                                      short   *watch_tgt_ang_z_p,
+                                      short effect_rate, VC_WORK *w_p,
+                                      MATRIX *head_mat, int anim_status);
+void vcMakeFarWatchTgtPos(VECTOR3 *watch_tgt_pos, VC_WORK *w_p,
+                          VC_AREA_SIZE_TYPE cur_rd_area_size);
+void vcSetWatchTgtXzPos(VECTOR3 *watch_pos, VECTOR3 *center_pos,
+                        VECTOR3 *cam_pos, int tgt_chara2watch_cir_dist,
+                        int tgt_watch_cir_r, short watch_cir_ang_y);
+void vcSetWatchTgtYParam(VECTOR3 *watch_pos, VC_WORK *w_p, int cam_mv_type,
+                         int watch_y);
+int  vcAdjustWatchYLimitHighWhenFarView(VECTOR3 *watch_pos, VECTOR3 *cam_pos,
+                                        short sy);
+void vcAutoRenewalCamTgtPos(VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type,
+                            VC_CAM_MV_PARAM  *cam_mv_prm_p,
+                            VC_ROAD_FLAGS     cur_rd_flags,
+                            VC_AREA_SIZE_TYPE cur_rd_area_size);
+int  vcRetMaxTgtMvXzLen(VC_WORK *w_p, VC_CAM_MV_PARAM *cam_mv_prm_p);
 void vcMakeIdealCamPosByHeadPos(VECTOR3 *ideal_pos, VC_WORK *w_p);
 void vcMakeIdealCamPosForFixAngCam(VECTOR3 *ideal_pos, VC_WORK *w_p);
 void vcMakeIdealCamPosForThroughDoorCam(VECTOR3 *ideal_pos, VC_WORK *w_p);
-void vcMakeIdealCamPosUseVC_ROAD_DATA(VECTOR3 *ideal_pos, VC_WORK *w_p, VC_AREA_SIZE_TYPE cur_rd_area_size);
-void vcAdjustXzInLimAreaUsingMIN_IN_ROAD_DIST(int *x_p, int *z_p, VC_LIMIT_AREA *lim_p);
-void vcMakeBasicCamTgtMvVec(VECTOR3 *tgt_mv_vec, VECTOR3 *ideal_pos, VC_WORK *w_p, int max_tgt_mv_xz_len);
+void vcMakeIdealCamPosUseVC_ROAD_DATA(VECTOR3 *ideal_pos, VC_WORK *w_p,
+                                      VC_AREA_SIZE_TYPE cur_rd_area_size);
+void vcAdjustXzInLimAreaUsingMIN_IN_ROAD_DIST(int *x_p, int *z_p,
+                                              VC_LIMIT_AREA *lim_p);
+void vcMakeBasicCamTgtMvVec(VECTOR3 *tgt_mv_vec, VECTOR3 *ideal_pos,
+                            VC_WORK *w_p, int max_tgt_mv_xz_len);
 void vcAdjTgtMvVecYByCurNearRoad(VECTOR3 *tgt_mv_vec, VC_WORK *w_p);
-void vcCamTgtMvVecIsFlipedFromCharaFront(VECTOR3 *tgt_mv_vec, VC_WORK *w_p, int max_tgt_mv_xz_len, VC_AREA_SIZE_TYPE cur_rd_area_size);
-int vcFlipFromCamExclusionArea(short *flip_ang_y_p, int *old_cam_excl_area_r_p, VECTOR3 *in_pos, VECTOR3 *chara_pos, short chara_eye_ang_y, VC_AREA_SIZE_TYPE cur_rd_area_size);
-void vcGetUseWatchAndCamMvParam(VC_WATCH_MV_PARAM **watch_mv_prm_pp, VC_CAM_MV_PARAM **cam_mv_prm_pp, int self_view_eff_rate, VC_WORK *w_p);
+void vcCamTgtMvVecIsFlipedFromCharaFront(VECTOR3 *tgt_mv_vec, VC_WORK *w_p,
+                                         int               max_tgt_mv_xz_len,
+                                         VC_AREA_SIZE_TYPE cur_rd_area_size);
+int  vcFlipFromCamExclusionArea(short *flip_ang_y_p, int *old_cam_excl_area_r_p,
+                                VECTOR3 *in_pos, VECTOR3 *chara_pos,
+                                short             chara_eye_ang_y,
+                                VC_AREA_SIZE_TYPE cur_rd_area_size);
+void vcGetUseWatchAndCamMvParam(VC_WATCH_MV_PARAM **watch_mv_prm_pp,
+                                VC_CAM_MV_PARAM   **cam_mv_prm_pp,
+                                int self_view_eff_rate, VC_WORK *w_p);
 void vcRenewalCamData(VC_WORK *w_p, VC_CAM_MV_PARAM *cam_mv_prm_p);
-void vcRenewalCamMatAng(VC_WORK *w_p, VC_WATCH_MV_PARAM *watch_mv_prm_p, VC_CAM_MV_TYPE cam_mv_type, int visible_chara_f);
-void vcMakeNewBaseCamAng(SVECTOR *new_base_ang, VC_CAM_MV_TYPE cam_mv_type, VC_WORK *w_p);
-void vcRenewalBaseCamAngAndAdjustOfsCamAng(VC_WORK *w_p, SVECTOR *new_base_cam_ang);
+void vcRenewalCamMatAng(VC_WORK *w_p, VC_WATCH_MV_PARAM *watch_mv_prm_p,
+                        VC_CAM_MV_TYPE cam_mv_type, int visible_chara_f);
+void vcMakeNewBaseCamAng(SVECTOR *new_base_ang, VC_CAM_MV_TYPE cam_mv_type,
+                         VC_WORK *w_p);
+void vcRenewalBaseCamAngAndAdjustOfsCamAng(VC_WORK *w_p,
+                                           SVECTOR *new_base_cam_ang);
 void vcMakeOfsCamTgtAng(SVECTOR *ofs_tgt_ang, MATRIX *base_matT, VC_WORK *w_p);
-void vcMakeOfsCam2CharaBottomAndTopAngByBaseMatT(SVECTOR *ofs_cam2chara_btm_ang, SVECTOR *ofs_cam2chara_top_ang, MATRIX *base_matT, VECTOR3 *cam_pos, VECTOR3 *chara_pos, int chara_bottom_y, int chara_top_y);
-void vcAdjCamOfsAngByCharaInScreen(SVECTOR *cam_ang, SVECTOR *ofs_cam2chara_btm_ang, SVECTOR *ofs_cam2chara_top_ang, VC_WORK *w_p);
-void vcAdjCamOfsAngByOfsAngSpd(SVECTOR *ofs_ang, SVECTOR *ofs_ang_spd, SVECTOR *ofs_tgt_ang, VC_WATCH_MV_PARAM *prm_p);
-void vcMakeCamMatAndCamAngByBaseAngAndOfsAng(SVECTOR *cam_mat_ang, MATRIX *cam_mat, SVECTOR *base_cam_ang, SVECTOR *ofs_cam_ang, VECTOR3 *cam_pos);
+void vcMakeOfsCam2CharaBottomAndTopAngByBaseMatT(
+    SVECTOR *ofs_cam2chara_btm_ang, SVECTOR *ofs_cam2chara_top_ang,
+    MATRIX *base_matT, VECTOR3 *cam_pos, VECTOR3 *chara_pos, int chara_bottom_y,
+    int chara_top_y);
+void vcAdjCamOfsAngByCharaInScreen(SVECTOR *cam_ang,
+                                   SVECTOR *ofs_cam2chara_btm_ang,
+                                   SVECTOR *ofs_cam2chara_top_ang,
+                                   VC_WORK *w_p);
+void vcAdjCamOfsAngByOfsAngSpd(SVECTOR *ofs_ang, SVECTOR *ofs_ang_spd,
+                               SVECTOR *ofs_tgt_ang, VC_WATCH_MV_PARAM *prm_p);
+void vcMakeCamMatAndCamAngByBaseAngAndOfsAng(SVECTOR *cam_mat_ang,
+                                             MATRIX  *cam_mat,
+                                             SVECTOR *base_cam_ang,
+                                             SVECTOR *ofs_cam_ang,
+                                             VECTOR3 *cam_pos);
 void vcSetDataToVwSystem(VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type);
 int vcCamMatNoise(int noise_w, int ang_spd1, int ang_spd2, int vcSelfViewTimer);
 int Math_VectorMagnitude(int x, int y, int z);
-int vcGetXZSumDistFromLimArea(int *out_vec_x_p, int *out_vec_z_p, int chk_wld_x, int chk_wld_z, int lim_min_x, int lim_max_x, int lim_min_z, int lim_max_z, int can_ret_minus_dist_f);
+int vcGetXZSumDistFromLimArea(int *out_vec_x_p, int *out_vec_z_p, int chk_wld_x,
+                              int chk_wld_z, int lim_min_x, int lim_max_x,
+                              int lim_min_z, int lim_max_z,
+                              int can_ret_minus_dist_f);
 
 #endif /* _VW_SYSTEM_H */

--- a/src/bodyprog/libsd/sdmain.c
+++ b/src/bodyprog/libsd/sdmain.c
@@ -1,0 +1,333 @@
+#include "common.h"
+#include "bodyprog/libsd.h"
+
+#include <libspu.h>
+#include <libsnd.h>
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", tone_adsr_mem);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", tone_adsr_back);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", sd_alloc_sort);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSpuMalloc);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSpuMallocWithStartAddr);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSpuFree);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdWorkInit);
+
+void SdInit(void) // 0x8009F490
+{
+    SsUtReverbOff();
+    sound_off();
+    SdWorkInit();
+    SpuInitMalloc(0x10, &sd_vb_malloc_rec);
+}
+
+void SdStart(void) // 0x8009F4D0
+{
+    if (sd_tick_mode > 0)
+    {
+        if (sd_tick_mode < 4)
+        {
+            smf_timer_set();
+        }
+    }
+    sd_interrupt_start_flag = 1;
+}
+
+void SdStart2(void) // 0x8009F510
+{
+    SdStart();
+}
+
+void SdSetTickMode(s32 tick_mode) // 0x8009F530
+{
+    sd_tick_mode = tick_mode;
+}
+
+void SdSeqCalledTbyT(void) // 0x8009F53C
+{
+    if (sd_interrupt_start_flag != 0)
+    {
+        smf_vsync();
+    }
+}
+
+void SdSetStereo(void) // 0x8009F568
+{
+    sd_mono_st_flag = 0;
+}
+
+void SdSetMono(void) // 0x8009F574
+{
+    sd_mono_st_flag = 1;
+}
+
+char SdSetReservedVoice(char voices) // 0x8009F584
+{
+    if (voices >= 0x19)
+    {
+        return -1;
+    }
+    if (voices == 0)
+    {
+        return -1;
+    }
+
+    sd_reserved_voice = voices;
+    return voices;
+}
+
+void SdSetTableSize(void) {} // 0x8009F5B8
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdEnd);
+
+void SdQuit(void) // 0x8009F64C
+{
+    sound_off();
+    SdWorkInit();
+    SpuQuit();
+}
+
+void SdSetSerialAttr(char s_num, char attr, char mode) // 0x8009F67C
+{
+    SpuCommonAttr spu_attr;
+
+    if (s_num == SS_SERIAL_A)
+    {
+        if (attr == SS_MIX)
+        {
+            spu_attr.mask   = SPU_COMMON_CDMIX;
+            spu_attr.cd.mix = mode;
+        }
+        else /* SS_REV */
+        {
+            spu_attr.mask      = SPU_COMMON_CDREV;
+            spu_attr.cd.reverb = mode;
+        }
+    }
+    else /* SS_SERIAL_B */
+    {
+        if (attr == SS_MIX)
+        {
+            spu_attr.mask    = SPU_COMMON_EXTMIX;
+            spu_attr.ext.mix = mode;
+        }
+        else /* SS_REV */
+        {
+            spu_attr.mask       = SPU_COMMON_EXTREV;
+            spu_attr.ext.reverb = mode;
+        }
+    }
+    SpuSetCommonAttr(&spu_attr);
+}
+
+void SdSetSerialVol(s16 s_num, s16 voll, s16 volr) // 0x8009F700
+{
+    // TODO: libsnd SsSetSerialVol uses char for s_num, callers also seem to
+    // pass char but only matches with s16 right now?
+
+    SpuCommonAttr attr;
+
+    s32 v_left  = voll << 8;
+    s32 v_right = volr << 8;
+
+    if (s_num == SS_SERIAL_A)
+    {
+        attr.mask            = (SPU_COMMON_CDVOLL | SPU_COMMON_CDVOLR);
+        attr.cd.volume.left  = v_left;
+        attr.cd.volume.right = v_right;
+    }
+    else /* SS_SERIAL_B */
+    {
+        attr.mask             = (SPU_COMMON_EXTVOLL | SPU_COMMON_EXTVOLR);
+        attr.ext.volume.left  = v_left;
+        attr.ext.volume.right = v_right;
+    }
+
+    SpuSetCommonAttr(&attr);
+}
+
+void SdSetMVol(s16 left, s16 right) // 0x8009F75C
+{
+    SpuCommonAttr attr;
+
+    attr.mask = (SPU_COMMON_MVOLL | SPU_COMMON_MVOLR | SPU_COMMON_MVOLMODEL |
+                 SPU_COMMON_MVOLMODER);
+    attr.mvol.left      = left << 7;
+    attr.mvol.right     = right << 7;
+    attr.mvolmode.left  = 0;
+    attr.mvolmode.right = 0;
+
+    SpuSetCommonAttr(&attr);
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdVabOpenHead);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdVabOpenHeadSticky);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdVabFakeHead);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdVbOpenOne);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdVabTransBody);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdVabTransBodyPartly);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdVabTransCompleted);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdVabClose);
+
+void SdSetAutoKeyOffMode(s16 mode) // 0x8009FF64
+{
+    sd_keyoff_mode = mode;
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdAutoKeyOffCheck);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSeqOpen);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSeqOpenWithAccNum);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSeqPlay);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSeqStop);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSeqClose);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSeqPause);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSeqReplay);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSeqSetVol);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSeqGetVol);
+
+void SdUtFlush(void) // 0x800A0794
+{
+    SdAutoKeyOffCheck();
+}
+
+void SdUtReverbOn(void) // 0x800A07B4
+{
+    SpuReserveReverbWorkArea(SPU_ON);
+    SpuSetReverb(SPU_ON);
+}
+
+void SdUtReverbOff(void) // 0x800A07DC
+{
+    sd_reverb_mode = 0;
+    SpuSetReverb(SPU_OFF);
+    SpuReserveReverbWorkArea(SPU_OFF);
+}
+
+s16 SdUtSetReverbType(s16 type) // 0x800A080C
+{
+    SpuReverbAttr attr;
+
+    attr.mask = SPU_REV_MODE;
+    attr.mode = type;
+
+    if (SpuSetReverbModeParam(&attr))
+    {
+        return -1;
+    }
+
+    sd_reverb_mode = type;
+    return type;
+}
+
+void SdUtSetReverbDepth(s16 left, s16 right) // 0x800A085C
+{
+    SpuReverbAttr attr;
+
+    attr.mask        = (SPU_REV_DEPTHL | SPU_REV_DEPTHR);
+    attr.depth.left  = (left << 0x10) >> 8;
+    attr.depth.right = (right << 0x10) >> 8;
+
+    SpuSetReverbModeParam(&attr);
+}
+
+void SdSetRVol(s16 left, s16 right) // 0x800A089C
+{
+    SpuReverbAttr attr;
+
+    attr.mask        = (SPU_REV_DEPTHL | SPU_REV_DEPTHR);
+    attr.depth.left  = (left << 0x10) >> 8;
+    attr.depth.right = (right << 0x10) >> 8;
+
+    SpuSetReverbModeParam(&attr);
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdUtSEAllKeyOff);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdUtAllKeyOff);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdUtGetVabHdr);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdVoKeyOn);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdVoKeyOff);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdVoKeyOffWithRROff);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdUtKeyOnV);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdUtKeyOn);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdVbKeyOn);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdUtKeyOffV);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdUtKeyOffVWithRROff);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdGetSeqStatus);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdUtSetDetVVol);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdUtSetVVol);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdUtGetDetVVol);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdUtGetVVol);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdGetTempo);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSetTempo);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSetSeqWide);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdGetMidiVol);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSetMidiVol);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSetMidiExpress);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdGetMidiExpress);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdGetMidiPan);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSetMidiPan);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdGetMidiPitchBendFine);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSetMidiPitchBendFine);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdGetTrackTranspause);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSetTrackTranspause);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdGetTrackMute);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdSetTrackMute);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdGetSeqControlStatus);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdGetSeqPlayStatus);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdGetSeqBeat);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmain", SdGetSeqBeat2);

--- a/src/bodyprog/libsd/sdmidi.c
+++ b/src/bodyprog/libsd/sdmidi.c
@@ -1,0 +1,67 @@
+#include "common.h"
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", func_800A397C);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", func_800A39B8);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", Note2Pitch);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", tre_calc);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", vib_calc);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", random_calc);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", volume_calc);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", smf_vol_set);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", master_vol_set);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", seq_master_vol_set);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", toremoro_set);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", pitch_bend_calc);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", pitch_calc);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", midi_mod);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", midi_porta);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", replay_reverb_set);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", midi_vsync);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", sound_seq_off);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", sound_off);
+
+void set_note_on_mb(void) {} // 0x800A4E90
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", adsr_set);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", rr_off);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", voice_check);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", key_on);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", key_off);
+
+void key_press(void) {} // 0x800A5DCC
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", get_vab_tone);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", smf_data_entry);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", control_change);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", program_change);
+
+void chan_press(void) {} // 0x800A6C58
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", pitch_bend);
+
+void control_code_set(void) {} // 0x800A6CB0

--- a/src/bodyprog/libsd/sdmidi2.c
+++ b/src/bodyprog/libsd/sdmidi2.c
@@ -1,0 +1,109 @@
+#include "common.h"
+#include "bodyprog/libsd.h"
+
+s32 smf_timer(void) // 0x800A6D18
+{
+    if ((sd_interrupt_start_flag == 0) || (sd_int_flag != 0))
+    {
+        return 1;
+    }
+    if (sd_int_flag2 == 0)
+    {
+        sd_int_flag2 = 1;
+        midi_smf_main();
+        if (sd_timer_sync >= 0xB)
+        {
+            midi_vsync();
+            SdAutoKeyOffCheck();
+            sd_timer_sync = 0;
+        }
+        sd_int_flag2 = 0;
+        sd_timer_sync += 1;
+    }
+    return 0;
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", smf_timer_set);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", smf_timer_end);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", smf_timer_stop);
+
+void smf_vsync(void) // 0x800A6F14
+{
+    if (sd_int_flag2 == 0)
+    {
+        sd_int_flag2 = 1;
+        if (smf_start_flag != 0)
+        {
+            midi_smf_main();
+            midi_smf_main();
+            midi_smf_main();
+            midi_smf_main();
+            midi_smf_main();
+            midi_smf_main();
+            midi_smf_main();
+            midi_smf_main();
+            midi_smf_main();
+            midi_smf_main();
+        }
+        midi_vsync();
+        SdAutoKeyOffCheck();
+        sd_int_flag2 = 0;
+    }
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", MemCmp);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", readMThd);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", readMTrk);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", readEOF);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", egetc);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", readvarinum);
+
+s32 to32bit(char arg0, char arg1, char arg2, char arg3) // 0x800A733C
+{
+    return (((((arg0 << 8) + arg1) << 8) + arg2) << 8) | arg3;
+}
+
+s32 to16bit(char arg0, char arg1) // 0x800A7368
+{
+    return (arg0 << 8) | arg1;
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", read32bit);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", read16bit);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", readheader);
+
+void len_add(s32 *ptr, s32 val) // 0x800A7814
+{
+    *ptr += val;
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", metaevent);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", sysex);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", chanmessage);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", readtrack);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", readtrack2);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", track_head_read);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", delta_time_conv);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", midi_file_out);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", midi_smf_main);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", midi_smf_stop);
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi2", midi_smf_stat);

--- a/src/bodyprog/libsd/ssmain.c
+++ b/src/bodyprog/libsd/ssmain.c
@@ -1,0 +1,27 @@
+#include "common.h"
+#include "bodyprog/libsd.h"
+
+void SsSetMVol(s16 left, s16 right) // 0x800A2294
+{
+    SdSetMVol(left, right);
+}
+
+void SsEnd(void) // 0x800A22C0
+{
+    SdEnd();
+}
+
+void SsSetSerialAttr(char s_num, char attr, char mode) // 0x800A22E0
+{
+    SdSetSerialAttr(s_num, attr, mode);
+}
+
+void SsSetSerialVol(char s_num, s16 voll, s16 volr) // 0x800A2308
+{
+    SdSetSerialVol(s_num, voll, volr);
+}
+
+void SsUtAllKeyOff(s16 mode) // 0x800A2338
+{
+    SdUtAllKeyOff(mode);
+}

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -7,27 +7,23 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcInitVCSystem);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcStartCameraSystem);
 
-// 0x80080A04
-void vcEndCameraSystem(void)
+void vcEndCameraSystem(void) // 0x80080A04
 {
     vcWork.view_cam_active_f_0 = 0;
 }
 
-// 0x80080A10
-s32 func_80080A10(void)
+s32 func_80080A10(void) // 0x80080A10
 {
     // TODO: bitfield access?
     return (vcWork.cur_near_road_2B8.road_p_0->cam_mv_type_14 >> 8) & 0xF;
 }
 
-// 0x80080A30
-void func_80080A30(s32 arg0)
+void func_80080A30(s32 arg0) // 0x80080A30
 {
     vcWork.field_2E4 = arg0;
 }
 
-// 0x80080A3C
-s32 func_80080A3C(void)
+s32 func_80080A3C(void) // 0x80080A3C
 {
     return vcWork.field_2E4;
 }
@@ -36,14 +32,12 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetFirstCamWork);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", func_80080B58);
 
-// 0x80080BF8
-void vcWorkSetFlags(VC_FLAGS enable, VC_FLAGS disable)
+void vcWorkSetFlags(VC_FLAGS enable, VC_FLAGS disable) // 0x80080BF8
 {
     vcWork.flags_8 = (vcWork.flags_8 | enable) & ~disable;
 }
 
-// 0x80080C18
-s32 func_80080C18(s32 arg0)
+s32 func_80080C18(s32 arg0) // 0x80080C18
 {
     s32 prev_val = vcWork.watch_tgt_max_y_88;
     vcWork.watch_tgt_max_y_88 = arg0;
@@ -54,39 +48,39 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcUserWatchTarget);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcUserCamTarget);
 
-// 0x80080D5C
-void vcChangeProjectionValue(s16 scr_y)
+void vcChangeProjectionValue(s16 scr_y) // 0x80080D5C
 {
     vcWork.geom_screen_dist_30 = scr_y;
 }
 
-// 0x80080D68
-void func_80080D68(void)
+void func_80080D68(void) // 0x80080D68
 {
     vcWork.field_D8 = 1;
 }
 
-// 0x80080D78
-void vcGetNowWatchPos(VECTOR3* watch_pos)
+void vcGetNowWatchPos(VECTOR3 *watch_pos) // 0x80080D78
 {
-    s32 temp_s1;
-    s32 temp_s4;
-    s32 temp_s5;
-    s32 temp_s6;
-    s32 temp_v0;
+    s32 sin_y;
+    s32 cos_y;
+    s32 cos_x;
+    s32 sin_x;
+    s32 r;
 
-    temp_s5 = shRcos(vcWork.cam_mat_ang_8E.vx);
-    temp_s6 = shRsin(vcWork.cam_mat_ang_8E.vx);
-    temp_s4 = shRcos(vcWork.cam_mat_ang_8E.vy);
-    temp_s1 = shRsin(vcWork.cam_mat_ang_8E.vy);
-    temp_v0 = Math_VectorMagnitude(vcWork.cam_pos_50.vx - vcWork.watch_tgt_pos_7C.vx, vcWork.cam_pos_50.vy - vcWork.watch_tgt_pos_7C.vy, vcWork.cam_pos_50.vz - vcWork.watch_tgt_pos_7C.vz);
-    watch_pos->vx = Math_MulFixed(Math_MulFixed(temp_v0, temp_s1, 0xC), temp_s5, 0xC) + vcWork.cam_pos_50.vx;
-    watch_pos->vz = Math_MulFixed(Math_MulFixed(temp_v0, temp_s4, 0xC), temp_s5, 0xC) + vcWork.cam_pos_50.vz;
-    watch_pos->vy = vcWork.cam_pos_50.vy - Math_MulFixed(temp_v0, temp_s6, 0xC);
+    cos_x = shRcos(vcWork.cam_mat_ang_8E.vx);
+    sin_x = shRsin(vcWork.cam_mat_ang_8E.vx);
+    cos_y = shRcos(vcWork.cam_mat_ang_8E.vy);
+    sin_y = shRsin(vcWork.cam_mat_ang_8E.vy);
+    r = Math_VectorMagnitude(vcWork.cam_pos_50.vx - vcWork.watch_tgt_pos_7C.vx,
+                             vcWork.cam_pos_50.vy - vcWork.watch_tgt_pos_7C.vy,
+                             vcWork.cam_pos_50.vz - vcWork.watch_tgt_pos_7C.vz);
+    watch_pos->vx = Math_MulFixed(Math_MulFixed(r, sin_y, 0xC), cos_x, 0xC) +
+                    vcWork.cam_pos_50.vx;
+    watch_pos->vz = Math_MulFixed(Math_MulFixed(r, cos_y, 0xC), cos_x, 0xC) +
+                    vcWork.cam_pos_50.vz;
+    watch_pos->vy = vcWork.cam_pos_50.vy - Math_MulFixed(r, sin_x, 0xC);
 }
 
-// 0x80080EA8
-void vcGetNowCamPos(VECTOR3* cam_pos)
+void vcGetNowCamPos(VECTOR3 *cam_pos) // 0x80080EA8
 {
     *cam_pos = vcWork.cam_pos_50;
 }
@@ -121,8 +115,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetNearestEnemyDataInVC_
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetNearRoadAryByCharaPos);
 
-// 0x8008227C
-s32 vcRetRoadUsePriority(VC_ROAD_TYPE rd_type)
+s32 vcRetRoadUsePriority(VC_ROAD_TYPE rd_type) // 0x8008227C
 {
     switch (rd_type)
     {
@@ -155,8 +148,8 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeFarWatchTgtPos);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetWatchTgtXzPos);
 
-// 0x800835C0
-void vcSetWatchTgtYParam(VECTOR3* watch_pos, VC_WORK* w_p, s32 cam_mv_type, s32 watch_y)
+void vcSetWatchTgtYParam(VECTOR3 *watch_pos, VC_WORK *w_p, s32 cam_mv_type,
+                         s32 watch_y) // 0x800835C0
 {
     if (cam_mv_type == VC_MV_SELF_VIEW)
     {
@@ -202,16 +195,16 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeNewBaseCamAng);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRenewalBaseCamAngAndAdjustOfsCamAng);
 
-// 0x800852C8
-void vcMakeOfsCamTgtAng(SVECTOR* ofs_tgt_ang, MATRIX* base_matT, VC_WORK* w_p)
+void vcMakeOfsCamTgtAng(SVECTOR *ofs_tgt_ang, MATRIX *base_matT,
+                        VC_WORK *w_p) // 0x800852C8
 {
-    SVECTOR sp10;
+    SVECTOR vec;
 
-    sp10.vx = (w_p->watch_tgt_pos_7C.vx - w_p->cam_pos_50.vx) >> 4;
-    sp10.vy = (w_p->watch_tgt_pos_7C.vy - w_p->cam_pos_50.vy) >> 4;
-    sp10.vz = (w_p->watch_tgt_pos_7C.vz - w_p->cam_pos_50.vz) >> 4;
-    ApplyMatrixSV(base_matT, &sp10, &sp10);
-    vwVectorToAngle(ofs_tgt_ang, &sp10);
+    vec.vx = (w_p->watch_tgt_pos_7C.vx - w_p->cam_pos_50.vx) >> 4;
+    vec.vy = (w_p->watch_tgt_pos_7C.vy - w_p->cam_pos_50.vy) >> 4;
+    vec.vz = (w_p->watch_tgt_pos_7C.vz - w_p->cam_pos_50.vz) >> 4;
+    ApplyMatrixSV(base_matT, &vec, &vec);
+    vwVectorToAngle(ofs_tgt_ang, &vec);
     ofs_tgt_ang->vz = w_p->watch_tgt_ang_z_8C;
 }
 
@@ -221,18 +214,21 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjCamOfsAngByCharaInScr
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjCamOfsAngByOfsAngSpd);
 
-// 0x800857EC
-void vcMakeCamMatAndCamAngByBaseAngAndOfsAng(SVECTOR* cam_mat_ang, MATRIX* cam_mat, SVECTOR* base_cam_ang, SVECTOR* ofs_cam_ang, VECTOR3* cam_pos)
+void vcMakeCamMatAndCamAngByBaseAngAndOfsAng(SVECTOR *cam_mat_ang,
+                                             MATRIX  *cam_mat,
+                                             SVECTOR *base_cam_ang,
+                                             SVECTOR *ofs_cam_ang,
+                                             VECTOR3 *cam_pos) // 0x800857EC
 {
-    MATRIX sp10;
-    MATRIX sp30;
+    MATRIX base_mat;
+    MATRIX ofs_mat;
 
     cam_mat->t[0] = cam_pos->vx >> 4;
     cam_mat->t[1] = cam_pos->vy >> 4;
     cam_mat->t[2] = cam_pos->vz >> 4;
-    func_80096C94(base_cam_ang, &sp10);
-    func_80096C94(ofs_cam_ang, &sp30);
-    MulMatrix0(&sp10, &sp30, cam_mat);
+    func_80096C94(base_cam_ang, &base_mat);
+    func_80096C94(ofs_cam_ang, &ofs_mat);
+    MulMatrix0(&base_mat, &ofs_mat, cam_mat);
     vwMatrixToAngleYXZ(cam_mat_ang, cam_mat);
 }
 

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -7,14 +7,12 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcInitCamera);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcSetCameraUseWarp);
 
-// 0x80040190
-int vcRetCamMvSmoothF()
+int vcRetCamMvSmoothF() // 0x80040190
 {
     return vcCameraInternalInfo.mv_smooth;
 }
 
-// 0x800401A0
-void func_800401A0(s32 arg0)
+void func_800401A0(s32 arg0) // 0x800401A0
 {
     if (arg0)
     {
@@ -26,14 +24,12 @@ void func_800401A0(s32 arg0)
     }
 }
 
-// 0x800401C0
-void vcSetEvCamRate(s16 ev_cam_rate)
+void vcSetEvCamRate(s16 ev_cam_rate) // 0x800401C0
 {
     vcCameraInternalInfo.ev_cam_rate = ev_cam_rate;
 }
 
-// 0x800401CC
-void func_800401CC()
+void func_800401CC() // 0x800401CC
 {
     func_80080D68();
 }
@@ -42,8 +38,8 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcMoveAndSetCamera);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcMakeHeroHeadPos);
 
-// 0x80040518
-void vcAddOfsToPos(VECTOR3* out_pos, VECTOR3* in_pos, s16 ofs_xz_r, s16 ang_y, s32 ofs_y)
+void vcAddOfsToPos(VECTOR3 *out_pos, VECTOR3 *in_pos, s16 ofs_xz_r, s16 ang_y,
+                   s32 ofs_y) // 0x80040518
 {
     out_pos->vx = in_pos->vx + ((ofs_xz_r * shRsin(ang_y)) >> 12);
     out_pos->vz = in_pos->vz + ((ofs_xz_r * shRcos(ang_y)) >> 12);

--- a/src/bodyprog/view/vw_calc.c
+++ b/src/bodyprog/view/vw_calc.c
@@ -11,8 +11,9 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwDecreaseSideOfVector);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwRetNewVelocityToTargetVal);
 
-// 0x80049464
-s32 vwRetNewAngSpdToTargetAng(s32 now_ang_spd, s16 now_ang, s16 tgt_ang, s32 accel_spd, s32 total_max_ang_spd, s32 dec_val_lim_spd)
+s32 vwRetNewAngSpdToTargetAng(s32 now_ang_spd, s16 now_ang, s16 tgt_ang,
+                              s32 accel_spd, s32 total_max_ang_spd,
+                              s32 dec_val_lim_spd) // 0x80049464
 {
     return vwRetNewVelocityToTargetVal(now_ang_spd, 0, ((tgt_ang - now_ang) << 0x14) >> 0x14, accel_spd, total_max_ang_spd, dec_val_lim_spd);
 }
@@ -27,8 +28,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_800496AC);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vbSetWorldScreenMatrix);
 
-// 0x800498D8
-void vbSetRefView(VbRVIEW* rview)
+void vbSetRefView(VbRVIEW *rview) // 0x800498D8
 {
     GsCOORDINATE2 sp10;
     SVECTOR sp60;
@@ -62,8 +62,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049F38);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_8004A54C);
 
-// 0x8004A66C
-void vwAngleToVector(SVECTOR* vec, SVECTOR* ang, s32 r)
+void vwAngleToVector(SVECTOR *vec, SVECTOR *ang, s32 r) // 0x8004A66C
 {
     s32 entou_r = (r * shRcos(ang->vx)) >> 12;
     vec->vy = (-r * shRsin(ang->vx)) >> 12;
@@ -71,22 +70,21 @@ void vwAngleToVector(SVECTOR* vec, SVECTOR* ang, s32 r)
     vec->vz = (entou_r * shRcos(ang->vy)) >> 12;
 }
 
-// 0x8004A714
-s32 vwVectorToAngle(SVECTOR* ang, SVECTOR* vec)
+s32 vwVectorToAngle(SVECTOR *ang, SVECTOR *vec) // 0x8004A714
 {
     VECTOR sp10;
-    s32 result;
+    s32    ret_r;
 
     sp10.vx = vec->vx;
     sp10.vy = vec->vy;
     sp10.vz = vec->vz;
     Square0(&sp10, &sp10);
-    result = SquareRoot0(sp10.vx + sp10.vy + sp10.vz);
-    
+    ret_r = SquareRoot0(sp10.vx + sp10.vy + sp10.vz);
+
     ang->vx = ratan2(-vec->vy, SquareRoot0(sp10.vx + sp10.vz));
     ang->vy = ratan2(vec->vx, vec->vz);
     ang->vz = 0;
-    return result;
+    return ret_r;
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwOresenHokan);

--- a/src/bodyprog/view/vw_main.c
+++ b/src/bodyprog/view/vw_main.c
@@ -2,8 +2,7 @@
 
 #include "bodyprog/vw_system.h"
 
-// 0x80048A38
-void vwInitViewInfo()
+void vwInitViewInfo() // 0x80048A38
 {
     vwViewPointInfo.rview.vp.vz = 0;
     vwViewPointInfo.rview.vp.vy = 0;
@@ -17,20 +16,17 @@ void vwInitViewInfo()
     vwSetViewInfo();
 }
 
-// 0x80048A90
-GsCOORDINATE2* vwGetViewCoord()
+GsCOORDINATE2 *vwGetViewCoord() // 0x80048A90
 {
     return &vwViewPointInfo.vwcoord;
 }
 
-// 0x80048A9C
-void vwGetViewPosition(VECTOR3* pos)
+void vwGetViewPosition(VECTOR3 *pos) // 0x80048A9C
 {
     *pos = vwViewPointInfo.worldpos;
 }
 
-// 0x80048AC4
-void vwGetViewAngle(SVECTOR* ang)
+void vwGetViewAngle(SVECTOR *ang) // 0x80048AC4
 {
     *ang = vwViewPointInfo.worldang;
 }
@@ -39,8 +35,8 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_main", func_80048AF4);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_main", vwSetCoordRefAndEntou);
 
-// 0x80048CF0
-void vwSetViewInfoDirectMatrix(GsCOORDINATE2* pcoord, MATRIX* cammat)
+void vwSetViewInfoDirectMatrix(GsCOORDINATE2 *pcoord,
+                               MATRIX        *cammat) // 0x80048CF0
 {
     vwViewPointInfo.vwcoord.flg = 0;
     vwViewPointInfo.vwcoord.super = pcoord;


### PR DESCRIPTION
Adds a few easy libsd matches, these mostly seem the same as libsnd funcs so wasn't sure if they were worth documenting separately, maybe if differences are found between them.

Updated clang-format to Allman, can use `git clang-format` to format any staged files for you, and ran that over view files.

There was an issue with clang-format wrapping `INCLUDE_ASM` to new lines too, which made splat put func into matchings folder & break the build, but adding it to `WhitespaceSensitiveMacros` seemed to fix that.