### PR TITLE
bodyprog: add 4 matches, update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -50,7 +50,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit:     80
+ColumnLimit:     0
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
@@ -79,7 +79,7 @@ IncludeCategories:
     SortPriority:    0
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
-IndentCaseLabels: false
+IndentCaseLabels: true
 IndentGotoLabels: true
 IndentPPDirectives: None
 IndentWidth:     4
@@ -103,7 +103,7 @@ PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
-PointerAlignment: Right
+PointerAlignment: Left
 ReflowComments:  true
 SortIncludes:    false
 SortUsingDeclarations: true

--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -135,6 +135,12 @@ g_Demo_CurControllerPacket = 0x800C4890;
 g_Demo_CurrDemoStep = 0x800C4894;
 g_Demo_VideoPresentInterval = 0x800C4898;
 
+SaveGame_ChecksumUpdate = 0x8002FF30; // type:func
+SaveGame_ChecksumValidate = 0x8002FF74; // type:func
+SaveGame_ChecksumGenerate = 0x8002FFD0; // type:func
+SaveGame_InventoryCopy = 0x8002FCCC; // type:func
+Game_SaveGameClear = 0x800350BC; // type:func
+
 GFX_ClearRectInterlaced = 0x80032358; // type:func
 GFX_Init = 0x80032428; // type:func
 Settings_ScreenXYSet = 0x800324f4; // type:func

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -1,7 +1,7 @@
 #ifndef _BODYPROG_H
 #define _BODYPROG_H
 
-#include "common.h"
+#include "game.h"
 #include "main/fsqueue.h"
 
 /** Declarations for unknown symbols in bodyprog. */
@@ -116,5 +116,15 @@ void func_80089128(void);
 
 /** Unknown bodyprog func. Called by `Fs_QueueWaitForEmpty` with `0` and then `1`. */
 void func_800892A4(s32);
+
+/** Updates the footer with the checksum of the given data */
+void SaveGame_ChecksumUpdate(s_ShSaveGameFooter* saveFooter, char* saveData, s32 saveDataLength);
+
+/** Generates checksum of the given saveData and compares against checksum value in the footer
+    Return 1 if checksum matches, otherwise 0 */
+s32 SaveGame_ChecksumValidate(s_ShSaveGameFooter* saveFooter, char* saveData, s32 saveDataLength);
+
+/** Generates an 8-bit XOR checksum over the given data, only appears used with s_ShSaveGame data */
+u8 SaveGame_ChecksumGenerate(char* saveData, s32 saveDataLength);
 
 #endif

--- a/include/bodyprog/vw_system.h
+++ b/include/bodyprog/vw_system.h
@@ -8,7 +8,7 @@
 // TODO:
 // - Add doc comments above func delcarations.
 // - Flags below are from SH2, most seem to match with SH but there might be some differences.
-// - Code that accesses VC_ROAD_TYPE & VC_NEAR_ROAD_DATA is odd, might need extra work.
+// - Code that accesses VC_ROAD_DATA & VC_NEAR_ROAD_DATA is odd, might need extra work.
 
 typedef enum _VC_ROAD_FLAGS
 {
@@ -131,11 +131,11 @@ typedef struct _VC_ROAD_DATA
 {
     VC_LIMIT_AREA lim_sw_0;
     VC_LIMIT_AREA lim_rd_8;
-    char          flags_10; // _VC_ROAD_FLAGS
-    char          area_size_type_11;
-    char          min_hy_12;
-    char          max_hy_13;
-    u_int         cam_mv_type_14;
+    VC_ROAD_FLAGS     flags_10 : 8;
+    VC_AREA_SIZE_TYPE area_size_type_11 : 2;
+    VC_ROAD_TYPE      rd_type_11 : 3;
+    u32               unk : 19; // May contain mv_y_type / rd_dir_type, maybe cam_mv_type below too
+    u_int             cam_mv_type_14;
 } VC_ROAD_DATA;
 STATIC_ASSERT_SIZEOF(VC_ROAD_DATA, 0x18);
 

--- a/include/game.h
+++ b/include/game.h
@@ -92,13 +92,27 @@ typedef struct _GameWork
     s_ControllerBindings controllerBinds_0;
     s8                   field_1C;
     s8                   field_1D;
-    char                 unk_1E[9];
-    u8                   extraOptionsEnabled_27;
-    char                 unk_28[1];
-    s8                   gameOptionsViewMode_29;
-    char                 unk_2A[0xE];
+    u8                   optSoundType_1E;
+    u8                   optVolumeBGM_1F;
+    u8                   optVolumeSE_20;
+    u8                   optVibrationEnabled_21;
+    u8                   optBrightness_22;
+    u8                   optWeaponCtrl_23;
+    u8                   optBloodColor_24;
+    u8                   optAutoLoad_25;
+    u8                   unk_26;
+    u8                   optExtraOptionsEnabled_27;
+    u8                   optViewCtrl_28;
+    s8                   optViewMode_29;
+    u8                   optRetreatTurn_2A;
+    u8                   optWalkRunCtrl_2B;
+    u8                   optAutoAiming_2C;
+    u8                   optBulletAdjust_2D;
+    char                 unk_2E[0x2];
+    char                 unk_30[8];
     s_ControllerData     controllers_38[2];
-    char                 pad90[0x4F8];
+    char                 unk_90[0x27C];
+    u8                   saveGame_30C[0x27C];
     u16                  gsScreenWidth_588;
     u16                  gsScreenHeight_58A;
     char                 unk_58C[4];
@@ -109,6 +123,7 @@ typedef struct _GameWork
     s32                  field_5A0;
     char                 unk_5A4[0x34];
 } s_GameWork;
+STATIC_ASSERT_SIZEOF(s_GameWork, 0x5D8);
 
 typedef struct _SubCharacter
 {
@@ -150,7 +165,8 @@ typedef struct _SysWork
     s32             field_2C;
     char            unk_30[0x1C];
     s_MainCharacter player_4C;
-    char            unk_1A0[0x930 - 0x1A0];
+    s_SubCharacter  characters_1A0[6];
+    GsCOORDINATE2   unk_coord_890[2];
     GsCOORDINATE2   hero_neck_930;
     char            unk_980[0x22A4 - 0x980];
     s32             field_22A4;
@@ -160,8 +176,19 @@ typedef struct _SysWork
     s16             field_237E;
     int             cam_r_xz_2380;
     int             cam_y_2384;
-    // more follows
+    u8              unk_2388[0x3E0];
 } s_SysWork;
+STATIC_ASSERT_SIZEOF(s_SysWork, 0x2768);
+
+/** s_ShSaveGameFooter: appended to ShSaveGame during game save, contains 8-bit XOR checksum + magic
+    Checksum generated via SaveGame_ChecksumGenerate function */
+#define SAVEGAME_FOOTER_MAGIC 0xDCDC
+typedef struct _ShSaveGameFooter
+{
+    u8  checksum_0[2];
+    u16 magic_2;
+} s_ShSaveGameFooter;
+STATIC_ASSERT_SIZEOF(s_ShSaveGameFooter, 4);
 
 extern s_SysWork   g_SysWork;
 extern s_GameWork  g_GameWork;

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -1,4 +1,3 @@
-#include "common.h"
 #include "bodyprog/bodyprog.h"
 #include "main/fsqueue.h"
 
@@ -171,7 +170,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FBB4);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FC3C);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FCCC);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SaveGame_InventoryCopy);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FD5C);
 
@@ -179,11 +178,38 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FDB0);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FE70);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FF30);
+void SaveGame_ChecksumUpdate(s_ShSaveGameFooter* saveFooter, char* saveData, s32 saveDataLength) // 0x8002FF30
+{
+    u8 checksum;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FF74);
+    saveFooter->checksum_0[0] = saveFooter->checksum_0[1] = 0;
+    saveFooter->magic_2                                   = SAVEGAME_FOOTER_MAGIC;
+    checksum                                              = SaveGame_ChecksumGenerate(saveData, saveDataLength);
+    saveFooter->checksum_0[0] = saveFooter->checksum_0[1] = checksum;
+}
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FFD0);
+s32 SaveGame_ChecksumValidate(s_ShSaveGameFooter* saveFooter, char* saveData, s32 saveDataLength) // 0x8002FF74
+{
+    s32 is_valid = 0;
+
+    if (saveFooter->checksum_0[0] == SaveGame_ChecksumGenerate(saveData, saveDataLength))
+        is_valid = saveFooter->magic_2 == SAVEGAME_FOOTER_MAGIC;
+
+    return is_valid;
+}
+
+u8 SaveGame_ChecksumGenerate(char* saveData, s32 saveDataLength) // 0x8002FFD0
+{
+    u8  checksum = 0;
+    int i        = 0;
+
+    for (i = 0; i < saveDataLength;)
+    {
+        ++i;
+        checksum ^= *saveData++;
+    }
+    return checksum;
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80030000);
 
@@ -367,7 +393,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80034F18);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80034FB8);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_800350BC);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", Game_SaveGameClear);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80035178);
 

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -467,7 +467,7 @@ void vcMakeIdealCamPosByHeadPos(VECTOR3* ideal_pos, VC_WORK* w_p, VC_AREA_SIZE_T
         return;
     }
 
-    if (g_pGameWork->gameOptionsViewMode_29)
+    if (g_pGameWork->optViewMode_29)
     {
         chara2cam_ang_y = w_p->chara_eye_ang_y_144 + DEG_TO_FPA(8.75f);
         ideal_pos->vy   = w_p->chara_head_pos_130.vy + 286;

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -3,6 +3,8 @@
 #include "bodyprog/vw_system.h"
 #include "bodyprog/math.h"
 
+#define MIN_IN_ROAD_DIST 4096 // vcGetMinInRoadDist() in SH2, hardcoded 4096 in SH1
+
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcInitVCSystem);
 
 void vcStartCameraSystem() // 0x800809DC
@@ -58,7 +60,7 @@ void vcWorkSetFlags(VC_FLAGS enable, VC_FLAGS disable) // 0x80080BF8
 
 s32 func_80080C18(s32 arg0) // 0x80080C18
 {
-    s32 prev_val = vcWork.watch_tgt_max_y_88;
+    s32 prev_val              = vcWork.watch_tgt_max_y_88;
     vcWork.watch_tgt_max_y_88 = arg0;
     return prev_val;
 }
@@ -357,12 +359,12 @@ void vcSetWatchTgtYParam(VECTOR3* watch_pos, VC_WORK* w_p, s32 cam_mv_type, s32 
 void vcAdjustWatchYLimitHighWhenFarView(VECTOR3* watch_pos, VECTOR3* cam_pos, s16 sy) // 0x800835E0
 {
     s16 max_cam_ang_x = ratan2(cam_pos->vy + 0x5000, 0xD000) - ratan2(g_GameWork.gsScreenHeight_58A / 2, sy);
-    s32 dist = Math_VectorMagnitude(watch_pos->vx - cam_pos->vx, 0, watch_pos->vz - cam_pos->vz);
-    s32 cam_ang_x = ratan2(-watch_pos->vy + cam_pos->vy, dist) * FP_ANGLE_COUNT;
+    s32 dist          = Math_VectorMagnitude(watch_pos->vx - cam_pos->vx, 0, watch_pos->vz - cam_pos->vz);
+    s32 cam_ang_x     = ratan2(-watch_pos->vy + cam_pos->vy, dist) * FP_ANGLE_COUNT;
 
     if ((max_cam_ang_x * FP_ANGLE_COUNT) < cam_ang_x)
     {
-        s32 ofs_y = (((dist >> FP_POS_Q) * shRsin(max_cam_ang_x)) / shRcos(max_cam_ang_x)) * 16;
+        s32 ofs_y     = (((dist >> FP_POS_Q) * shRsin(max_cam_ang_x)) / shRcos(max_cam_ang_x)) * 16;
         watch_pos->vy = cam_pos->vy - ofs_y;
     }
 }
@@ -488,8 +490,6 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeIdealCamPosUseVC_ROA
 
 void vcAdjustXzInLimAreaUsingMIN_IN_ROAD_DIST(s32* x_p, s32* z_p, VC_LIMIT_AREA* lim_p) // 0x80084210
 {
-    #define MIN_IN_ROAD_DIST 4096 // vcGetMinInRoadDist() in SH2, hardcoded 4096 in SH1
-    
     s32 min_z;
     s32 min_x;
     s32 max_z;
@@ -557,7 +557,81 @@ void vcMakeBasicCamTgtMvVec(VECTOR3* tgt_mv_vec, VECTOR3* ideal_pos, VC_WORK* w_
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcAdjTgtMvVecYByCurNearRoad);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcCamTgtMvVecIsFlipedFromCharaFront);
+void vcCamTgtMvVecIsFlipedFromCharaFront(VECTOR3* tgt_mv_vec, VC_WORK* w_p, s32 max_tgt_mv_xz_len, VC_AREA_SIZE_TYPE cur_rd_area_size)
+{
+    VECTOR3            pre_tgt_pos;
+    VECTOR3            chk_pos;
+    VECTOR3            post_tgt_pos;
+    s16                flip_ang_y;
+    VC_NEAR_ROAD_DATA* use_nearest_p;
+    s16                ang_y;
+    s32                flip_dist; // todo: name maybe switched with mv_len
+    s32                chk_near_dist;
+    s32                mv_len;
+    s32                min_z;
+    s32                min_x;
+    s32                max_z;
+    s32                max_x;
+
+    pre_tgt_pos.vx = tgt_mv_vec->vx + w_p->cam_tgt_pos_44.vx;
+    pre_tgt_pos.vz = tgt_mv_vec->vz + w_p->cam_tgt_pos_44.vz;
+    flip_dist      = vcFlipFromCamExclusionArea(&flip_ang_y, &w_p->old_cam_excl_area_r_6C, &pre_tgt_pos, &w_p->chara_pos_114, w_p->chara_eye_ang_y_144, cur_rd_area_size);
+    if (flip_dist > 0)
+    {
+        mv_len = flip_dist;
+        if (flip_dist > 0x800)
+            mv_len = 0x800;
+
+        // chk_pos is unused?
+        chk_pos.vx = pre_tgt_pos.vx + Math_MulFixed(mv_len, shRsin(flip_ang_y), FP_SIN_Q);
+        chk_pos.vz = pre_tgt_pos.vz + Math_MulFixed(mv_len, shRcos(flip_ang_y), FP_SIN_Q);
+
+        if (w_p->cur_near_road_2B8.road_p_0->flags_10 & VC_RD_MARGE_ROAD_F)
+        {
+            chk_near_dist = vcGetNearestNEAR_ROAD_DATA(&use_nearest_p, VC_CHK_NEAREST_ROAD_TYPE, w_p->cur_near_road_2B8.road_p_0->rd_type_11, &pre_tgt_pos, w_p, 1);
+            if (use_nearest_p == NULL)
+                use_nearest_p = &vcNullNearRoad;
+            else if (chk_near_dist > 0)
+                use_nearest_p = &w_p->cur_near_road_2B8;
+        }
+        else
+        {
+            use_nearest_p = &w_p->cur_near_road_2B8;
+        }
+
+        post_tgt_pos.vx = pre_tgt_pos.vx + ((flip_dist * shRsin(flip_ang_y)) >> FP_SIN_Q);
+        post_tgt_pos.vz = pre_tgt_pos.vz + ((flip_dist * shRcos(flip_ang_y)) >> FP_SIN_Q);
+
+        min_x = (use_nearest_p->rd_14.min_hx << 8) + MIN_IN_ROAD_DIST;
+        max_x = (use_nearest_p->rd_14.max_hx << 8) - MIN_IN_ROAD_DIST;
+        min_z = (use_nearest_p->rd_14.min_hz << 8) + MIN_IN_ROAD_DIST;
+        max_z = (use_nearest_p->rd_14.max_hz << 8) - MIN_IN_ROAD_DIST;
+
+        if (max_x < min_x)
+        {
+            min_x = (min_x + max_x) >> 1;
+            max_x = min_x;
+        }
+        if (max_z < min_z)
+        {
+            min_z = (min_z + max_z) >> 1;
+            max_z = min_z;
+        }
+
+        post_tgt_pos.vx = CLAMP(post_tgt_pos.vx, min_x, max_x);
+        post_tgt_pos.vz = CLAMP(post_tgt_pos.vz, min_z, max_z);
+
+        tgt_mv_vec->vx = post_tgt_pos.vx - w_p->cam_tgt_pos_44.vx;
+        tgt_mv_vec->vz = post_tgt_pos.vz - w_p->cam_tgt_pos_44.vz;
+
+        if (max_tgt_mv_xz_len < Math_VectorMagnitude(tgt_mv_vec->vx, 0, tgt_mv_vec->vz))
+        {
+            ang_y          = ratan2(tgt_mv_vec->vx, tgt_mv_vec->vz);
+            tgt_mv_vec->vx = Math_MulFixed(max_tgt_mv_xz_len, shRsin(ang_y), FP_SIN_Q);
+            tgt_mv_vec->vz = Math_MulFixed(max_tgt_mv_xz_len, shRcos(ang_y), FP_SIN_Q);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcFlipFromCamExclusionArea);
 
@@ -618,8 +692,8 @@ void vcRenewalCamData(VC_WORK* w_p, VC_CAM_MV_PARAM* cam_mv_prm_p) // 0x80084BD8
                                    &w_p->cam_tgt_pos_44, 0x199, cam_mv_prm_p->accel_xz,
                                    cam_mv_prm_p->max_spd_xz, dec_spd_per_dist_xz, 0xC000);
 
-    w_p->cam_velo_60.vy = vwRetNewVelocityToTargetVal(w_p->cam_velo_60.vy, w_p->cam_pos_50.vy, w_p->cam_tgt_pos_44.vy,
-                                                      cam_mv_prm_p->accel_y, cam_mv_prm_p->max_spd_y, dec_spd_per_dist_y);
+    w_p->cam_velo_60.vy  = vwRetNewVelocityToTargetVal(w_p->cam_velo_60.vy, w_p->cam_pos_50.vy, w_p->cam_tgt_pos_44.vy,
+                                                       cam_mv_prm_p->accel_y, cam_mv_prm_p->max_spd_y, dec_spd_per_dist_y);
     w_p->cam_mv_ang_y_5C = ratan2(w_p->cam_velo_60.vx, w_p->cam_velo_60.vz);
 
     w_p->cam_pos_50.vx += Math_MulFixed(w_p->cam_velo_60.vx, g_CurDeltaTime, FP_SIN_Q);
@@ -740,12 +814,10 @@ void vcAdjCamOfsAngByCharaInScreen(SVECTOR* cam_ang, SVECTOR* ofs_cam2chara_btm_
     s16 adj_cam_ang_y;
 
     watch2chr_bottom_ofs_ang_x = shAngleRegulate(ofs_cam2chara_btm_ang->vx - cam_ang->vx);
-    watch2chr_top_ofs_ang_x = shAngleRegulate(ofs_cam2chara_top_ang->vx - cam_ang->vx);
-    watch2chr_ofs_ang_y = shAngleRegulate(ofs_cam2chara_top_ang->vy - cam_ang->vy);
+    watch2chr_top_ofs_ang_x    = shAngleRegulate(ofs_cam2chara_top_ang->vx - cam_ang->vx);
+    watch2chr_ofs_ang_y        = shAngleRegulate(ofs_cam2chara_top_ang->vy - cam_ang->vy);
 
-    adj_cam_ang_y = (watch2chr_ofs_ang_y > w_p->scr_half_ang_wx_2E) ?
-                        (watch2chr_ofs_ang_y - w_p->scr_half_ang_wx_2E) :
-                        ((-w_p->scr_half_ang_wx_2E > watch2chr_ofs_ang_y) ? (w_p->scr_half_ang_wx_2E + watch2chr_ofs_ang_y) : 0);
+    adj_cam_ang_y = (watch2chr_ofs_ang_y > w_p->scr_half_ang_wx_2E) ? (watch2chr_ofs_ang_y - w_p->scr_half_ang_wx_2E) : ((-w_p->scr_half_ang_wx_2E > watch2chr_ofs_ang_y) ? (w_p->scr_half_ang_wx_2E + watch2chr_ofs_ang_y) : 0);
 
     /*
     var_a1 = watch2chr_bottom_ofs_ang_x + w_p->scr_half_ang_wy_2C;

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -243,6 +243,6 @@ void vcSetRefPosAndCamPosAngByPad(VECTOR3* ref_pos, s_SysWork* sys_p) // 0x80040
         ref_pos->vz           = (sp18.vz + sp58.vz) * 16;
         sys_p->cam_ang_y_237A = ((cam_ang.vy + DEG_TO_FPA(11.25f)) << 0x14) >> 0x14;
         sys_p->cam_y_2384     = -sp58.vy * 16;
-        sys_p->cam_r_xz_2380 = SquareRoot0((sp58.vx * sp58.vx) + (sp58.vz * sp58.vz)) * 16;
+        sys_p->cam_r_xz_2380  = SquareRoot0((sp58.vx * sp58.vx) + (sp58.vz * sp58.vz)) * 16;
     }
 }

--- a/src/bodyprog/view/vw_calc.c
+++ b/src/bodyprog/view/vw_calc.c
@@ -6,21 +6,20 @@
 extern MATRIX D_800C3868;
 extern MATRIX D_800C6FC0; // Might be psyq GsWSMATRIX.
 
-void vwRenewalXZVelocityToTargetPos(s32* velo_x, s32* velo_z, VECTOR3* now_pos, VECTOR3* tgt_pos, s32 tgt_r,
-                                    s32 accel, s32 total_max_spd, s32 dec_forwd_lim_spd, s32 dec_accel_side) // 0x80048F28
+void vwRenewalXZVelocityToTargetPos(s32* velo_x, s32* velo_z, VECTOR3* now_pos, VECTOR3* tgt_pos, s32 tgt_r, s32 accel, s32 total_max_spd, s32 dec_forwd_lim_spd, s32 dec_accel_side) // 0x80048F28
 {
 // SH2 locals
 #if 0
     /* 0x1d */ float vec_xz[4];
-	/* 0x1d */ float lim_spd;
-	/* 0x1d */ float to_tgt_dist;
-	/* 0x16 */ float to_tgt_ang_y;
-	/* 0x18 */ float ang_y;
-	/* 0x1d */ float spd;
-	/* 0x2 */ float add_spd;
-	/* 0x1d */ float cam2tgt_dir_vec[4];
-	/* 0x1d */ float cam_mv_ang_y;
-	/* 0x1d */ float cam2tgt_ang_y;
+    /* 0x1d */ float lim_spd;
+    /* 0x1d */ float to_tgt_dist;
+    /* 0x16 */ float to_tgt_ang_y;
+    /* 0x18 */ float ang_y;
+    /* 0x1d */ float spd;
+    /* 0x2 */ float add_spd;
+    /* 0x1d */ float cam2tgt_dir_vec[4];
+    /* 0x1d */ float cam_mv_ang_y;
+    /* 0x1d */ float cam2tgt_ang_y;
 #endif
 
     SVECTOR unused; // cam2tgt_dir_vec?
@@ -153,17 +152,17 @@ void vbSetWorldScreenMatrix(GsCOORDINATE2* coord) // 0x800497E4
 void vbSetRefView(VbRVIEW* rview) // 0x800498D8
 {
     GsCOORDINATE2 sp10;
-    SVECTOR sp60;
-    SVECTOR sp68;
+    SVECTOR       sp60;
+    SVECTOR       sp68;
 
-    sp10.flg = 0;
+    sp10.flg   = 0;
     sp10.super = rview->super;
-    sp68.vx = rview->vr.vx - rview->vp.vx;
-    sp68.vy = rview->vr.vy - rview->vp.vy;
-    sp68.vz = rview->vr.vz - rview->vp.vz;
+    sp68.vx    = rview->vr.vx - rview->vp.vx;
+    sp68.vy    = rview->vr.vy - rview->vp.vy;
+    sp68.vz    = rview->vr.vz - rview->vp.vz;
     vwVectorToAngle(&sp60, &sp68);
     func_80096E78(&sp60, &sp10.coord);
-    
+
     sp10.coord.t[0] = rview->vp.vx;
     sp10.coord.t[1] = rview->vp.vy;
     sp10.coord.t[2] = rview->vp.vz;
@@ -187,9 +186,9 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_8004A54C);
 void vwAngleToVector(SVECTOR* vec, SVECTOR* ang, s32 r) // 0x8004A66C
 {
     s32 entou_r = (r * shRcos(ang->vx)) >> FP_SIN_Q;
-    vec->vy = (-r * shRsin(ang->vx)) >> FP_SIN_Q;
-    vec->vx = (entou_r * shRsin(ang->vy)) >> FP_SIN_Q;
-    vec->vz = (entou_r * shRcos(ang->vy)) >> FP_SIN_Q;
+    vec->vy     = (-r * shRsin(ang->vx)) >> FP_SIN_Q;
+    vec->vx     = (entou_r * shRsin(ang->vy)) >> FP_SIN_Q;
+    vec->vz     = (entou_r * shRcos(ang->vy)) >> FP_SIN_Q;
 }
 
 s32 vwVectorToAngle(SVECTOR* ang, SVECTOR* vec) // 0x8004A714

--- a/src/bodyprog/view/vw_main.c
+++ b/src/bodyprog/view/vw_main.c
@@ -11,7 +11,7 @@ void vwInitViewInfo() // 0x80048A38
     vwViewPointInfo.rview.vr.vx = 0;
     vwViewPointInfo.rview.vr.vy = 0;
     vwViewPointInfo.rview.vr.vz = 4096;
-    vwViewPointInfo.rview.rz = 0;
+    vwViewPointInfo.rview.rz    = 0;
     vwViewPointInfo.rview.super = &vwViewPointInfo.vwcoord;
     GsInitCoordinate2(NULL, &vwViewPointInfo.vwcoord);
     vwSetViewInfo();
@@ -51,12 +51,12 @@ void vwSetCoordRefAndEntou(GsCOORDINATE2* parent_p, s32 ref_x, s32 ref_y, s32 re
 
     view_mtx->t[0] = (ref_x >> FP_POS_Q) + (((cam_xz_r >> FP_POS_Q) * shRsin(cam_ang_y)) >> FP_SIN_Q);
     view_mtx->t[1] = (ref_y >> FP_POS_Q) + (cam_y >> FP_POS_Q);
-    view_mtx->t[2] =  (ref_z >> FP_POS_Q) + (((cam_xz_r >> FP_POS_Q) * shRcos(cam_ang_y)) >> FP_SIN_Q);
+    view_mtx->t[2] = (ref_z >> FP_POS_Q) + (((cam_xz_r >> FP_POS_Q) * shRcos(cam_ang_y)) >> FP_SIN_Q);
 }
 
 void vwSetViewInfoDirectMatrix(GsCOORDINATE2* pcoord, MATRIX* cammat) // 0x80048CF0
 {
-    vwViewPointInfo.vwcoord.flg = 0;
+    vwViewPointInfo.vwcoord.flg   = 0;
     vwViewPointInfo.vwcoord.super = pcoord;
     vwViewPointInfo.vwcoord.coord = *cammat;
 }

--- a/src/screens/stream/stream.c
+++ b/src/screens/stream/stream.c
@@ -290,7 +290,7 @@ void open_main(s32 file_idx, s16 num_frames) // 0x801E2AA4
 
 INCLUDE_ASM("asm/screens/stream/nonmatchings/stream", movie_main);
 
-void strSetDefDecEnv(DECENV *dec, int x0, int y0, int x1, int y1) // 0x801E2F8C
+void strSetDefDecEnv(DECENV* dec, int x0, int y0, int x1, int y1) // 0x801E2F8C
 {
     dec->rect[0].w = 480;
     dec->rect[1].w = 480;
@@ -312,7 +312,7 @@ void strSetDefDecEnv(DECENV *dec, int x0, int y0, int x1, int y1) // 0x801E2F8C
     dec->rect[1].y = y1;
 }
 
-void strInit(CdlLOC* loc, void(*callback)()) // 0x801E300C
+void strInit(CdlLOC* loc, void (*callback)()) // 0x801E300C
 {
     DecDCTReset(0);
     DecDCToutCallback(callback);
@@ -387,7 +387,7 @@ void strKickCD(CdlLOC* loc) // 0x801E31CC
 
 int strNextVlc(DECENV* dec) // 0x801E3298
 {
-    u_long* next, *strNext();
+    u_long *next, *strNext();
 
     u_long cnt = 2000;
     while ((next = strNext(dec)) == 0)
@@ -410,7 +410,7 @@ u_long* strNext(DECENV* dec) // 0x801E331C
     CDSECTOR* sector;
     int       cnt = MOVIE_WAIT;
 
-    while (StGetNext((u_long **)&addr, (u_long **)&sector))
+    while (StGetNext((u_long**)&addr, (u_long**)&sector))
     {
         if (--cnt == 0)
         {

--- a/src/screens/stream/stream.c
+++ b/src/screens/stream/stream.c
@@ -131,7 +131,7 @@ void func_801E279C(void)
     s32 prev_594;
     s32 file_idx = 2053; // XA/C1_20670
 
-    if (g_pGameWork->extraOptionsEnabled_27 & 1)
+    if (g_pGameWork->optExtraOptionsEnabled_27 & 1)
     {
         file_idx = 2054; // XA/C2_20670
     }


### PR DESCRIPTION
Added `vcCamTgtMvVecIsFlipedFromCharaFront` & some savegame checksum funcs, and made clang-format closer to our formatting style.

clang-format might need some more tweaking though, would be nice if we can get it nailed down, running `git clang-format` before `git commit` would be a lot easier than manually fixing up formatting each time. (iirc some editors can also read clang-format and use formatting from it too)