### PR TITLE
Add `view` and `stream` matches, start s_GameWork/s_SysWork

### DIFF
--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -1,17 +1,19 @@
 g_MainLoop_NumFrames = 0x800B9CCC;
 g_CurOTNum = 0x800B9FB8;
-g_SysWork = 0x800B9FC0; // type:SYS_W size:0x2768 - SYS_W struct?
-g_GameWork = 0x800BC728; // type:SH_SYS size:0x5D8 - SH_SYS? SH2_SYS in sh2
-g_pGameWork = 0x80024D44; // type:u32 SH_SYS* ?
-
-g_JoyPadBuff_tmp_P1 = 0x800BCCDC;
-g_JoyPadBuff_tmp_P2 = 0x800BC78C;
-g_JoyPadBuff_P1 = 0x800BC760; // type:s64
+g_SysWork = 0x800B9FC0; // type:SysWork size:0x2768 - should use s_SysWork here, but splat only supports custom structs with capital letter at beginning
+g_GameWork = 0x800BC728; // type:GameWork size:0x5D8
+g_pGameWork = 0x80024D44; // type:u32
+g_pSaveGame = 0x80024D48; // type:u32
+g_pController1 = 0x80024D4C; // type:u32
+g_pController2 = 0x80024D50; // type:u32
+g_pGameWork0 = 0x80024D54; // type:u32 same as g_pGameWork ?
 
 g_CurDeltaTime = 0x800B5CC0; // type:s32 - Q20.12 fixed point, usually 0x44 (0.0166..) or 0x88 (0.033..)
 
 // sh "view" / "vw" / "vc" / "vb" code
 // most names from SH2, functions seem to match pretty close between it and SH1, besides a few missing/added funcs
+hack_vcSetWatchTgtXzPos_fix = 0x8002B2B4; // type:s32 - some 0x80083500 value which probably coincidentally points to code inside vcSetWatchTgtXzPos, probably unrelated flags or something - a jtbl is right before this which spimdisasm decides to make it part of, breaking vcSetWatchTgtXzPos build
+
 vcInitCamera = 0x8004004c; // type:func
 vcSetCameraUseWarp = 0x800400d4; // type:func
 vcRetCamMvSmoothF = 0x80040190; // type:func

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -11,14 +11,14 @@ def add_custom_arguments(parser):
     )
 
 def apply_main(config, args):
-    config['mapfile'] = f'build/SLUS_007.07.map'
-    config['myimg'] = f'build/SLUS_007.07'
+    config['mapfile'] = f'build/out/SLUS_007.07.map'
+    config['myimg'] = f'build/out/SLUS_007.07'
     config['baseimg'] = f'rom/SLUS_007.07'
     config['source_directories'] = ['src/main', 'include', 'asm/main']
 
 def apply_overlay(binary_name, src_name, config, args):
-    config['mapfile'] = f'build/{os.path.basename(binary_name)}.map'
-    config['myimg'] = f'build/{os.path.basename(binary_name)}'
+    config['mapfile'] = f'build/out/{binary_name}.map'
+    config['myimg'] = f'build/out/{binary_name}'
     config['baseimg'] = f'assets/{binary_name}'
     config['source_directories'] = [f'src/{src_name}', f'asm/{src_name}', 'include']
 
@@ -30,7 +30,13 @@ def apply(config, args):
         if overlay == "bodyprog":
             apply_overlay("1ST/BODYPROG.BIN", "bodyprog", config, args)
         elif overlay == "b_konami":
-            apply_overlay("1ST/B_KONAMI.BIN", "b_konami", config, args)
+            apply_overlay("1ST/B_KONAMI.BIN", "screens/b_konami", config, args)
+        elif overlay == "option" or overlay == "options":
+            apply_overlay("VIN/OPTION.BIN", "screens/options", config, args)
+        elif overlay == "saveload":
+            apply_overlay("VIN/SAVELOAD.BIN", "screens/saveload", config, args)
+        elif overlay == "stf_roll" or overlay == "credits":
+            apply_overlay("VIN/STF_ROLL.BIN", "screens/credits", config, args)
         elif overlay == "stream":
             apply_overlay("VIN/STREAM.BIN", "stream", config, args)
     config["arch"] = "mipsel"

--- a/include/bodyprog/math.h
+++ b/include/bodyprog/math.h
@@ -4,7 +4,7 @@
 void func_80096C94(SVECTOR*, MATRIX*); // custom vwRotMatrix*** ?
 void func_80096E78(SVECTOR*, MATRIX*); // another custom vwRotMatrix*** ?
 
-s32 shRcos(s16);
-s32 shRsin(s16);
+s32 shRcos(s32);
+s32 shRsin(s32);
 
 #endif /* _BODYPROG_MATH_H */

--- a/include/bodyprog/vw_system.h
+++ b/include/bodyprog/vw_system.h
@@ -6,7 +6,7 @@
 #include <libgs.h>
 
 // TODO:
-// - change "struct SYS_W" to "SYS_W" below once SYS_W struct is added
+// - update func prototypes to match 1:1 with C files (s32 instead of int, etc)
 // - flags below are from SH2, most seem to match with SH but might be some
 // differences
 // - code that accesses VC_ROAD_TYPE & VC_NEAR_ROAD_DATA is odd, might need

--- a/include/bodyprog/vw_system.h
+++ b/include/bodyprog/vw_system.h
@@ -177,8 +177,8 @@ typedef struct _VC_WORK
     u_char                    through_door_activate_init_f_C;
     u_char                    unk_D[3];
     VC_THROUGH_DOOR_CAM_PARAM through_door_10;
-    u_short                   scr_half_ang_wy_2C;
-    u_short                   scr_half_ang_wx_2E;
+    s16                       scr_half_ang_wy_2C;
+    s16                       scr_half_ang_wx_2E;
     short geom_screen_dist_30; // related to GsSetProjection /
                                // g_GameSys.gs_y_res_58A
     short                field_32;
@@ -275,10 +275,10 @@ void vcMoveAndSetCamera(int in_connect_f, int change_debug_mode, int for_f,
 void vcMakeHeroHeadPos(VECTOR3 *head_pos);
 void vcAddOfsToPos(VECTOR3 *out_pos, VECTOR3 *in_pos, short ofs_xz_r,
                    short ang_y, int ofs_y);
-void vcSetRefPosAndSysRef2CamParam(VECTOR3 *ref_pos, struct SYS_W *sys_p,
+void vcSetRefPosAndSysRef2CamParam(VECTOR3 *ref_pos, s_SysWork *sys_p,
                                    int for_f, int back_f, int right_f,
                                    int left_f, int up_f, int down_f);
-void vcSetRefPosAndCamPosAngByPad(VECTOR3 *ref_pos, struct SYS_W *sys_p);
+void vcSetRefPosAndCamPosAngByPad(VECTOR3 *ref_pos, s_SysWork *sys_p);
 
 // vw_main
 void           vwInitViewInfo();
@@ -319,7 +319,7 @@ void vcInitVCSystem(VC_ROAD_DATA *vc_road_ary_list);
 void vcStartCameraSystem();
 void vcEndCameraSystem();
 void vcSetFirstCamWork(VECTOR3 *cam_pos, short chara_eye_ang_y,
-                       u_char use_through_door_cam_f);
+                       int use_through_door_cam_f);
 void vcWorkSetFlags(VC_FLAGS enable, VC_FLAGS disable);
 void vcUserWatchTarget(VECTOR3 *watch_tgt_pos, VC_WATCH_MV_PARAM *watch_prm_p,
                        int warp_watch_f);
@@ -366,7 +366,7 @@ int  vcAdvantageDistOfOldCurRoad(VC_NEAR_ROAD_DATA *old_cur_p);
 void vcAutoRenewalWatchTgtPosAndAngZ(VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type,
                                      VC_AREA_SIZE_TYPE cur_rd_area_size,
                                      int               far_watch_rate,
-                                     short             self_view_eff_rate);
+                                     int               self_view_eff_rate);
 void vcMakeNormalWatchTgtPos(VECTOR3 *watch_tgt_pos, short *watch_tgt_ang_z_p,
                              VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type,
                              VC_AREA_SIZE_TYPE cur_rd_area_size);
@@ -381,14 +381,15 @@ void vcSetWatchTgtXzPos(VECTOR3 *watch_pos, VECTOR3 *center_pos,
                         int tgt_watch_cir_r, short watch_cir_ang_y);
 void vcSetWatchTgtYParam(VECTOR3 *watch_pos, VC_WORK *w_p, int cam_mv_type,
                          int watch_y);
-int  vcAdjustWatchYLimitHighWhenFarView(VECTOR3 *watch_pos, VECTOR3 *cam_pos,
+void vcAdjustWatchYLimitHighWhenFarView(VECTOR3 *watch_pos, VECTOR3 *cam_pos,
                                         short sy);
 void vcAutoRenewalCamTgtPos(VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type,
                             VC_CAM_MV_PARAM  *cam_mv_prm_p,
                             VC_ROAD_FLAGS     cur_rd_flags,
                             VC_AREA_SIZE_TYPE cur_rd_area_size);
 int  vcRetMaxTgtMvXzLen(VC_WORK *w_p, VC_CAM_MV_PARAM *cam_mv_prm_p);
-void vcMakeIdealCamPosByHeadPos(VECTOR3 *ideal_pos, VC_WORK *w_p);
+void vcMakeIdealCamPosByHeadPos(VECTOR3 *ideal_pos, VC_WORK *w_p,
+                                VC_AREA_SIZE_TYPE cur_rd_area_size);
 void vcMakeIdealCamPosForFixAngCam(VECTOR3 *ideal_pos, VC_WORK *w_p);
 void vcMakeIdealCamPosForThroughDoorCam(VECTOR3 *ideal_pos, VC_WORK *w_p);
 void vcMakeIdealCamPosUseVC_ROAD_DATA(VECTOR3 *ideal_pos, VC_WORK *w_p,

--- a/include/common.h
+++ b/include/common.h
@@ -14,4 +14,7 @@
 #define STATIC_ASSERT_SIZEOF(TYPE, SIZE) \
     typedef char static_assertion_sizeof_##TYPE[(sizeof(TYPE) == (SIZE)) ? 1 : -1]
 
+#define CLAMP(val, min, max)                                                   \
+    (((val) < (min)) ? (min) : ((val) > (max)) ? (max) : (val))
+
 #endif

--- a/include/game.h
+++ b/include/game.h
@@ -1,9 +1,176 @@
 #ifndef GAME_H
 #define GAME_H
 
-#include "common.h"
+#include "gpu.h"
 
 extern void* g_OvlDynamic;
 extern void* g_OvlBodyprog;
+
+typedef struct _AnalogPadData
+{
+    u8  status;
+    u8  data_format;
+    u16 digitalButtons;
+    u8  right_x;
+    u8  right_y;
+    u8  left_x;
+    u8  left_y;
+} s_AnalogPadData;
+
+typedef enum _PadButton
+{
+    Pad_BtnSelect    = 0x1,
+    Pad_BtnL3        = 0x2,
+    Pad_BtnR3        = 0x4,
+    Pad_BtnStart     = 0x8,
+    Pad_BtnDpadUp    = 0x10,
+    Pad_BtnDpadRight = 0x20,
+    Pad_BtnDpadDown  = 0x40,
+    Pad_BtnDpadLeft  = 0x80,
+    Pad_BtnL2        = 0x100,
+    Pad_BtnR2        = 0x200,
+    Pad_BtnL1        = 0x400,
+    Pad_BtnR1        = 0x800,
+    Pad_BtnTriangle  = 0x1000,
+    Pad_BtnCircle    = 0x2000,
+    Pad_BtnCross     = 0x4000,
+    Pad_BtnSquare    = 0x8000,
+    Pad_LSUp2        = 0x10000,
+    Pad_LSRight2     = 0x20000,
+    Pad_LSDown2      = 0x40000,
+    Pad_LSLeft2      = 0x80000,
+    Pad_RSUp         = 0x100000,
+    Pad_RSRight      = 0x200000,
+    Pad_RSDown       = 0x400000,
+    Pad_RSLeft       = 0x800000,
+    Pad_LSUp         = 0x1000000,
+    Pad_LSRight      = 0x2000000,
+    Pad_LSDown       = 0x4000000,
+    Pad_LSLeft       = 0x8000000,
+} e_PadButton;
+
+typedef struct _ControllerData
+{
+    s_AnalogPadData AnalogPad;
+    int             field_8;
+    e_PadButton     btns_held_C;
+    e_PadButton     btns_new_10;
+    char            field_14[4];
+    e_PadButton     field_18;
+    int             field_1C;
+    char            field_20;
+    char            field_21;
+    char            field_22;
+    char            field_23;
+    char            field_24;
+    char            field_25;
+    char            field_26;
+    char            field_27;
+    int             field_28;
+} s_ControllerData;
+
+typedef struct _ControllerBindings
+{
+    u16 enter;
+    u16 cancel;
+    u16 skip;
+    u16 action;
+    u16 aim;
+    u16 light;
+    u16 run;
+    u16 view;
+    u16 step_l;
+    u16 step_r;
+    u16 pause;
+    u16 item;
+    u16 map;
+    u16 option;
+} s_ControllerBindings;
+
+typedef struct _GameWork
+{
+    s_ControllerBindings controllerBinds_0;
+    s8                   field_1C;
+    s8                   field_1D;
+    char                 unk_1E[9];
+    u8                   extraOptionsEnabled_27;
+    char                 unk_28[1];
+    s8                   gameOptionsViewMode_29;
+    char                 unk_2A[0xE];
+    s_ControllerData     controllers_38[2];
+    char                 pad90[0x4F8];
+    u16                  gsScreenWidth_588;
+    u16                  gsScreenHeight_58A;
+    char                 unk_58C[4];
+    s32                  field_590;
+    s32                  field_594;
+    s32                  field_598;
+    s32                  field_59C;
+    s32                  field_5A0;
+    char                 unk_5A4[0x34];
+} s_GameWork;
+
+typedef struct _SubCharacter
+{
+    char    chara_type_0;
+    char    field_1;
+    char    field_2;
+    char    field_3;
+    char    flags_4[0x14];
+    VECTOR3 position_18;
+    SVECTOR rotation_24;
+    SVECTOR rot_spd_2C;
+    int     field_34;
+    int     chara_mv_spd_38;
+    s16     chara_mv_ang_y_3C;
+    u8      pad_3E[2];
+    u8      unk_40[0x128 - 0x40];
+} s_SubCharacter;
+STATIC_ASSERT_SIZEOF(s_SubCharacter, 0x128);
+
+typedef struct _MainCharacter
+{
+    s_SubCharacter c;
+    u8             extra[0x2C];
+} s_MainCharacter;
+STATIC_ASSERT_SIZEOF(s_MainCharacter, 0x154);
+
+typedef struct _SysWork
+{
+    char            unk_0[8];
+    s32             field_8;
+    s32             field_C;
+    s32             field_10;
+    s32             field_14;
+    char            unk_18[4];
+    s32             field_1C;
+    s32             field_20;
+    s32             field_24;
+    s32             field_28;
+    s32             field_2C;
+    char            unk_30[0x1C];
+    s_MainCharacter player_4C;
+    char            unk_1A0[0x930 - 0x1A0];
+    GsCOORDINATE2   hero_neck_930;
+    char            unk_980[0x22A4 - 0x980];
+    s32             field_22A4;
+    char            unk_22A8[0xD2];
+    s16             cam_ang_y_237A;
+    s16             cam_ang_z_237C;
+    s16             field_237E;
+    int             cam_r_xz_2380;
+    int             cam_y_2384;
+    // more follows
+} s_SysWork;
+
+extern s_GameWork  g_GameWork;
+extern s_SysWork   g_SysWork;
+extern s_GameWork *g_pGameWork;
+
+extern s_ControllerData *g_pController1;
+extern s_ControllerData *g_pController2;
+extern s_GameWork       *g_pGameWork0;
+
+extern s32 g_CurDeltaTime;
 
 #endif

--- a/include/gpu.h
+++ b/include/gpu.h
@@ -5,6 +5,7 @@
 
 #include <libgte.h>
 #include <libgpu.h>
+#include <libgs.h>
 
 /** Primitive types. */
 enum PrimType

--- a/src/bodyprog/bodyprog_8004A87C.c
+++ b/src/bodyprog/bodyprog_8004A87C.c
@@ -1,5 +1,4 @@
-#include "common.h"
-#include "gpu.h"
+#include "game.h"
 #include "bodyprog/bodyprog.h"
 
 #include <libgs.h>
@@ -49,13 +48,13 @@ void func_8004B6D4(s16 arg0, s16 arg1)
 {
     if (arg0 != -1)
     {
-        D_800C38FC = arg0 + (-D_800BCCB0 / 2);
+        D_800C38FC = arg0 + (-g_GameWork.gsScreenWidth_588 / 2);
         D_800C391C = D_800C38FC;
     }
     
     if (arg1 != -1)
     {
-        D_800C38FE = arg1 + (-D_800BCCB2 / 2);
+        D_800C38FE = arg1 + (-g_GameWork.gsScreenHeight_58A / 2);
     }
 }
 

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -5,14 +5,20 @@
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcInitVCSystem);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcStartCameraSystem);
+void vcStartCameraSystem() // 0x800809DC
+{
+    vcWork.view_cam_active_f_0 = 1;
+    vcWork.field_D8            = 0;
+    vcWork.field_FC            = 0;
+    vcWork.geom_screen_dist_30 = g_GameWork.gsScreenHeight_58A;
+}
 
-void vcEndCameraSystem(void) // 0x80080A04
+void vcEndCameraSystem() // 0x80080A04
 {
     vcWork.view_cam_active_f_0 = 0;
 }
 
-s32 func_80080A10(void) // 0x80080A10
+s32 func_80080A10() // 0x80080A10
 {
     // TODO: bitfield access?
     return (vcWork.cur_near_road_2B8.road_p_0->cam_mv_type_14 >> 8) & 0xF;
@@ -23,14 +29,25 @@ void func_80080A30(s32 arg0) // 0x80080A30
     vcWork.field_2E4 = arg0;
 }
 
-s32 func_80080A3C(void) // 0x80080A3C
+s32 func_80080A3C() // 0x80080A3C
 {
     return vcWork.field_2E4;
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetFirstCamWork);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", func_80080B58);
+void func_80080B58(GsCOORDINATE2 *a1, SVECTOR *a2, VECTOR3 *a3) // 0x80080B58
+{
+    MATRIX sp10;
+
+    vcWork.field_FC = 1;
+    func_80049984(a1, &vcWork.field_DC);
+    func_80096C94(a2, &sp10);
+    MulMatrix(&vcWork.field_DC, &sp10);
+    vcWork.field_DC.t[0] = a3->vx >> 4;
+    vcWork.field_DC.t[1] = a3->vy >> 4;
+    vcWork.field_DC.t[2] = a3->vz >> 4;
+}
 
 void vcWorkSetFlags(VC_FLAGS enable, VC_FLAGS disable) // 0x80080BF8
 {
@@ -44,16 +61,48 @@ s32 func_80080C18(s32 arg0) // 0x80080C18
     return prev_val;
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcUserWatchTarget);
+void vcUserWatchTarget(VECTOR3 *watch_tgt_pos, VC_WATCH_MV_PARAM *watch_prm_p,
+                       s32 warp_watch_f) // 0x80080C2C
+{
+    vcWork.flags_8 =
+        (vcWork.flags_8 & ~(VC_USER_WATCH_F | VC_VISIBLE_CHARA_F)) |
+        VC_USER_WATCH_F;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcUserCamTarget);
+    if (warp_watch_f != 0)
+        vcWork.flags_8 |= VC_WARP_WATCH_F;
+
+    vcWork.watch_tgt_pos_7C   = *watch_tgt_pos;
+    vcWork.watch_tgt_ang_z_8C = 0;
+
+    if (watch_prm_p == NULL)
+        vcWork.user_watch_mv_prm_70 = deflt_watch_mv_prm;
+    else
+        vcWork.user_watch_mv_prm_70 = *watch_prm_p;
+}
+
+void vcUserCamTarget(VECTOR3 *cam_tgt_pos, VC_CAM_MV_PARAM *cam_prm_p,
+                     s32 warp_cam_f) // 0x80080CBC
+{
+    vcWork.flags_8 =
+        (vcWork.flags_8 & ~(VC_USER_CAM_F | VC_WARP_CAM_F)) | VC_USER_CAM_F;
+
+    if (warp_cam_f != 0)
+        vcWork.flags_8 |= VC_WARP_CAM_F;
+
+    vcWork.cam_tgt_pos_44 = *cam_tgt_pos;
+
+    if (cam_prm_p == NULL)
+        vcWork.user_cam_mv_prm_34 = cam_mv_prm_user;
+    else
+        vcWork.user_cam_mv_prm_34 = *cam_prm_p;
+}
 
 void vcChangeProjectionValue(s16 scr_y) // 0x80080D5C
 {
     vcWork.geom_screen_dist_30 = scr_y;
 }
 
-void func_80080D68(void) // 0x80080D68
+void func_80080D68() // 0x80080D68
 {
     vcWork.field_D8 = 1;
 }
@@ -85,9 +134,33 @@ void vcGetNowCamPos(VECTOR3 *cam_pos) // 0x80080EA8
     *cam_pos = vcWork.cam_pos_50;
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcReturnPreAutoCamWork);
+void vcReturnPreAutoCamWork(int warp_f) // 0x80080ED0
+{
+    if (warp_f)
+        vcWork.flags_8 |= VC_WARP_CAM_F | VC_WARP_WATCH_F | VC_WARP_CAM_TGT_F;
+    vcWork.flags_8 &= ~(VC_USER_CAM_F | VC_USER_WATCH_F);
+    vcWork.geom_screen_dist_30 = g_GameWork.gsScreenHeight_58A;
+}
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetSubjChara);
+void vcSetSubjChara(VECTOR3 *chara_pos, s32 chara_bottom_y, s32 chara_top_y,
+                    s32 chara_grnd_y, VECTOR3 *chara_head_pos, s16 chara_mv_spd,
+                    s32 chara_mv_ang_y, s16 chara_ang_spd_y,
+                    s16 chara_eye_ang_y, s16 chara_eye_ang_wy,
+                    s32 chara_watch_xz_r) // 0x80080F14
+{
+    vcWork.chara_pos_114        = *chara_pos;
+    vcWork.chara_bottom_y_120   = chara_bottom_y;
+    vcWork.chara_top_y_124      = chara_top_y;
+    vcWork.chara_center_y_128   = (chara_bottom_y + chara_top_y) >> 1;
+    vcWork.chara_grnd_y_12C     = chara_grnd_y;
+    vcWork.chara_head_pos_130   = *chara_head_pos;
+    vcWork.chara_mv_spd_13C     = chara_mv_spd;
+    vcWork.chara_eye_ang_y_144  = chara_eye_ang_y;
+    vcWork.chara_mv_ang_y_140   = chara_mv_ang_y;
+    vcWork.chara_ang_spd_y_142  = chara_ang_spd_y;
+    vcWork.chara_eye_ang_wy_146 = chara_eye_ang_wy;
+    vcWork.chara_watch_xz_r_148 = chara_watch_xz_r;
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcExecCamera);
 
@@ -107,9 +180,69 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRetSelfViewEffectRate);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetFlagsByCamMvType);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcPreSetDataInVC_WORK);
+void vcPreSetDataInVC_WORK(VC_WORK      *w_p,
+                           VC_ROAD_DATA *vc_road_ary_list) // 0x80081B6C
+{
+    if (g_CurDeltaTime != 0)
+    {
+        if (vcWork.flags_8 & VC_PRS_F_VIEW_F)
+            vcWork.flags_8 |= VC_OLD_PRS_F_VIEW_F;
+        else
+            vcWork.flags_8 &= ~VC_OLD_PRS_F_VIEW_F;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetTHROUGH_DOOR_CAM_PARAM_in_VC_WORK);
+        if (g_pController1->btns_held_C & g_pGameWork0->controllerBinds_0.view)
+            vcWork.flags_8 |= VC_PRS_F_VIEW_F;
+        else
+            vcWork.flags_8 &= ~VC_PRS_F_VIEW_F;
+    }
+
+    vcWork.scr_half_ang_wx_2E = (s16)(ratan2(g_GameWork.gsScreenWidth_588,
+                                             vcWork.geom_screen_dist_30) >>
+                                      1);
+    vcWork.scr_half_ang_wy_2C = (s16)(ratan2(g_GameWork.gsScreenHeight_58A,
+                                             vcWork.geom_screen_dist_30) >>
+                                      1);
+
+    if (vcWork.through_door_activate_init_f_C != 0)
+        vcSetTHROUGH_DOOR_CAM_PARAM_in_VC_WORK(&vcWork, VC_TDSC_START);
+
+    vcSetTHROUGH_DOOR_CAM_PARAM_in_VC_WORK(&vcWork, VC_TDSC_MAIN);
+    vcSetNearestEnemyDataInVC_WORK(w_p);
+    vcSetNearRoadAryByCharaPos(w_p, vc_road_ary_list, 0x14000, 0,
+                               w_p->nearest_enemy_p_2DC != NULL);
+}
+
+void vcSetTHROUGH_DOOR_CAM_PARAM_in_VC_WORK(
+    VC_WORK *w_p, enum _THROUGH_DOOR_SET_CMD_TYPE set_cmd_type) // 0x80081CBC
+{
+    VC_THROUGH_DOOR_CAM_PARAM *prm_p = &w_p->through_door_10;
+
+    switch (set_cmd_type)
+    {
+    case VC_TDSC_START:
+        w_p->through_door_10.active_f_0 = 1;
+        prm_p->timer_4                  = 0;
+        prm_p->rail_ang_y_8             = w_p->chara_eye_ang_y_144;
+        prm_p->rail_sta_pos_C.vx        = w_p->chara_pos_114.vx;
+        prm_p->rail_sta_pos_C.vy        = w_p->chara_grnd_y_12C - 7987;
+        prm_p->rail_sta_pos_C.vz        = w_p->chara_pos_114.vz;
+        break;
+    case VC_TDSC_END:
+        w_p->through_door_10.active_f_0 = 0;
+        prm_p->timer_4                  = 0;
+        break;
+    case VC_TDSC_MAIN:
+        if (w_p->through_door_10.active_f_0 != 0)
+        {
+            prm_p->rail_sta_to_chara_dist_18 = Math_VectorMagnitude(
+                w_p->chara_pos_114.vx - w_p->through_door_10.rail_sta_pos_C.vx,
+                0,
+                w_p->chara_pos_114.vz - w_p->through_door_10.rail_sta_pos_C.vz);
+            prm_p->timer_4 += g_CurDeltaTime;
+        }
+        break;
+    }
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetNearestEnemyDataInVC_WORK);
 
@@ -138,7 +271,47 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcGetNearestNEAR_ROAD_DATA
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdvantageDistOfOldCurRoad);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAutoRenewalWatchTgtPosAndAngZ);
+void vcAutoRenewalWatchTgtPosAndAngZ(VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type,
+                                     VC_AREA_SIZE_TYPE cur_rd_area_size,
+                                     int               far_watch_rate,
+                                     int self_view_eff_rate) // 0x80082B10
+{
+    VECTOR3 far_watch_pos;
+
+    vcMakeFarWatchTgtPos(&far_watch_pos, w_p, cur_rd_area_size);
+    if (cam_mv_type != VC_MV_SELF_VIEW)
+    {
+        vcMakeNormalWatchTgtPos(&w_p->watch_tgt_pos_7C,
+                                &w_p->watch_tgt_ang_z_8C, w_p, cam_mv_type,
+                                cur_rd_area_size);
+        if (far_watch_rate != 0)
+        {
+            w_p->watch_tgt_pos_7C.vx +=
+                (far_watch_rate *
+                 (far_watch_pos.vx - w_p->watch_tgt_pos_7C.vx)) >>
+                0xC;
+            w_p->watch_tgt_pos_7C.vy +=
+                (far_watch_rate *
+                 (far_watch_pos.vy - w_p->watch_tgt_pos_7C.vy)) >>
+                0xC;
+            w_p->watch_tgt_pos_7C.vz +=
+                (far_watch_rate *
+                 (far_watch_pos.vz - w_p->watch_tgt_pos_7C.vz)) >>
+                0xC;
+        }
+    }
+    else
+    {
+        w_p->watch_tgt_pos_7C = far_watch_pos;
+    }
+
+    vcMixSelfViewEffectToWatchTgtPos(
+        &w_p->watch_tgt_pos_7C, &w_p->watch_tgt_ang_z_8C, self_view_eff_rate,
+        w_p, &g_SysWork.hero_neck_930.workm, g_SysWork.player_4C.c.flags_4[0]);
+
+    if (w_p->watch_tgt_pos_7C.vy > w_p->watch_tgt_max_y_88)
+        w_p->watch_tgt_pos_7C.vy = w_p->watch_tgt_max_y_88;
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeNormalWatchTgtPos);
 
@@ -146,28 +319,169 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMixSelfViewEffectToWatch
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeFarWatchTgtPos);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetWatchTgtXzPos);
+void vcSetWatchTgtXzPos(VECTOR3 *watch_pos, VECTOR3 *center_pos,
+                        VECTOR3 *cam_pos, s32 tgt_chara2watch_cir_dist,
+                        s32 tgt_watch_cir_r, s16 watch_cir_ang_y) // 0x800834A8
+{
+    s16 cam2chr_ang;
+    s32 chr2watch_x;
+    s32 chr2watch_z;
+
+    cam2chr_ang =
+        ratan2(center_pos->vx - cam_pos->vx, center_pos->vz - cam_pos->vz);
+
+    chr2watch_x =
+        Math_MulFixed(tgt_chara2watch_cir_dist, shRsin(cam2chr_ang), 0xC) +
+        Math_MulFixed(tgt_watch_cir_r, shRsin(watch_cir_ang_y), 0xC);
+    chr2watch_z =
+        Math_MulFixed(tgt_chara2watch_cir_dist, shRcos(cam2chr_ang), 0xC) +
+        Math_MulFixed(tgt_watch_cir_r, shRcos(watch_cir_ang_y), 0xC);
+
+    watch_pos->vx = center_pos->vx + chr2watch_x;
+    watch_pos->vz = center_pos->vz + chr2watch_z;
+}
 
 void vcSetWatchTgtYParam(VECTOR3 *watch_pos, VC_WORK *w_p, s32 cam_mv_type,
                          s32 watch_y) // 0x800835C0
 {
     if (cam_mv_type == VC_MV_SELF_VIEW)
-    {
         watch_pos->vy = w_p->chara_center_y_128;
-    }
     else
-    {
         watch_pos->vy = watch_y;
+}
+
+void vcAdjustWatchYLimitHighWhenFarView(VECTOR3 *watch_pos, VECTOR3 *cam_pos,
+                                        short sy) // 0x800835E0
+{
+    s16 max_cam_ang_x = ratan2(cam_pos->vy + 0x5000, 0xD000) -
+                        ratan2(g_GameWork.gsScreenHeight_58A / 2, sy);
+    s32 dist      = Math_VectorMagnitude(watch_pos->vx - cam_pos->vx, 0,
+                                         watch_pos->vz - cam_pos->vz);
+    s32 cam_ang_x = ratan2(-watch_pos->vy + cam_pos->vy, dist) * 65536;
+
+    if (max_cam_ang_x * 65536 < cam_ang_x)
+    {
+        s32 ofs_y =
+            (((dist >> 4) * shRsin(max_cam_ang_x)) / shRcos(max_cam_ang_x)) *
+            0x10;
+        watch_pos->vy = cam_pos->vy - ofs_y;
     }
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjustWatchYLimitHighWhenFarView);
+void vcAutoRenewalCamTgtPos(VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type,
+                            VC_CAM_MV_PARAM  *cam_mv_prm_p,
+                            VC_ROAD_FLAGS     cur_rd_flags,
+                            VC_AREA_SIZE_TYPE cur_rd_area_size) // 0x800836E8
+{
+    VECTOR3 tgt_vec;
+    VECTOR3 ideal_pos;
+    s32     max_tgt_mv_xz_len;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAutoRenewalCamTgtPos);
+    switch (cam_mv_type)
+    {
+    case VC_MV_SELF_VIEW:
+        vcMakeIdealCamPosByHeadPos(&ideal_pos, w_p, cur_rd_area_size);
+        break;
+    case VC_MV_FIX_ANG:
+        vcMakeIdealCamPosForFixAngCam(&ideal_pos, w_p);
+        break;
+    case VC_MV_THROUGH_DOOR:
+        vcMakeIdealCamPosForThroughDoorCam(&ideal_pos, w_p);
+        break;
+    default:
+        vcMakeIdealCamPosUseVC_ROAD_DATA(&ideal_pos, w_p, cur_rd_area_size);
+        break;
+    }
+    if (vcWork.flags_8 & VC_WARP_CAM_TGT_F)
+        w_p->cam_tgt_pos_44 = ideal_pos;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRetMaxTgtMvXzLen);
+    // TODO: not sure what's going on here, doesn't seem to work as if statement
+    switch (cam_mv_type == VC_MV_SELF_VIEW)
+    {
+    case 0:
+        max_tgt_mv_xz_len = vcRetMaxTgtMvXzLen(w_p, cam_mv_prm_p);
+        vcMakeBasicCamTgtMvVec(&tgt_vec, &ideal_pos, w_p, max_tgt_mv_xz_len);
+        if ((cam_mv_type == VC_MV_CHASE) &&
+            !(cur_rd_flags & VC_RD_NO_FRONT_FLIP_F))
+        {
+            vcCamTgtMvVecIsFlipedFromCharaFront(
+                &tgt_vec, w_p, max_tgt_mv_xz_len, cur_rd_area_size);
+        }
+        if (cam_mv_type != VC_MV_THROUGH_DOOR)
+        {
+            vcAdjTgtMvVecYByCurNearRoad(&tgt_vec, w_p);
+        }
+        break;
+    case 1:
+        vcMakeBasicCamTgtMvVec(&tgt_vec, &ideal_pos, w_p, 0x1000);
+        break;
+    }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeIdealCamPosByHeadPos);
+    w_p->cam_tgt_mv_ang_y_10C = ratan2(tgt_vec.vx, tgt_vec.vz);
+
+    if (g_CurDeltaTime != 0 || vcWork.flags_8 & VC_WARP_CAM_TGT_F)
+    {
+        w_p->cam_tgt_pos_44.vx += tgt_vec.vx;
+        w_p->cam_tgt_pos_44.vy += tgt_vec.vy;
+        w_p->cam_tgt_pos_44.vz += tgt_vec.vz;
+        w_p->cam_tgt_velo_100.vx = (tgt_vec.vx << 0xC) / g_CurDeltaTime;
+        w_p->cam_tgt_velo_100.vy = (tgt_vec.vy << 0xC) / g_CurDeltaTime;
+        w_p->cam_tgt_velo_100.vz = (tgt_vec.vz << 0xC) / g_CurDeltaTime;
+        w_p->cam_tgt_spd_110 = Math_VectorMagnitude(w_p->cam_tgt_velo_100.vx, 0,
+                                                    w_p->cam_tgt_velo_100.vz);
+        return;
+    }
+
+    w_p->cam_tgt_velo_100.vx = 0;
+    w_p->cam_tgt_velo_100.vz = 0;
+    w_p->cam_tgt_spd_110     = 0;
+}
+
+s32 vcRetMaxTgtMvXzLen(VC_WORK         *w_p,
+                       VC_CAM_MV_PARAM *cam_mv_prm_p) // 0x8008395C
+{
+    s32 max_spd_xz;
+
+    max_spd_xz =
+        w_p->chara_mv_spd_13C + 0x1000 + abs(w_p->chara_ang_spd_y_142 * 8);
+    max_spd_xz = (max_spd_xz < 0x2333) ? 0x2333 : max_spd_xz;
+    max_spd_xz =
+        (cam_mv_prm_p->max_spd_xz > max_spd_xz ? max_spd_xz
+                                               : cam_mv_prm_p->max_spd_xz);
+
+    return Math_MulFixed(max_spd_xz, g_CurDeltaTime, 0xC);
+}
+
+void vcMakeIdealCamPosByHeadPos(
+    VECTOR3 *ideal_pos, VC_WORK *w_p,
+    VC_AREA_SIZE_TYPE cur_rd_area_size) // 0x800839CC
+{
+    s32 chara2cam_ang_y;
+
+    if (w_p->flags_8 & VC_WARP_WATCH_F)
+    {
+        ideal_pos->vx = w_p->chara_pos_114.vx;
+        ideal_pos->vy = w_p->chara_top_y_124;
+        ideal_pos->vz = w_p->chara_pos_114.vz;
+        return;
+    }
+
+    if (g_pGameWork->gameOptionsViewMode_29)
+    {
+        chara2cam_ang_y = w_p->chara_eye_ang_y_144 + 0x638;
+        ideal_pos->vy   = w_p->chara_head_pos_130.vy + 0x11E;
+    }
+    else
+    {
+        chara2cam_ang_y = w_p->chara_eye_ang_y_144 + 0x78E;
+        ideal_pos->vy   = w_p->chara_head_pos_130.vy + 0x199;
+    }
+
+    ideal_pos->vx =
+        w_p->chara_head_pos_130.vx + ((shRsin(chara2cam_ang_y) * 0x2E1) >> 0xC);
+    ideal_pos->vz =
+        w_p->chara_head_pos_130.vz + ((shRcos(chara2cam_ang_y) * 0x2E1) >> 0xC);
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeIdealCamPosForFixAngCam);
 
@@ -177,7 +491,38 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeIdealCamPosUseVC_ROA
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjustXzInLimAreaUsingMIN_IN_ROAD_DIST);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeBasicCamTgtMvVec);
+void vcMakeBasicCamTgtMvVec(VECTOR3 *tgt_mv_vec, VECTOR3 *ideal_pos,
+                            VC_WORK *w_p, s32 max_tgt_mv_xz_len) // 0x800842C0
+{
+    s32 now2ideal_tgt_dist;
+    s16 now2ideal_tgt_ang_y;
+    s32 temp_s0; // SH2: float xz_vec[4];
+    s32 temp_s1;
+
+    temp_s1 = ideal_pos->vx - w_p->cam_tgt_pos_44.vx;
+    temp_s0 = ideal_pos->vz - w_p->cam_tgt_pos_44.vz;
+
+    now2ideal_tgt_dist  = Math_VectorMagnitude(temp_s1, 0, temp_s0);
+    now2ideal_tgt_ang_y = ratan2(temp_s1, temp_s0);
+
+    if (now2ideal_tgt_dist < max_tgt_mv_xz_len)
+    {
+        tgt_mv_vec->vx = ideal_pos->vx - w_p->cam_tgt_pos_44.vx;
+        tgt_mv_vec->vz = ideal_pos->vz - w_p->cam_tgt_pos_44.vz;
+    }
+    else
+    {
+        tgt_mv_vec->vx =
+            (max_tgt_mv_xz_len * shRsin(now2ideal_tgt_ang_y)) >> 0xC;
+        tgt_mv_vec->vz =
+            (max_tgt_mv_xz_len * shRcos(now2ideal_tgt_ang_y)) >> 0xC;
+    }
+
+    if (g_CurDeltaTime == 0 && !(vcWork.flags_8 & VC_WARP_CAM_TGT_F))
+        tgt_mv_vec->vy = 0;
+    else
+        tgt_mv_vec->vy = ideal_pos->vy - w_p->cam_tgt_pos_44.vy;
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjTgtMvVecYByCurNearRoad);
 
@@ -185,15 +530,161 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcCamTgtMvVecIsFlipedFromC
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcFlipFromCamExclusionArea);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcGetUseWatchAndCamMvParam);
+void vcGetUseWatchAndCamMvParam(VC_WATCH_MV_PARAM **watch_mv_prm_pp,
+                                VC_CAM_MV_PARAM   **cam_mv_prm_pp,
+                                s32                 self_view_eff_rate,
+                                VC_WORK            *w_p) // 0x80084A34
+{
+    VC_CAM_MV_PARAM *cam_mv_prm_stg_p;
+    s32              add_ang_accel_y;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRenewalCamData);
+    if (w_p->flags_8 & VC_USER_WATCH_F)
+    {
+        *watch_mv_prm_pp = &w_p->user_watch_mv_prm_70;
+    }
+    else
+    {
+        vcWatchMvPrmSt.ang_accel_x =
+            Math_MulFixed(self_view_watch_mv_prm.ang_accel_x -
+                              deflt_watch_mv_prm.ang_accel_x,
+                          self_view_eff_rate, 0xC) +
+            deflt_watch_mv_prm.ang_accel_x;
+        vcWatchMvPrmSt.ang_accel_y =
+            Math_MulFixed(self_view_watch_mv_prm.ang_accel_y -
+                              deflt_watch_mv_prm.ang_accel_y,
+                          self_view_eff_rate, 0xC) +
+            deflt_watch_mv_prm.ang_accel_y;
+        vcWatchMvPrmSt.max_ang_spd_x =
+            deflt_watch_mv_prm.max_ang_spd_x +
+            Math_MulFixed(self_view_watch_mv_prm.max_ang_spd_x -
+                              deflt_watch_mv_prm.max_ang_spd_x,
+                          self_view_eff_rate, 0xC);
+        vcWatchMvPrmSt.max_ang_spd_y =
+            deflt_watch_mv_prm.max_ang_spd_y +
+            Math_MulFixed(self_view_watch_mv_prm.max_ang_spd_y -
+                              deflt_watch_mv_prm.max_ang_spd_y,
+                          self_view_eff_rate, 0xC);
+        *watch_mv_prm_pp = &vcWatchMvPrmSt;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRenewalCamMatAng);
+        add_ang_accel_y = (((s64)w_p->chara_mv_spd_13C * 0x1000) >> 0xC);
+        add_ang_accel_y = CLAMP(add_ang_accel_y, 0, 0x2000);
+
+        vcWatchMvPrmSt.ang_accel_y += add_ang_accel_y;
+    }
+
+    cam_mv_prm_stg_p = (w_p->flags_8 & VC_USER_CAM_F) ? &w_p->user_cam_mv_prm_34
+                                                      : &cam_mv_prm_user;
+    *cam_mv_prm_pp   = cam_mv_prm_stg_p;
+}
+
+void vcRenewalCamData(VC_WORK *w_p, VC_CAM_MV_PARAM *cam_mv_prm_p) // 0x80084BD8
+{
+    s32 dec_spd_per_dist_xz;
+    s32 dec_spd_per_dist_y;
+
+    if (w_p->flags_8 & VC_WARP_CAM_F) // & 4
+    {
+        w_p->cam_mv_ang_y_5C =
+            ratan2(w_p->cam_tgt_pos_44.vx - w_p->cam_pos_50.vx,
+                   w_p->cam_tgt_pos_44.vz - w_p->cam_pos_50.vz);
+        w_p->cam_pos_50     = w_p->cam_tgt_pos_44;
+        w_p->cam_velo_60.vx = 0;
+        w_p->cam_velo_60.vy = 0;
+        w_p->cam_velo_60.vz = 0;
+        return;
+    }
+
+    dec_spd_per_dist_xz = Math_MulFixed(cam_mv_prm_p->accel_xz, 0x666, 0xC);
+    dec_spd_per_dist_y  = Math_MulFixed(cam_mv_prm_p->accel_y, 0x1000, 0xC);
+
+    vwRenewalXZVelocityToTargetPos(
+        &w_p->cam_velo_60.vx, &w_p->cam_velo_60.vz, &w_p->cam_pos_50,
+        &w_p->cam_tgt_pos_44, 0x199, cam_mv_prm_p->accel_xz,
+        cam_mv_prm_p->max_spd_xz, dec_spd_per_dist_xz, 0xC000);
+
+    w_p->cam_velo_60.vy = vwRetNewVelocityToTargetVal(
+        w_p->cam_velo_60.vy, w_p->cam_pos_50.vy, w_p->cam_tgt_pos_44.vy,
+        cam_mv_prm_p->accel_y, cam_mv_prm_p->max_spd_y, dec_spd_per_dist_y);
+    w_p->cam_mv_ang_y_5C = ratan2(w_p->cam_velo_60.vx, w_p->cam_velo_60.vz);
+    w_p->cam_pos_50.vx +=
+        Math_MulFixed(w_p->cam_velo_60.vx, g_CurDeltaTime, 12);
+    w_p->cam_pos_50.vy +=
+        Math_MulFixed(w_p->cam_velo_60.vy, g_CurDeltaTime, 12);
+    w_p->cam_pos_50.vz +=
+        Math_MulFixed(w_p->cam_velo_60.vz, g_CurDeltaTime, 12);
+}
+
+void vcRenewalCamMatAng(VC_WORK *w_p, VC_WATCH_MV_PARAM *watch_mv_prm_p,
+                        VC_CAM_MV_TYPE cam_mv_type,
+                        s32            visible_chara_f) // 0x80084D54
+{
+    SVECTOR ofs_tgt_ang;
+    SVECTOR new_base_cam_ang;
+    MATRIX  new_base_matT;
+    SVECTOR ofs_cam2chara_btm_ang;
+    SVECTOR ofs_cam2chara_top_ang;
+
+    vcMakeNewBaseCamAng(&new_base_cam_ang, cam_mv_type, w_p);
+    if (new_base_cam_ang.vx != w_p->base_cam_ang_C8.vx ||
+        new_base_cam_ang.vy != w_p->base_cam_ang_C8.vy ||
+        new_base_cam_ang.vz != w_p->base_cam_ang_C8.vz)
+    {
+        vcRenewalBaseCamAngAndAdjustOfsCamAng(w_p, &new_base_cam_ang);
+    }
+
+    func_80096C94(&w_p->base_cam_ang_C8, &new_base_matT);
+    TransposeMatrix(&new_base_matT, &new_base_matT);
+    vcMakeOfsCamTgtAng(&ofs_tgt_ang, &new_base_matT, w_p);
+    if (visible_chara_f != 0)
+    {
+        vcMakeOfsCam2CharaBottomAndTopAngByBaseMatT(
+            &ofs_cam2chara_btm_ang, &ofs_cam2chara_top_ang, &new_base_matT,
+            &w_p->cam_pos_50, &w_p->chara_pos_114, w_p->chara_bottom_y_120,
+            w_p->chara_top_y_124);
+        vcAdjCamOfsAngByCharaInScreen(&ofs_tgt_ang, &ofs_cam2chara_btm_ang,
+                                      &ofs_cam2chara_top_ang, w_p);
+    }
+
+    if (w_p->flags_8 & VC_WARP_WATCH_F)
+    {
+        w_p->ofs_cam_ang_B8        = ofs_tgt_ang;
+        w_p->ofs_cam_ang_spd_C0.vx = 0;
+        w_p->ofs_cam_ang_spd_C0.vy = 0;
+        w_p->ofs_cam_ang_spd_C0.vz = 0;
+    }
+    else
+    {
+        vcAdjCamOfsAngByOfsAngSpd(&w_p->ofs_cam_ang_B8,
+                                  &w_p->ofs_cam_ang_spd_C0, &ofs_tgt_ang,
+                                  watch_mv_prm_p);
+    }
+    vcMakeCamMatAndCamAngByBaseAngAndOfsAng(
+        &w_p->cam_mat_ang_8E, &w_p->cam_mat_98, &new_base_cam_ang,
+        &w_p->ofs_cam_ang_B8, &w_p->cam_pos_50);
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeNewBaseCamAng);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRenewalBaseCamAngAndAdjustOfsCamAng);
+void vcRenewalBaseCamAngAndAdjustOfsCamAng(
+    VC_WORK *w_p, SVECTOR *new_base_cam_ang) // 0x800851B0
+{
+    MATRIX old_base_mat;
+    MATRIX new_base_mat;
+    MATRIX new_base_matT;
+    // names for these two might be switched
+    MATRIX ofs_mat;
+    MATRIX adj_ofs_mat;
+
+    ofs_mat = GsIDMATRIX;
+    func_80096C94(&w_p->base_cam_ang_C8, &old_base_mat);
+    func_80096C94(new_base_cam_ang, &new_base_mat);
+    TransposeMatrix(&new_base_mat, &new_base_matT);
+    func_80096C94(&w_p->ofs_cam_ang_B8, &adj_ofs_mat);
+    MulMatrix0(&new_base_matT, &old_base_mat, &ofs_mat);
+    MulMatrix2(&ofs_mat, &adj_ofs_mat);
+    vwMatrixToAngleYXZ(&w_p->ofs_cam_ang_B8, &adj_ofs_mat);
+    w_p->base_cam_ang_C8 = *new_base_cam_ang;
+}
 
 void vcMakeOfsCamTgtAng(SVECTOR *ofs_tgt_ang, MATRIX *base_matT,
                         VC_WORK *w_p) // 0x800852C8
@@ -208,9 +699,89 @@ void vcMakeOfsCamTgtAng(SVECTOR *ofs_tgt_ang, MATRIX *base_matT,
     ofs_tgt_ang->vz = w_p->watch_tgt_ang_z_8C;
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeOfsCam2CharaBottomAndTopAngByBaseMatT);
+void vcMakeOfsCam2CharaBottomAndTopAngByBaseMatT(
+    SVECTOR *ofs_cam2chara_btm_ang, SVECTOR *ofs_cam2chara_top_ang,
+    MATRIX *base_matT, VECTOR3 *cam_pos, VECTOR3 *chara_pos, s32 chara_bottom_y,
+    s32 chara_top_y) // 0x80085358
+{
+    SVECTOR vec;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjCamOfsAngByCharaInScreen);
+    vec.vx = ((chara_pos->vx - cam_pos->vx) >> 4);
+    vec.vy = ((chara_bottom_y - cam_pos->vy) >> 4);
+    vec.vz = ((chara_pos->vz - cam_pos->vz) >> 4);
+    ApplyMatrixSV(base_matT, &vec, &vec);
+    vwVectorToAngle(ofs_cam2chara_btm_ang, &vec);
+
+    vec.vx = ((chara_pos->vx - cam_pos->vx) >> 4);
+    vec.vy = ((chara_top_y - cam_pos->vy) >> 4);
+    vec.vz = ((chara_pos->vz - cam_pos->vz) >> 4);
+    ApplyMatrixSV(base_matT, &vec, &vec);
+    vwVectorToAngle(ofs_cam2chara_top_ang, &vec);
+}
+
+static inline s16 shAngleRegulate(s32 a)
+{
+    return (a << 0x14) >> 0x14;
+}
+
+void vcAdjCamOfsAngByCharaInScreen(SVECTOR *cam_ang,
+                                   SVECTOR *ofs_cam2chara_btm_ang,
+                                   SVECTOR *ofs_cam2chara_top_ang,
+                                   VC_WORK *w_p) // 0x80085460
+{
+    // sh2 dwarf names
+    s16 adj_cam_ang_x;
+    s16 var_a1; // probably temp for adj_cam_ang_x
+    s16 watch2chr_ofs_ang_y;
+    s16 watch2chr_bottom_ofs_ang_x;
+    s16 watch2chr_top_ofs_ang_x;
+    s16 adj_cam_ang_y;
+
+    watch2chr_bottom_ofs_ang_x =
+        shAngleRegulate(ofs_cam2chara_btm_ang->vx - cam_ang->vx);
+    watch2chr_top_ofs_ang_x =
+        shAngleRegulate(ofs_cam2chara_top_ang->vx - cam_ang->vx);
+    watch2chr_ofs_ang_y =
+        shAngleRegulate(ofs_cam2chara_top_ang->vy - cam_ang->vy);
+
+    adj_cam_ang_y = (watch2chr_ofs_ang_y > w_p->scr_half_ang_wx_2E)
+                        ? watch2chr_ofs_ang_y - w_p->scr_half_ang_wx_2E
+                        : ((-w_p->scr_half_ang_wx_2E > watch2chr_ofs_ang_y)
+                               ? w_p->scr_half_ang_wx_2E + watch2chr_ofs_ang_y
+                               : 0);
+
+    /*
+    var_a1 = watch2chr_bottom_ofs_ang_x + w_p->scr_half_ang_wy_2C;
+    if (watch2chr_bottom_ofs_ang_x >= -w_p->scr_half_ang_wy_2C) {
+        var_a1 = 0;
+    }*/
+
+    // TODO: var_a1 should probably be merged into adj_cam_ang_x somehow
+
+    var_a1 = (watch2chr_bottom_ofs_ang_x >= -w_p->scr_half_ang_wy_2C)
+                 ? 0
+                 : watch2chr_bottom_ofs_ang_x + w_p->scr_half_ang_wy_2C;
+
+    if (w_p->scr_half_ang_wy_2C < (watch2chr_top_ofs_ang_x - var_a1))
+        var_a1 = watch2chr_top_ofs_ang_x - w_p->scr_half_ang_wy_2C;
+
+    // SH2 uses similar checks with 0.52359879 / 30 degrees
+    if (var_a1 < -341)
+    {
+        adj_cam_ang_x = -341;
+    }
+    else
+    {
+        adj_cam_ang_x = var_a1;
+        if (var_a1 > 341)
+        {
+            adj_cam_ang_x = 341;
+        }
+    }
+
+    cam_ang->vy += adj_cam_ang_y;
+    cam_ang->vx = adj_cam_ang_x + cam_ang->vx;
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjCamOfsAngByOfsAngSpd);
 
@@ -232,10 +803,137 @@ void vcMakeCamMatAndCamAngByBaseAngAndOfsAng(SVECTOR *cam_mat_ang,
     vwMatrixToAngleYXZ(cam_mat_ang, cam_mat);
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetDataToVwSystem);
+void vcSetDataToVwSystem(VC_WORK *w_p, VC_CAM_MV_TYPE cam_mv_type) // 0x80085884
+{
+    MATRIX  noise_cam_mat;
+    MATRIX  noise_mat;
+    SVECTOR noise_ang;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcCamMatNoise);
+    if (w_p->field_D8 != 0)
+    {
+        w_p->field_D8 = 0;
+        vwSetCoordRefAndEntou(&g_SysWork.hero_neck_930, 0, -0xCC, 0x4CC, 0x800,
+                              0, -0x333, 0x1000);
+    }
+    else if (w_p->field_FC != 0)
+    {
+        w_p->field_FC = 0;
+        vwSetViewInfoDirectMatrix(NULL, &w_p->field_DC);
+    }
+    else if (cam_mv_type == VC_MV_SELF_VIEW)
+    {
+        vcSelfViewTimer += g_CurDeltaTime;
+
+        noise_ang.vx = vcCamMatNoise(4, 0x1638, 0x238E, vcSelfViewTimer);
+        noise_ang.vy = vcCamMatNoise(2, 0x11C7, 0x2C71, vcSelfViewTimer);
+        noise_ang.vz = 0;
+        func_80096C94(&noise_ang, &noise_mat);
+
+        noise_mat.m[0][0] +=
+            vcCamMatNoise(0xC, 0x1F1C, 0x2800, vcSelfViewTimer);
+        noise_mat.m[0][1] +=
+            vcCamMatNoise(0xC, 0x1AAA, 0x2C71, vcSelfViewTimer);
+        noise_mat.m[0][2] +=
+            vcCamMatNoise(0xC, 0x1AAA, 0x238E, vcSelfViewTimer);
+        noise_mat.m[1][0] +=
+            vcCamMatNoise(0xC, 0x1638, 0x1638, vcSelfViewTimer);
+        noise_mat.m[1][1] +=
+            vcCamMatNoise(0xC, 0x2800, 0x11C7, vcSelfViewTimer);
+        noise_mat.m[1][2] +=
+            vcCamMatNoise(0xC, 0x1CE3, 0x2A38, vcSelfViewTimer);
+        MulMatrix0(&w_p->cam_mat_98, &noise_mat, &noise_cam_mat);
+
+        noise_cam_mat.t[0] = w_p->cam_mat_98.t[0];
+        noise_cam_mat.t[1] = w_p->cam_mat_98.t[1];
+        noise_cam_mat.t[2] = w_p->cam_mat_98.t[2];
+        vwSetViewInfoDirectMatrix(NULL, &noise_cam_mat);
+    }
+    else
+    {
+        vwSetViewInfoDirectMatrix(NULL, &w_p->cam_mat_98);
+    }
+}
+
+s32 vcCamMatNoise(s32 noise_w, s32 ang_spd1, s32 ang_spd2,
+                  s32 vcSelfViewTimer) // 0x80085A7C
+{
+    s32 noise;
+
+    noise = shRcos((ang_spd1 * (s64)vcSelfViewTimer) >> 12) +
+            shRcos((ang_spd2 * (s64)vcSelfViewTimer) >> 12);
+    noise = noise >> 1;
+
+    return (noise_w * noise) >> 12;
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", Math_VectorMagnitude);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcGetXZSumDistFromLimArea);
+s32 vcGetXZSumDistFromLimArea(s32 *out_vec_x_p, s32 *out_vec_z_p, s32 chk_wld_x,
+                              s32 chk_wld_z, s32 lim_min_x, s32 lim_max_x,
+                              s32 lim_min_z, s32 lim_max_z,
+                              s32 can_ret_minus_dist_f) // 0x80085C80
+{
+    s32 cntr_x;
+    s32 cntr_z;
+    s32 x_dist;
+    s32 z_dist;
+    s32 ret_dist;
+
+    if (lim_max_x < chk_wld_x)
+    {
+        cntr_x       = lim_max_x - chk_wld_x;
+        *out_vec_x_p = cntr_x;
+        x_dist       = -cntr_x;
+    }
+    else if (chk_wld_x < lim_min_x)
+    {
+        x_dist       = lim_min_x - chk_wld_x;
+        *out_vec_x_p = x_dist;
+    }
+    else
+    {
+        *out_vec_x_p = 0;
+        if (chk_wld_x >= (lim_max_x + lim_min_x) >> 1)
+            x_dist = chk_wld_x - lim_max_x;
+        else
+            x_dist = lim_min_x - chk_wld_x;
+    }
+
+    if (lim_max_z < chk_wld_z)
+    {
+        cntr_z       = lim_max_z - chk_wld_z;
+        *out_vec_z_p = cntr_z;
+        z_dist       = -cntr_z;
+    }
+    else if (chk_wld_z < lim_min_z)
+    {
+        z_dist       = lim_min_z - chk_wld_z;
+        *out_vec_z_p = z_dist;
+    }
+    else
+    {
+        *out_vec_z_p = 0;
+        if (chk_wld_z >= (lim_max_z + lim_min_z) >> 1)
+            z_dist = chk_wld_z - lim_max_z;
+        else
+            z_dist = lim_min_z - chk_wld_z;
+    }
+
+    if (x_dist >= 0)
+    {
+        ret_dist = x_dist;
+        if (z_dist >= 0)
+            ret_dist += z_dist;
+    }
+    else
+    {
+        ret_dist = z_dist;
+        if (ret_dist < 0 && ret_dist < x_dist)
+            ret_dist = x_dist;
+    }
+
+    if (can_ret_minus_dist_f == 0 && ret_dist < 0)
+        ret_dist = 0;
+
+    return ret_dist;
+}

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "game.h"
 
 #include "bodyprog/vw_system.h"
 #include "bodyprog/math.h"

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -489,7 +489,43 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeIdealCamPosForThroug
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeIdealCamPosUseVC_ROAD_DATA);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjustXzInLimAreaUsingMIN_IN_ROAD_DIST);
+// vcGetMinInRoadDist() in SH2, hardcoded 4096 in SH1
+#define MIN_IN_ROAD_DIST 4096
+
+void vcAdjustXzInLimAreaUsingMIN_IN_ROAD_DIST(
+    s32 *x_p, s32 *z_p,
+    VC_LIMIT_AREA *lim_p) // 0x80084210
+{
+    s32 min_z;
+    s32 min_x;
+    s32 max_z;
+    s32 max_x;
+
+    s32 x = *x_p;
+    s32 z = *z_p;
+
+    min_x = (lim_p->min_hx << 8) + MIN_IN_ROAD_DIST;
+    max_x = (lim_p->max_hx << 8) - MIN_IN_ROAD_DIST;
+    min_z = (lim_p->min_hz << 8) + MIN_IN_ROAD_DIST;
+    max_z = (lim_p->max_hz << 8) - MIN_IN_ROAD_DIST;
+
+    if (max_x < min_x)
+    {
+        min_x = (min_x + max_x) >> 1;
+        max_x = min_x;
+    }
+    if (max_z < min_z)
+    {
+        min_z = (min_z + max_z) >> 1;
+        max_z = min_z;
+    }
+
+    x = CLAMP(x, min_x, max_x);
+    z = CLAMP(z, min_z, max_z);
+
+    *x_p = x;
+    *z_p = z;
+}
 
 void vcMakeBasicCamTgtMvVec(VECTOR3 *tgt_mv_vec, VECTOR3 *ideal_pos,
                             VC_WORK *w_p, s32 max_tgt_mv_xz_len) // 0x800842C0

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -193,7 +193,9 @@ void vcSetRefPosAndCamPosAngByPad(VECTOR3   *ref_pos,
     sp38.t[2] = sp18.vz;
     vwSetViewInfoDirectMatrix(NULL, &sp38);
 
-    if (g_pController2->btns_held_C & 0x0F005000)
+    if (g_pController2->btns_held_C &
+        (Pad_LSUp | Pad_LSRight | Pad_LSDown | Pad_LSLeft | Pad_BtnCross |
+         Pad_BtnTriangle))
     {
         SVECTOR sp58;
         vwAngleToVector(&sp58, &cam_ang, 0x500);

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -3,9 +3,26 @@
 #include "bodyprog/vw_system.h"
 #include "bodyprog/math.h"
 
+extern s32 D_800B5C34; // sensitivity multiplier?
+
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcInitCamera);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcSetCameraUseWarp);
+void vcSetCameraUseWarp(VECTOR3 *chr_pos, s16 chr_ang_y) // 0x800400D4
+{
+    VECTOR3 cam_pos;
+    SVECTOR cam_ang;
+
+    cam_ang.vx = 0;
+    cam_ang.vy = chr_ang_y;
+    cam_ang.vz = 0;
+
+    cam_pos.vx = chr_pos->vx - ((shRsin(chr_ang_y) * 0x1800) >> 0xC);
+    cam_pos.vy = chr_pos->vy - 0x1B33;
+    cam_pos.vz = chr_pos->vz - ((shRcos(chr_ang_y) * 0x1800) >> 0xC);
+
+    vcSetFirstCamWork(&cam_pos, chr_ang_y, g_SysWork.field_22A4 & 0x40);
+    g_SysWork.field_22A4 &= ~0x40;
+}
 
 int vcRetCamMvSmoothF() // 0x80040190
 {
@@ -15,13 +32,9 @@ int vcRetCamMvSmoothF() // 0x80040190
 void func_800401A0(s32 arg0) // 0x800401A0
 {
     if (arg0)
-    {
         vcCameraInternalInfo.ev_cam_rate = 4096;
-    }
     else
-    {
         vcCameraInternalInfo.ev_cam_rate = 0;
-    }
 }
 
 void vcSetEvCamRate(s16 ev_cam_rate) // 0x800401C0
@@ -36,7 +49,23 @@ void func_800401CC() // 0x800401CC
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcMoveAndSetCamera);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcMakeHeroHeadPos);
+void vcMakeHeroHeadPos(VECTOR3 *head_pos) // 0x8004047C
+{
+    MATRIX  neck_lwm;
+    SVECTOR fpos;
+    VECTOR  sp38;
+
+    func_80049984(&g_SysWork.hero_neck_930, &neck_lwm);
+
+    fpos.vx = 0;
+    fpos.vy = -0x19;
+    fpos.vz = 0;
+    ApplyMatrix(&neck_lwm, &fpos, &sp38);
+
+    head_pos->vx = (sp38.vx + neck_lwm.t[0]) * 0x10;
+    head_pos->vy = ((sp38.vy + neck_lwm.t[1]) * 0x10) - 0x4CC;
+    head_pos->vz = (sp38.vz + neck_lwm.t[2]) * 0x10;
+}
 
 void vcAddOfsToPos(VECTOR3 *out_pos, VECTOR3 *in_pos, s16 ofs_xz_r, s16 ang_y,
                    s32 ofs_y) // 0x80040518
@@ -46,6 +75,134 @@ void vcAddOfsToPos(VECTOR3 *out_pos, VECTOR3 *in_pos, s16 ofs_xz_r, s16 ang_y,
     out_pos->vy = in_pos->vy + ofs_y;
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcSetRefPosAndSysRef2CamParam);
+void vcSetRefPosAndSysRef2CamParam(VECTOR3 *ref_pos, s_SysWork *sys_p,
+                                   s32 for_f, s32 back_f, s32 right_f,
+                                   s32 left_f, s32 up_f,
+                                   s32 down_f) // 0x800405C4
+{
+    if (for_f != 0)
+        sys_p->cam_r_xz_2380 -= 0x199;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcSetRefPosAndCamPosAngByPad);
+    if (back_f != 0)
+        sys_p->cam_r_xz_2380 += 0x199;
+
+    if (right_f != 0)
+        sys_p->cam_ang_y_237A = sys_p->cam_ang_y_237A - (D_800B5C34 * 0xB);
+
+    if (left_f != 0)
+        sys_p->cam_ang_y_237A = sys_p->cam_ang_y_237A + (D_800B5C34 * 0xB);
+
+    if (up_f != 0)
+        sys_p->cam_y_2384 -= 0x199;
+
+    if (down_f != 0)
+        sys_p->cam_y_2384 += 0x199;
+
+    if (sys_p->cam_r_xz_2380 < 0x1000)
+        sys_p->cam_r_xz_2380 = 0x1000;
+
+    vcAddOfsToPos(ref_pos, &g_SysWork.player_4C.c.position_18, 0x800,
+                  g_SysWork.player_4C.c.rotation_24.vy, -0x1000);
+}
+
+void vcSetRefPosAndCamPosAngByPad(VECTOR3   *ref_pos,
+                                  s_SysWork *sys_p) // 0x800406D4
+{
+    SVECTOR cam_ang;
+    VECTOR3 sp18;
+    VECTOR3 cam_pos;
+    MATRIX  sp38;
+    s32     var_s0;
+    s32     var_v1;
+    s32     var_v1_4;
+
+    vwGetViewPosition(&cam_pos);
+
+    sp18.vx = (cam_pos.vx >> 4);
+    sp18.vy = (cam_pos.vy >> 4);
+    sp18.vz = (cam_pos.vz >> 4);
+
+    vwGetViewAngle(&cam_ang);
+
+    if (!(g_pController2->btns_held_C & Pad_BtnCircle))
+    {
+        if (g_pController2->btns_held_C & Pad_LSDown)
+            cam_ang.vx = cam_ang.vx - (D_800B5C34 * 0xB);
+        if (g_pController2->btns_held_C & Pad_LSUp)
+            cam_ang.vx = cam_ang.vx + (D_800B5C34 * 0xB);
+        if (g_pController2->btns_held_C & Pad_LSRight)
+            cam_ang.vy = cam_ang.vy + (D_800B5C34 * 0xB);
+        if (g_pController2->btns_held_C & Pad_LSLeft)
+            cam_ang.vy = cam_ang.vy - (D_800B5C34 * 0xB);
+
+        if (g_pController2->btns_held_C & (Pad_BtnTriangle | Pad_BtnCross))
+        {
+            var_s0 = 0;
+            if (g_pController2->btns_held_C & Pad_BtnTriangle)
+                var_s0 = 0x19;
+            if (g_pController2->btns_held_C & Pad_BtnCross)
+                var_s0 = -0x1A;
+
+            var_v1 = var_s0 * shRsin(cam_ang.vy);
+            if (var_v1 < 0)
+                var_v1 += 0xFFF;
+
+            sp18.vx += var_v1 >> 0xC;
+            var_v1_4 = var_s0 * shRcos(cam_ang.vy);
+            if (var_v1_4 < 0)
+                var_v1_4 += 0xFFF;
+
+            sp18.vz += var_v1_4 >> 0xC;
+        }
+    }
+    else
+    {
+        if (g_pController2->btns_held_C & Pad_LSUp)
+            sp18.vy -= 0x19;
+        if (g_pController2->btns_held_C & Pad_LSDown)
+            sp18.vy += 0x19;
+
+        if (g_pController2->btns_held_C & (Pad_LSRight | Pad_LSLeft))
+        {
+            var_s0 = 0;
+            if (g_pController2->btns_held_C & Pad_LSRight)
+                var_s0 = 0x19;
+            if (g_pController2->btns_held_C & Pad_LSLeft)
+                var_s0 = -0x1A;
+
+            var_v1 = var_s0 * shRsin(cam_ang.vy + 1024);
+            if (var_v1 < 0)
+            {
+                var_v1 += 0xFFF;
+            }
+
+            sp18.vx += var_v1 >> 0xC;
+            var_v1_4 = var_s0 * shRcos(cam_ang.vy + 1024);
+            if (var_v1_4 < 0)
+            {
+                var_v1_4 += 0xFFF;
+            }
+            sp18.vz += var_v1_4 >> 0xC;
+        }
+    }
+
+    func_80096E78(&cam_ang, &sp38);
+
+    sp38.t[0] = sp18.vx;
+    sp38.t[1] = sp18.vy;
+    sp38.t[2] = sp18.vz;
+    vwSetViewInfoDirectMatrix(NULL, &sp38);
+
+    if (g_pController2->btns_held_C & 0x0F005000)
+    {
+        SVECTOR sp58;
+        vwAngleToVector(&sp58, &cam_ang, 0x500);
+        ref_pos->vx           = (sp18.vx + sp58.vx) * 0x10;
+        ref_pos->vy           = (sp18.vy + sp58.vy) * 0x10;
+        ref_pos->vz           = (sp18.vz + sp58.vz) * 0x10;
+        sys_p->cam_ang_y_237A = ((cam_ang.vy + 0x800) << 0x14) >> 0x14;
+        sys_p->cam_y_2384     = -sp58.vy * 0x10;
+        sys_p->cam_r_xz_2380 =
+            SquareRoot0((sp58.vx * sp58.vx) + (sp58.vz * sp58.vz)) * 0x10;
+    }
+}

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "game.h"
 
 #include "bodyprog/vw_system.h"
 #include "bodyprog/math.h"

--- a/src/bodyprog/view/vw_calc.c
+++ b/src/bodyprog/view/vw_calc.c
@@ -3,9 +3,97 @@
 #include "bodyprog/vw_system.h"
 #include "bodyprog/math.h"
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwRenewalXZVelocityToTargetPos);
+extern MATRIX D_800C3868;
+extern MATRIX D_800C6FC0; // might be psyq GsWSMATRIX
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwLimitOverLimVector);
+void vwRenewalXZVelocityToTargetPos(s32 *velo_x, s32 *velo_z, VECTOR3 *now_pos,
+                                    VECTOR3 *tgt_pos, s32 tgt_r, s32 accel,
+                                    s32 total_max_spd, s32 dec_forwd_lim_spd,
+                                    s32 dec_accel_side) // 0x80048F28
+{
+// SH2 locals
+#if 0
+    /* 0x1d */ float vec_xz[4];
+	/* 0x1d */ float lim_spd;
+	/* 0x1d */ float to_tgt_dist;
+	/* 0x16 */ float to_tgt_ang_y;
+	/* 0x18 */ float ang_y;
+	/* 0x1d */ float spd;
+	/* 0x2 */ float add_spd;
+	/* 0x1d */ float cam2tgt_dir_vec[4];
+	/* 0x1d */ float cam_mv_ang_y;
+	/* 0x1d */ float cam2tgt_ang_y;
+#endif
+
+    SVECTOR unused; // cam2tgt_dir_vec ?
+    s16     temp_v0;
+    s32     ang_y;
+    s32     temp_s0;
+    s32     to_tgt_ang_y;
+    s32     add_spd;
+    s32     temp_s1_2;
+    s32     temp_s1_3;
+    s32     temp_v0_2;
+    s32     var_s1;
+
+    temp_v0 = ratan2(tgt_pos->vx - now_pos->vx, tgt_pos->vz - now_pos->vz);
+
+    // shSinCosV is called in SH2 while SH just calls shRsin/shRcos and does
+    // nothing with result
+    unused.vx = shRsin(temp_v0);
+    unused.vy = shRcos(temp_v0);
+
+    ratan2(*velo_x, *velo_z);
+
+    add_spd = Math_MulFixed(accel, g_CurDeltaTime, 0xC);
+    *velo_x += (add_spd * shRsin(temp_v0)) >> 0xC;
+    *velo_z += (add_spd * shRcos(temp_v0)) >> 0xC;
+
+    temp_v0_2 = Math_VectorMagnitude(*velo_x, 0, *velo_z);
+    if (total_max_spd < temp_v0_2)
+    {
+        temp_s1_2 = temp_v0_2 - total_max_spd;
+        ang_y     = ratan2(*velo_x, *velo_z);
+        *velo_x -= Math_MulFixed(temp_s1_2, shRsin(ang_y), 0xC);
+        *velo_z -= Math_MulFixed(temp_s1_2, shRcos(ang_y), 0xC);
+    }
+
+    temp_s1_3    = tgt_pos->vx - now_pos->vx;
+    temp_s0      = tgt_pos->vz - now_pos->vz;
+    to_tgt_ang_y = ratan2(temp_s1_3, temp_s0);
+    var_s1 =
+        Math_MulFixed(dec_forwd_lim_spd,
+                      Math_VectorMagnitude(temp_s1_3, 0, temp_s0) - tgt_r, 0xC);
+
+    if (var_s1 < 0)
+        var_s1 = 0;
+
+    vwLimitOverLimVector(velo_x, velo_z, var_s1, to_tgt_ang_y);
+    vwDecreaseSideOfVector(velo_x, velo_z,
+                           Math_MulFixed(dec_accel_side, g_CurDeltaTime, 0xC),
+                           var_s1 >> 1, to_tgt_ang_y);
+}
+
+void vwLimitOverLimVector(s32 *vec_x, s32 *vec_z, s32 lim_vec_len,
+                          s16 lim_vec_ang_y) // 0x8004914C
+{
+    s32 over_spd;
+    s32 lim_spd_dir_x;
+    s32 lim_spd_dir_z;
+
+    lim_spd_dir_x = shRsin(lim_vec_ang_y);
+    lim_spd_dir_z = shRcos(lim_vec_ang_y);
+
+    over_spd = (Math_MulFixed(*vec_x, lim_spd_dir_x, 0xC) +
+                Math_MulFixed(*vec_z, lim_spd_dir_z, 0xC)) -
+               lim_vec_len;
+
+    if (over_spd > 0)
+    {
+        *vec_x -= Math_MulFixed(over_spd, lim_spd_dir_x, 0xC);
+        *vec_z -= Math_MulFixed(over_spd, lim_spd_dir_z, 0xC);
+    }
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwDecreaseSideOfVector);
 
@@ -22,11 +110,59 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_800494B0);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049530);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vwMatrixToAngleYXZ);
+void vwMatrixToAngleYXZ(SVECTOR *ang, MATRIX *mat) // 0x800495D4
+{
+    s32 r_xz = SquareRoot0((mat->m[0][2] * mat->m[0][2]) +
+                           (mat->m[2][2] * mat->m[2][2]));
+    ang->vx  = ratan2(-mat->m[1][2], r_xz);
+
+    if (ang->vx == 1024)
+    {
+        ang->vz = 0;
+        ang->vy = ratan2(mat->m[0][1], mat->m[2][1]);
+    }
+    else if (ang->vx == -1024)
+    {
+        ang->vz = 0;
+        ang->vy = ratan2(-mat->m[0][1], -mat->m[2][1]);
+    }
+    else
+    {
+        ang->vz = ratan2(mat->m[1][0], mat->m[1][1]);
+        ang->vy = ratan2(mat->m[0][2], mat->m[2][2]);
+    }
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_800496AC);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", vbSetWorldScreenMatrix);
+void vbSetWorldScreenMatrix(GsCOORDINATE2 *coord) // 0x800497E4
+{
+    MATRIX work;
+    VECTOR sp30;
+
+    func_80049984(coord, &D_800C3868);
+    TransposeMatrix(&D_800C3868, &work);
+    MulMatrix0(&work, &GsIDMATRIX2, &VbWvsMatrix);
+
+    VbWvsMatrix.t[2] = 0;
+    VbWvsMatrix.t[1] = 0;
+    VbWvsMatrix.t[0] = 0;
+
+    D_800C6FC0.m[0][0] = VbWvsMatrix.m[0][0];
+    D_800C6FC0.m[0][1] = VbWvsMatrix.m[0][1];
+    D_800C6FC0.m[0][2] = VbWvsMatrix.m[0][2];
+    D_800C6FC0.m[1][0] = VbWvsMatrix.m[1][0];
+    D_800C6FC0.m[1][1] = VbWvsMatrix.m[1][1];
+    D_800C6FC0.m[1][2] = VbWvsMatrix.m[1][2];
+    D_800C6FC0.m[2][0] = VbWvsMatrix.m[2][0];
+    D_800C6FC0.m[2][1] = VbWvsMatrix.m[2][1];
+    D_800C6FC0.m[2][2] = VbWvsMatrix.m[2][2];
+
+    sp30.vx = -D_800C3868.t[0];
+    sp30.vy = -D_800C3868.t[1];
+    sp30.vz = -D_800C3868.t[2];
+    ApplyMatrixLV(&VbWvsMatrix, &sp30, (VECTOR *)&D_800C6FC0.t);
+}
 
 void vbSetRefView(VbRVIEW *rview) // 0x800498D8
 {

--- a/src/bodyprog/view/vw_calc.c
+++ b/src/bodyprog/view/vw_calc.c
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "game.h"
 
 #include "bodyprog/vw_system.h"
 #include "bodyprog/math.h"

--- a/src/bodyprog/view/vw_main.c
+++ b/src/bodyprog/view/vw_main.c
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "game.h"
 
 #include "bodyprog/vw_system.h"
 

--- a/src/bodyprog/view/vw_main.c
+++ b/src/bodyprog/view/vw_main.c
@@ -33,7 +33,29 @@ void vwGetViewAngle(SVECTOR *ang) // 0x80048AC4
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_main", func_80048AF4);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_main", vwSetCoordRefAndEntou);
+void vwSetCoordRefAndEntou(GsCOORDINATE2 *parent_p, s32 ref_x, s32 ref_y,
+                           s32 ref_z, s16 cam_ang_y, s16 cam_ang_z, s32 cam_y,
+                           s32 cam_xz_r) // 0x80048BE0
+{
+    SVECTOR view_ang;
+    MATRIX *view_mtx = &vwViewPointInfo.vwcoord.coord;
+
+    vwViewPointInfo.vwcoord.flg   = 0;
+    vwViewPointInfo.vwcoord.super = parent_p;
+
+    view_ang.vy = cam_ang_y;
+    view_ang.vz = cam_ang_z;
+    view_ang.vx = -ratan2(-cam_y, cam_xz_r);
+    view_ang.vy = (view_ang.vy + 0x800) & 0xFFF;
+
+    func_80096E78(&view_ang, view_mtx);
+
+    view_mtx->t[0] =
+        (ref_x >> 4) + (((cam_xz_r >> 4) * shRsin(cam_ang_y)) >> 0xC);
+    view_mtx->t[1] = (ref_y >> 4) + (cam_y >> 4);
+    view_mtx->t[2] =
+        (ref_z >> 4) + (((cam_xz_r >> 4) * shRcos(cam_ang_y)) >> 0xC);
+}
 
 void vwSetViewInfoDirectMatrix(GsCOORDINATE2 *pcoord,
                                MATRIX        *cammat) // 0x80048CF0
@@ -43,7 +65,24 @@ void vwSetViewInfoDirectMatrix(GsCOORDINATE2 *pcoord,
     vwViewPointInfo.vwcoord.coord = *cammat;
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_main", vwSetViewInfo);
+// inlined into vwSetViewInfo, maybe vwMatrixToPosition?
+static inline void Math_MatrixToPosition(VECTOR3 *pos, MATRIX *workm)
+{
+    pos->vx = workm->t[0] * 16;
+    pos->vy = workm->t[1] * 16;
+    pos->vz = workm->t[2] * 16;
+}
+
+void vwSetViewInfo() // 0x80048D48
+{
+    vbSetRefView(&vwViewPointInfo.rview);
+
+    Math_MatrixToPosition(&vwViewPointInfo.worldpos,
+                          &vwViewPointInfo.vwcoord.workm);
+
+    vwMatrixToAngleYXZ(&vwViewPointInfo.worldang,
+                       &vwViewPointInfo.vwcoord.workm);
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_main", func_80048DA8);
 

--- a/src/stream/stream.c
+++ b/src/stream/stream.c
@@ -204,6 +204,7 @@ void func_801E28B0(void)
 
 void func_801E2908(void)
 {
+    // old IDB name MainLoopState11_Movie_PlayEnding_801E2908
     s_GameWork       *gameWork   = g_pGameWork0;
     s_ControllerData *controller = g_pController1;
     s32               prev_594;
@@ -267,7 +268,7 @@ void func_801E2A24(void)
     D_800B5C30           = 0x1000;
 }
 
-void open_main(s32 file_idx, s16 num_frames)
+void open_main(s32 file_idx, s16 num_frames) // 0x801E2AA4
 {
     Fs_QueueWaitForEmpty();
     if (!num_frames)
@@ -283,7 +284,7 @@ void open_main(s32 file_idx, s16 num_frames)
 
 INCLUDE_ASM("asm/stream/nonmatchings/stream", movie_main);
 
-void strSetDefDecEnv(DECENV *dec, int x0, int y0, int x1, int y1)
+void strSetDefDecEnv(DECENV *dec, int x0, int y0, int x1, int y1) // 0x801E2F8C
 {
     dec->rect[0].w = 480;
     dec->rect[1].w = 480;
@@ -305,7 +306,7 @@ void strSetDefDecEnv(DECENV *dec, int x0, int y0, int x1, int y1)
     dec->rect[1].y = y1;
 }
 
-void strInit(CdlLOC *loc, void (*callback)())
+void strInit(CdlLOC *loc, void (*callback)()) // 0x801E300C
 {
     DecDCTReset(0);
     DecDCToutCallback(callback);
@@ -314,7 +315,7 @@ void strInit(CdlLOC *loc, void (*callback)())
     strKickCD(loc);
 }
 
-void strCallback()
+void strCallback() // 0x801E307C
 {
     RECT snap_rect;
     int  id;
@@ -357,7 +358,7 @@ void strCallback()
     }
 }
 
-void strKickCD(CdlLOC *loc)
+void strKickCD(CdlLOC *loc) // 0x801E31CC
 {
     char   v2[8];
     u_char param;
@@ -376,7 +377,7 @@ void strKickCD(CdlLOC *loc)
         VSync(0);
 }
 
-int strNextVlc(DECENV *dec)
+int strNextVlc(DECENV *dec) // 0x801E3298
 {
     u_long *next, *strNext();
 
@@ -395,7 +396,7 @@ int strNextVlc(DECENV *dec)
     return 0;
 }
 
-u_long *strNext(DECENV *dec)
+u_long *strNext(DECENV *dec) // 0x801E331C
 {
     u_long   *addr;
     CDSECTOR *sector;
@@ -427,7 +428,7 @@ u_long *strNext(DECENV *dec)
     return addr;
 }
 
-void strSync(DECENV *dec)
+void strSync(DECENV *dec) // 0x801E3438
 {
     volatile u_long cnt = WAIT_TIME;
 

--- a/src/stream/stream.c
+++ b/src/stream/stream.c
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "game.h"
 
 #include <libcd.h>
 #include <libds.h>
@@ -6,104 +6,306 @@
 #include <libgpu.h>
 #include <libpress.h>
 
-extern int StCdIntrFlag; // not included in SDK docs/headers, but movie player sample code (and moviesys) uses it?
+#include "main/fileinfo.h"
+#include "bodyprog/bodyprog.h"
+
+extern int StCdIntrFlag; // not included in SDK docs/headers, but movie player
+                         // sample code (and moviesys) uses it?
+
+extern s32 D_800B5C30;
+extern s32 D_801E3F3C;
+
+extern s32 D_800BCD0C;
+extern u8  D_800A900C[];
 
 typedef struct
 {
-    /* 0x00 */ u_long *vlcbuf[2];
-    /* 0x08 */ int vlcid;
+    /* 0x00 */ u_long  *vlcbuf[2];
+    /* 0x08 */ int      vlcid;
     /* 0x0C */ u_short *imgbuf;
-    /* 0x10 */ RECT rect[2];
-    /* 0x20 */ int rectid;
-    /* 0x24 */ RECT slice;
-    /* 0x2C */ int isdone;
+    /* 0x10 */ RECT     rect[2];
+    /* 0x20 */ int      rectid;
+    /* 0x24 */ RECT     slice;
+    /* 0x2C */ int      isdone;
 } DECENV;
 
 typedef struct
 {
-    /* 0x00000 */ CdlLOC loc;
-    /* 0x00004 */ DECENV dec;
-    /* 0x00034 */ int Rewind_Switch; // or Clear_Flag
-    /* 0x00038 */ int width;
-    /* 0x0003C */ int height;
+    /* 0x00000 */ CdlLOC  loc;
+    /* 0x00004 */ DECENV  dec;
+    /* 0x00034 */ int     Rewind_Switch; // or Clear_Flag
+    /* 0x00038 */ int     width;
+    /* 0x0003C */ int     height;
     /* 0x00040 */ u_short imgbuf0[5760];
     /* 0x02D40 */ u_short imgbuf1[5760];
-    /* 0x05A40 */ u_long sect_buff[11776];
-    /* 0x11240 */ u_long vlcbuf0[14336];
-    /* 0x1F240 */ u_long vlcbuf1[14336];
+    /* 0x05A40 */ u_long  sect_buff[11776];
+    /* 0x11240 */ u_long  vlcbuf0[14336];
+    /* 0x1F240 */ u_long  vlcbuf1[14336];
 } MOVIE_STR;
 
 // customised StHEADER ?
-typedef struct {
+typedef struct
+{
     u_short id;
     u_short type;
     u_short secCount;
     u_short nSectors;
-    u_long frameCount;
-    u_long frameSize;
+    u_long  frameCount;
+    u_long  frameSize;
     u_short width;
     u_short height;
-    u_long headm;
-    u_long headv;
-    u_long user;
+    u_long  headm;
+    u_long  headv;
+    u_long  user;
 } CDSECTOR;
 
 #define RING_SIZE 23
 #define MOVIE_WAIT 2000
-#define PPW 3/2
+#define PPW 3 / 2
 
-extern MOVIE_STR* m;
-extern u_int frame_cnt;
+extern MOVIE_STR *m;
+extern s32        frame_cnt;
 
-void open_main(int file_idx, int num_frames);
-void movie_main(char *file_name, int f_size, int sector);
-void strSetDefDecEnv(DECENV *dec, int x0, int y0, int x1, int y1);
-void strInit(CdlLOC *loc, void (*callback)());
-void strCallback();
-void strKickCD(CdlLOC *loc);
-int strNextVlc(DECENV *dec);
+void    open_main(s32 file_idx, s16 num_frames);
+void    movie_main(char *file_name, int f_size, int sector);
+void    strSetDefDecEnv(DECENV *dec, int x0, int y0, int x1, int y1);
+void    strInit(CdlLOC *loc, void (*callback)());
+void    strCallback();
+void    strKickCD(CdlLOC *loc);
+int     strNextVlc(DECENV *dec);
 u_long *strNext(DECENV *dec);
-void strSync(DECENV *dec, int mode);
+void    strSync(DECENV *dec);
 
-INCLUDE_ASM("asm/stream/nonmatchings/stream", func_801E2654);
+void func_801E2654(void)
+{
+    // old IDB name MainLoopState3_StartMovieIntro_801E2654
+    s32 prev_594;
 
-INCLUDE_ASM("asm/stream/nonmatchings/stream", func_801E279C);
+    switch (g_GameWork.field_598)
+    {
+    case 0:
+        VSync(8);
+        D_800BCD0C = 6;
+        GameFS_TitleGfxLoad();
+        g_GameWork.field_598 += 1;
+        break;
+    case 1:
+        if ((g_pController1->btns_held_C != 0) || (g_SysWork.field_1C >= 301))
+        {
+            D_800BCD0C           = 3;
+            g_GameWork.field_598 = 2;
+        }
+        break;
+    case 2:
+        if ((D_800BCD0C & 7) == 5)
+        {
+            Fs_QueueWaitForEmpty();
+            prev_594             = g_GameWork.field_594;
+            g_GameWork.field_594 = 6;
+            g_SysWork.field_1C   = 0;
+            g_SysWork.field_20   = 0;
+            g_GameWork.field_59C = 0;
+            g_GameWork.field_5A0 = 0;
+            g_SysWork.field_8    = 0;
+            g_SysWork.field_24   = 0;
+            g_SysWork.field_C    = 0;
+            g_SysWork.field_28   = 0;
+            g_SysWork.field_10   = 0;
+            g_SysWork.field_2C   = 0;
+            g_SysWork.field_14   = 0;
+            g_GameWork.field_598 = prev_594;
+            g_GameWork.field_590 = prev_594;
+            g_GameWork.field_598 = 0;
+        }
+        break;
+    }
+    func_800314EC(D_800A900C);
+}
 
-INCLUDE_ASM("asm/stream/nonmatchings/stream", func_801E2838);
+void func_801E279C(void)
+{
+    // old IDB name MainLoopState6_Movie_PlayIntro_801E279C
 
-INCLUDE_ASM("asm/stream/nonmatchings/stream", func_801E28B0);
+    s32 prev_594;
+    s32 file_idx = 2053; // XA/C1_20670
 
-INCLUDE_ASM("asm/stream/nonmatchings/stream", func_801E2908);
+    if (g_pGameWork->extraOptionsEnabled_27 & 1)
+    {
+        file_idx = 2054; // XA/C2_20670
+    }
 
-INCLUDE_ASM("asm/stream/nonmatchings/stream", func_801E2A24);
+    open_main(file_idx, 0);
 
-INCLUDE_ASM("asm/stream/nonmatchings/stream", open_main);
+    prev_594             = g_GameWork.field_594;
+    g_GameWork.field_594 = 7;
+    g_SysWork.field_1C   = 0;
+    g_SysWork.field_20   = 0;
+    g_GameWork.field_59C = 0;
+    g_GameWork.field_5A0 = 0;
+    g_SysWork.field_8    = 0;
+    g_SysWork.field_24   = 0;
+    g_SysWork.field_C    = 0;
+    g_SysWork.field_28   = 0;
+    g_SysWork.field_10   = 0;
+    g_SysWork.field_2C   = 0;
+    g_SysWork.field_14   = 0;
+    g_GameWork.field_598 = prev_594;
+    g_GameWork.field_590 = prev_594;
+    g_GameWork.field_598 = 0;
+    D_800B5C30           = 0x1000;
+}
+
+void func_801E2838(void)
+{
+    // old IDB name MainLoopState9_Movie_PlayOpening_801E2838
+    s32 prev_594;
+
+    open_main(2055, 0); // XA/M1_03500
+    prev_594             = g_GameWork.field_594;
+    g_GameWork.field_594 = 0xA;
+    g_SysWork.field_1C   = 0;
+    g_SysWork.field_20   = 0;
+    g_GameWork.field_59C = 0;
+    g_GameWork.field_5A0 = 0;
+    g_SysWork.field_8    = 0;
+    g_SysWork.field_24   = 0;
+    g_SysWork.field_C    = 0;
+    g_SysWork.field_28   = 0;
+    g_SysWork.field_10   = 0;
+    g_SysWork.field_2C   = 0;
+    g_SysWork.field_14   = 0;
+    g_GameWork.field_598 = prev_594;
+    g_GameWork.field_590 = prev_594;
+    g_GameWork.field_598 = 0;
+}
+
+void func_801E28B0(void)
+{
+    // old IDB name MainLoopStateD_ReturnToGame_801E28B0
+    s32 prev_594;
+
+    prev_594             = g_GameWork.field_594;
+    g_GameWork.field_594 = 0xB;
+    g_SysWork.field_1C   = 0;
+    g_SysWork.field_20   = 0;
+    g_GameWork.field_59C = 0;
+    g_GameWork.field_5A0 = 0;
+    g_SysWork.field_8    = 0;
+    g_SysWork.field_24   = 0;
+    g_SysWork.field_C    = 0;
+    g_SysWork.field_28   = 0;
+    g_SysWork.field_10   = 0;
+    g_SysWork.field_2C   = 0;
+    g_SysWork.field_14   = 0;
+    g_GameWork.field_598 = prev_594;
+    g_GameWork.field_590 = prev_594;
+    g_GameWork.field_598 = 0;
+}
+
+void func_801E2908(void)
+{
+    s_GameWork       *gameWork   = g_pGameWork0;
+    s_ControllerData *controller = g_pController1;
+    s32               prev_594;
+
+    if (controller->btns_new_10 & gameWork->controllerBinds_0.cancel)
+    {
+        prev_594             = g_GameWork.field_594;
+        g_GameWork.field_594 = 0x16;
+        g_SysWork.field_1C   = 0;
+        g_SysWork.field_20   = 0;
+        g_GameWork.field_59C = 0;
+        g_GameWork.field_5A0 = 0;
+        g_SysWork.field_8    = 0;
+        g_SysWork.field_24   = 0;
+        g_SysWork.field_C    = 0;
+        g_SysWork.field_28   = 0;
+        g_SysWork.field_10   = 0;
+        g_SysWork.field_2C   = 0;
+        g_SysWork.field_14   = 0;
+        g_GameWork.field_598 = prev_594;
+        g_GameWork.field_590 = prev_594;
+        g_GameWork.field_598 = 0;
+    }
+    if (controller->field_18 & 0x08000000)
+    {
+        D_801E3F3C -= 1;
+    }
+    if (controller->field_18 & 0x02000000)
+    {
+        D_801E3F3C += 1;
+    }
+    func_80031EFC(0x28, 0x28);
+    if (controller->btns_new_10 & gameWork->controllerBinds_0.enter)
+    {
+        open_main(2072 - D_801E3F3C, 0);
+    }
+}
+
+void func_801E2A24(void)
+{
+    // old IDB name MainLoopState5_Movie_PlayIntroAlternate_801E2A24
+    s32 prev_594;
+
+    open_main(2053, 2060); // XA/C1_20670
+    prev_594             = g_GameWork.field_594;
+    g_GameWork.field_594 = 7;
+    g_SysWork.field_1C   = 0;
+    g_SysWork.field_20   = 0;
+    g_GameWork.field_59C = 0;
+    g_GameWork.field_5A0 = 0;
+    g_SysWork.field_8    = 0;
+    g_SysWork.field_24   = 0;
+    g_SysWork.field_C    = 0;
+    g_SysWork.field_28   = 0;
+    g_SysWork.field_10   = 0;
+    g_SysWork.field_2C   = 0;
+    g_SysWork.field_14   = 0;
+    g_GameWork.field_598 = prev_594;
+    g_GameWork.field_590 = prev_594;
+    g_GameWork.field_598 = 0;
+    D_800B5C30           = 0x1000;
+}
+
+void open_main(s32 file_idx, s16 num_frames)
+{
+    Fs_QueueWaitForEmpty();
+    if (!num_frames)
+    {
+        num_frames = g_FileTable[file_idx].blockCount - 7;
+    }
+    GFX_ClearRectInterlaced(0, 16, 480, 480, 0, 0, 0);
+    movie_main(NULL, num_frames, g_FileTable[file_idx].startSector);
+    GFX_ClearRectInterlaced(0, 16, 480, 480, 0, 0, 0);
+    VSync(0);
+    GsSwapDispBuff();
+}
 
 INCLUDE_ASM("asm/stream/nonmatchings/stream", movie_main);
 
-void strSetDefDecEnv(DECENV* dec, int x0, int y0, int x1, int y1)
+void strSetDefDecEnv(DECENV *dec, int x0, int y0, int x1, int y1)
 {
     dec->rect[0].w = 480;
     dec->rect[1].w = 480;
-    dec->vlcid = 0;
-    dec->rectid = 0;
-    dec->isdone = 0;
+    dec->vlcid     = 0;
+    dec->rectid    = 0;
+    dec->isdone    = 0;
     dec->rect[0].x = x0;
     dec->rect[0].y = y0;
     dec->rect[0].h = 240;
     dec->rect[1].x = x1;
     dec->rect[1].h = 240;
-    dec->slice.x = x0;
-    dec->slice.y = y0;
-    dec->slice.w = 16*PPW;
-    dec->slice.h = 240;
+    dec->slice.x   = x0;
+    dec->slice.y   = y0;
+    dec->slice.w   = 16 * PPW;
+    dec->slice.h   = 240;
     dec->vlcbuf[0] = m->vlcbuf0;
     dec->vlcbuf[1] = m->vlcbuf1;
-    dec->imgbuf = m->imgbuf0;
+    dec->imgbuf    = m->imgbuf0;
     dec->rect[1].y = y1;
 }
 
-void strInit(CdlLOC* loc, void (*callback)())
+void strInit(CdlLOC *loc, void (*callback)())
 {
     DecDCTReset(0);
     DecDCToutCallback(callback);
@@ -115,8 +317,8 @@ void strInit(CdlLOC* loc, void (*callback)())
 void strCallback()
 {
     RECT snap_rect;
-    int id;
-    u16* imgbuf;
+    int  id;
+    u16 *imgbuf;
 
     if (StCdIntrFlag)
     {
@@ -131,33 +333,33 @@ void strCallback()
 
     imgbuf = m->imgbuf0;
     m->dec.slice.x += m->dec.slice.w;
-    
+
     if (m->dec.imgbuf == imgbuf)
     {
         imgbuf = m->imgbuf1;
     }
-    
+
     m->dec.imgbuf = imgbuf;
 
-    if (m->dec.slice.x < m->dec.rect[m->dec.rectid].x + m->dec.rect[m->dec.rectid].w)
+    if (m->dec.slice.x <
+        m->dec.rect[m->dec.rectid].x + m->dec.rect[m->dec.rectid].w)
     {
-        DecDCTout((u_long *)m->dec.imgbuf, m->dec.slice.w*m->dec.slice.h/2);
+        DecDCTout((u_long *)m->dec.imgbuf, m->dec.slice.w * m->dec.slice.h / 2);
     }
     else
     {
         DrawSync(0);
         m->dec.isdone = 1;
 
-        m->dec.rectid = m->dec.rectid ^ 1;
+        m->dec.rectid  = m->dec.rectid ^ 1;
         m->dec.slice.x = m->dec.rect[m->dec.rectid].x;
         m->dec.slice.y = m->dec.rect[m->dec.rectid].y;
     }
-
 }
 
-void strKickCD(CdlLOC* loc)
+void strKickCD(CdlLOC *loc)
 {
-    char v2[8];
+    char   v2[8];
     u_char param;
 
     while (!CdControlB(CdlNop, 0, v2) || (v2[0] & 2) == 0)
@@ -166,10 +368,11 @@ void strKickCD(CdlLOC* loc)
         VSync(0);
     }
     param = 0x80;
-    while (!CdControl(CdlSetmode, &param, 0));
+    while (!CdControl(CdlSetmode, &param, 0))
+        ;
     while (!CdControl(CdlSeekL, loc, 0))
         VSync(0);
-    while (!CdRead2(CdlModeStream|CdlModeSpeed|CdlModeRT|CdlModeSize1))
+    while (!CdRead2(CdlModeStream | CdlModeSpeed | CdlModeRT | CdlModeSize1))
         VSync(0);
 }
 
@@ -194,14 +397,14 @@ int strNextVlc(DECENV *dec)
 
 u_long *strNext(DECENV *dec)
 {
-    u_long *addr;
+    u_long   *addr;
     CDSECTOR *sector;
-    int cnt = MOVIE_WAIT;
+    int       cnt = MOVIE_WAIT;
 
-    while (StGetNext((u_long **)&addr,(u_long **)&sector))
+    while (StGetNext((u_long **)&addr, (u_long **)&sector))
     {
         if (--cnt == 0)
-            return(0);
+            return (0);
     }
 
     if (addr[0] != sector->headm || addr[1] != sector->headv)
@@ -214,17 +417,17 @@ u_long *strNext(DECENV *dec)
 
     if (m->width != sector->width || m->height != sector->height)
     {
-        m->width = sector->width;
+        m->width  = sector->width;
         m->height = sector->height;
     }
 
-    dec->rect[0].w = dec->rect[1].w = m->width*PPW;
+    dec->rect[0].w = dec->rect[1].w = m->width * PPW;
     dec->rect[0].h = dec->rect[1].h = m->height;
-    dec->slice.h = m->height;
+    dec->slice.h                    = m->height;
     return addr;
 }
 
-void strSync(DECENV *dec, int mode /* VOID */)
+void strSync(DECENV *dec)
 {
     volatile u_long cnt = WAIT_TIME;
 
@@ -232,12 +435,11 @@ void strSync(DECENV *dec, int mode /* VOID */)
     {
         if (--cnt == 0)
         {
-            dec->isdone = 1;
-            dec->rectid = dec->rectid ^ 1;
+            dec->isdone  = 1;
+            dec->rectid  = dec->rectid ^ 1;
             dec->slice.x = dec->rect[dec->rectid].x;
             dec->slice.y = dec->rect[dec->rectid].y;
         }
     }
     dec->isdone = 0;
 }
-

--- a/tools/decompile.py
+++ b/tools/decompile.py
@@ -128,8 +128,26 @@ class InjectRes(Enum):
 # check if the overlay can be compiled
 def check_injected_code(func) -> InjectRes:
     print(f"make {func.overlay_name}")
+    
+    make_str = ""
+    if func.overlay_name == "SLUS_007.07" or func.overlay_name == "main":
+        make_str = ""
+    else:
+        if func.overlay_name == "bodyprog":
+            make_str = "build/out/1ST/BODYPROG.BIN"
+        elif func.overlay_name == "b_konami":
+            make_str = "build/out/1ST/B_KONAMI.BIN"
+        elif func.overlay_name == "option" or func.overlay_name == "options":
+            make_str = "build/out/VIN/OPTION.BIN"
+        elif func.overlay_name == "saveload":
+            make_str = "build/out/VIN/SAVELOAD.BIN"
+        elif func.overlay_name == "stf_roll" or func.overlay_name == "credits":
+            make_str = "build/out/VIN/STF_ROLL.BIN"
+        elif func.overlay_name == "stream":
+            make_str = "build/out/VIN/STREAM.BIN"
+    
     compile_result = subprocess.run(
-        f"make {func.overlay_name}",
+        f"make {make_str}",
         cwd=root_dir,
         shell=True,
         check=False,


### PR DESCRIPTION
Adds most of the view/stream matches on decomp.me

```
$ python3 -m mapfile_parser progress build/out/VIN/STREAM.BIN.map asm/stream/ asm/stream/nonmatchings/ -i 3
stream.c.o                  :         2696 /     3704    72.7862%  ( 42.2836% /  58.0928%)

$ python3 -m mapfile_parser progress build/out/1ST/BODYPROG.BIN.map asm/bodyprog/ asm/bodyprog/nonmatchings/
bodyprog                    :        73976 /   501608    14.7478%  ( 14.7478% / 100.0000%)
```

stream would be almost 100% if this func could match: https://decomp.me/scratch/b3QWM, tried a bunch of changes and haven't had any luck yet though :/

Added kinda hacky fixes to decompile.py & diff_setting.py to get asm-differ at least start working, came in useful to get the scratches merged properly, needs some more work to let it auto-build again though.

Let me know if anything needs updating.