### PR TITLE
Move stream function declarations to `stream.h`

### DIFF
--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -118,13 +118,13 @@ void func_80089128(void);
 void func_800892A4(s32);
 
 /** Updates the footer with the checksum of the given data */
-void SaveGame_ChecksumUpdate(s_ShSaveGameFooter* saveFooter, char* saveData, s32 saveDataLength);
+void SaveGame_ChecksumUpdate(s_ShSaveGameFooter* saveFooter, s8* saveData, s32 saveDataLength);
 
 /** Generates checksum of the given saveData and compares against checksum value in the footer
     Return 1 if checksum matches, otherwise 0 */
-s32 SaveGame_ChecksumValidate(s_ShSaveGameFooter* saveFooter, char* saveData, s32 saveDataLength);
+s32 SaveGame_ChecksumValidate(s_ShSaveGameFooter* saveFooter, s8* saveData, s32 saveDataLength);
 
 /** Generates an 8-bit XOR checksum over the given data, only appears used with s_ShSaveGame data */
-u8 SaveGame_ChecksumGenerate(char* saveData, s32 saveDataLength);
+u8 SaveGame_ChecksumGenerate(s8* saveData, s32 saveDataLength);
 
 #endif

--- a/include/screens/b_konami/b_konami.h
+++ b/include/screens/b_konami/b_konami.h
@@ -1,5 +1,5 @@
-#ifndef B_KONAMI_H
-#define B_KONAMI_H
+#ifndef _B_KONAMI_H
+#define _B_KONAMI_H
 
 #include "common.h"
 

--- a/include/screens/credits/credits.h
+++ b/include/screens/credits/credits.h
@@ -1,5 +1,5 @@
-#ifndef CREDITS_H
-#define CREDITS_H
+#ifndef _CREDITS_H
+#define _CREDITS_H
 
 #include "common.h"
 

--- a/include/screens/options/options.h
+++ b/include/screens/options/options.h
@@ -1,5 +1,5 @@
-#ifndef OPTIONS_H
-#define OPTIONS_H
+#ifndef _OPTIONS_H
+#define _OPTIONS_H
 
 #include "common.h"
 

--- a/include/screens/saveload/saveload.h
+++ b/include/screens/saveload/saveload.h
@@ -1,5 +1,5 @@
-#ifndef SAVELOAD_H
-#define SAVELOAD_H
+#ifndef _SAVELOAD_H
+#define _SAVELOAD_H
 
 #include "common.h"
 

--- a/include/screens/stream/stream.h
+++ b/include/screens/stream/stream.h
@@ -1,0 +1,72 @@
+#ifndef _STREAM_H
+#define _STREAM_H
+
+#include "common.h"
+
+extern int StCdIntrFlag; // Not included in SDK docs/headers, but movie player sample code (and moviesys) uses it?
+
+extern s32 D_800B5C30;
+extern s32 D_801E3F3C;
+
+extern s32 D_800BCD0C;
+extern u8  D_800A900C[];
+
+typedef struct
+{
+    /* 0x00 */ u_long* vlcbuf[2];
+    /* 0x08 */ s32     vlcid;
+    /* 0x0C */ u16*    imgbuf;
+    /* 0x10 */ RECT    rect[2];
+    /* 0x20 */ s32     rectid;
+    /* 0x24 */ RECT    slice;
+    /* 0x2C */ s32     isdone;
+} DECENV;
+
+typedef struct
+{
+    /* 0x00000 */ CdlLOC loc;
+    /* 0x00004 */ DECENV dec;
+    /* 0x00034 */ s32    Rewind_Switch; // or Clear_Flag
+    /* 0x00038 */ s32    width;
+    /* 0x0003C */ s32    height;
+    /* 0x00040 */ u16    imgbuf0[5760];
+    /* 0x02D40 */ u16    imgbuf1[5760];
+    /* 0x05A40 */ u_long sect_buff[11776];
+    /* 0x11240 */ u_long vlcbuf0[14336];
+    /* 0x1F240 */ u_long vlcbuf1[14336];
+} MOVIE_STR;
+
+// Customised StHEADER?
+typedef struct
+{
+    u16    id;
+    u16    type;
+    u16    secCount;
+    u16    nSectors;
+    u_long frameCount;
+    u_long frameSize;
+    u16    width;
+    u16    height;
+    u_long headm;
+    u_long headv;
+    u_long user;
+} CDSECTOR;
+
+#define RING_SIZE 23
+#define MOVIE_WAIT 2000
+#define PPW 3 / 2
+
+extern MOVIE_STR* m;
+extern s32        frame_cnt;
+
+void    open_main(s32 file_idx, s16 num_frames);
+void    movie_main(s8* file_name, s32 f_size, s32 sector);
+void    strSetDefDecEnv(DECENV* dec, s32 x0, s32 y0, s32 x1, s32 y1);
+void    strInit(CdlLOC* loc, void (*callback)());
+void    strCallback();
+void    strKickCD(CdlLOC* loc);
+s32     strNextVlc(DECENV* dec);
+u_long* strNext(DECENV* dec);
+void    strSync(DECENV* dec);
+
+#endif

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -178,7 +178,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FDB0);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FE70);
 
-void SaveGame_ChecksumUpdate(s_ShSaveGameFooter* saveFooter, char* saveData, s32 saveDataLength) // 0x8002FF30
+void SaveGame_ChecksumUpdate(s_ShSaveGameFooter* saveFooter, s8* saveData, s32 saveDataLength) // 0x8002FF30
 {
     u8 checksum;
 
@@ -188,26 +188,29 @@ void SaveGame_ChecksumUpdate(s_ShSaveGameFooter* saveFooter, char* saveData, s32
     saveFooter->checksum_0[0] = saveFooter->checksum_0[1] = checksum;
 }
 
-s32 SaveGame_ChecksumValidate(s_ShSaveGameFooter* saveFooter, char* saveData, s32 saveDataLength) // 0x8002FF74
+s32 SaveGame_ChecksumValidate(s_ShSaveGameFooter* saveFooter, s8* saveData, s32 saveDataLength) // 0x8002FF74
 {
     s32 is_valid = 0;
 
     if (saveFooter->checksum_0[0] == SaveGame_ChecksumGenerate(saveData, saveDataLength))
+    {
         is_valid = saveFooter->magic_2 == SAVEGAME_FOOTER_MAGIC;
+    }
 
     return is_valid;
 }
 
-u8 SaveGame_ChecksumGenerate(char* saveData, s32 saveDataLength) // 0x8002FFD0
+u8 SaveGame_ChecksumGenerate(s8* saveData, s32 saveDataLength) // 0x8002FFD0
 {
     u8  checksum = 0;
     int i        = 0;
 
     for (i = 0; i < saveDataLength;)
     {
-        ++i;
+        i++;
         checksum ^= *saveData++;
     }
+
     return checksum;
 }
 

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -557,8 +557,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003AB28);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003B550);
 
-void func_8003B560(void) {
-}
+void func_8003B560(void) {}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003B568);
 

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -580,7 +580,9 @@ void vcCamTgtMvVecIsFlipedFromCharaFront(VECTOR3* tgt_mv_vec, VC_WORK* w_p, s32 
     {
         mv_len = flip_dist;
         if (flip_dist > 0x800)
+        {
             mv_len = 0x800;
+        }
 
         // chk_pos is unused?
         chk_pos.vx = pre_tgt_pos.vx + Math_MulFixed(mv_len, shRsin(flip_ang_y), FP_SIN_Q);
@@ -590,9 +592,13 @@ void vcCamTgtMvVecIsFlipedFromCharaFront(VECTOR3* tgt_mv_vec, VC_WORK* w_p, s32 
         {
             chk_near_dist = vcGetNearestNEAR_ROAD_DATA(&use_nearest_p, VC_CHK_NEAREST_ROAD_TYPE, w_p->cur_near_road_2B8.road_p_0->rd_type_11, &pre_tgt_pos, w_p, 1);
             if (use_nearest_p == NULL)
+            {
                 use_nearest_p = &vcNullNearRoad;
+            }
             else if (chk_near_dist > 0)
+            {
                 use_nearest_p = &w_p->cur_near_road_2B8;
+            }
         }
         else
         {

--- a/src/main/fsmem.c
+++ b/src/main/fsmem.c
@@ -42,9 +42,7 @@ void Fs_InitializeMem(u8* start, u32 size)
     }
 }
 
-void nullsub_80011cfc(void)
-{
-}
+void nullsub_80011cfc(void) {}
 
 void* Fs_AllocMem(s32 size)
 {

--- a/src/main/memcpy.c
+++ b/src/main/memcpy.c
@@ -2,6 +2,4 @@
 
 INCLUDE_ASM("asm/main/nonmatchings/memcpy", memcpy);
 
-void nullsub_800120b0(void)
-{
-}
+void nullsub_800120b0(void) {}

--- a/src/maps/map0_s00/map0_s00.c
+++ b/src/maps/map0_s00/map0_s00.c
@@ -32,8 +32,7 @@ INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800CF974);
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800CFFF8);
 
-void func_800D0124(void) {
-}
+void func_800D0124(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D012C);
 
@@ -57,11 +56,9 @@ INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D0CB8);
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D0E04);
 
-void func_800D0E24(void) {
-}
+void func_800D0E24(void) {}
 
-void func_800D0E2C(void) {
-}
+void func_800D0E2C(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D0E34);
 
@@ -93,25 +90,19 @@ INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D2E50);
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D2E60);
 
-void func_800D2E6C(void) {
-}
+void func_800D2E6C(void) {}
 
-void func_800D2E74(void) {
-}
+void func_800D2E74(void) {}
 
-void func_800D2E7C(void) {
-}
+void func_800D2E7C(void) {}
 
-void func_800D2E84(void) {
-}
+void func_800D2E84(void) {}
 
-void func_800D2E8C(void) {
-}
+void func_800D2E8C(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D2E94);
 
-void func_800D2E9C(void) {
-}
+void func_800D2E9C(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D2EA4);
 
@@ -129,8 +120,7 @@ INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D3B44);
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D3EF4);
 
-void func_800D4924(void) {
-}
+void func_800D4924(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D492C);
 
@@ -146,8 +136,7 @@ INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D5FCC);
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D63D0);
 
-void func_800D654C(void) {
-}
+void func_800D654C(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D6554);
 

--- a/src/maps/map0_s01/map0_s01.c
+++ b/src/maps/map0_s01/map0_s01.c
@@ -20,8 +20,7 @@ INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800CF3F4);
 
 INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800CF7BC);
 
-void func_800CF8E8(void) {
-}
+void func_800CF8E8(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800CF8F0);
 
@@ -75,19 +74,15 @@ INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800D2054);
 
 INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800D2094);
 
-void func_800D20E4(void) {
-}
+void func_800D20E4(void) {}
 
-void func_800D20EC(void) {
-}
+void func_800D20EC(void) {}
 
-void func_800D20F4(void) {
-}
+void func_800D20F4(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800D20FC);
 
-void func_800D2104(void) {
-}
+void func_800D2104(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800D210C);
 
@@ -157,134 +152,91 @@ INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800D3DFC);
 
 INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800D3EB8);
 
-void func_800D4114(void) {
-}
+void func_800D4114(void) {}
 
-void func_800D411C(void) {
-}
+void func_800D411C(void) {}
 
-void func_800D4124(void) {
-}
+void func_800D4124(void) {}
 
-void func_800D412C(void) {
-}
+void func_800D412C(void) {}
 
-void func_800D4134(void) {
-}
+void func_800D4134(void) {}
 
-void func_800D413C(void) {
-}
+void func_800D413C(void) {}
 
-void func_800D4144(void) {
-}
+void func_800D4144(void) {}
 
-void func_800D414C(void) {
-}
+void func_800D414C(void) {}
 
-void func_800D4154(void) {
-}
+void func_800D4154(void) {}
 
-void func_800D415C(void) {
-}
+void func_800D415C(void) {}
 
-void func_800D4164(void) {
-}
+void func_800D4164(void) {}
 
-void func_800D416C(void) {
-}
+void func_800D416C(void) {}
 
-void func_800D4174(void) {
-}
+void func_800D4174(void) {}
 
-void func_800D417C(void) {
-}
+void func_800D417C(void) {}
 
-void func_800D4184(void) {
-}
+void func_800D4184(void) {}
 
-void func_800D418C(void) {
-}
+void func_800D418C(void) {}
 
-void func_800D4194(void) {
-}
+void func_800D4194(void) {}
 
-void func_800D419C(void) {
-}
+void func_800D419C(void) {}
 
-void func_800D41A4(void) {
-}
+void func_800D41A4(void) {}
 
-void func_800D41AC(void) {
-}
+void func_800D41AC(void) {}
 
-void func_800D41B4(void) {
-}
+void func_800D41B4(void) {}
 
-void func_800D41BC(void) {
-}
+void func_800D41BC(void) {}
 
-void func_800D41C4(void) {
-}
+void func_800D41C4(void) {}
 
-void func_800D41CC(void) {
-}
+void func_800D41CC(void) {}
 
-void func_800D41D4(void) {
-}
+void func_800D41D4(void) {}
 
-void func_800D41DC(void) {
-}
+void func_800D41DC(void) {}
 
-void func_800D41E4(void) {
-}
+void func_800D41E4(void) {}
 
-void func_800D41EC(void) {
-}
+void func_800D41EC(void) {}
 
-void func_800D41F4(void) {
-}
+void func_800D41F4(void) {}
 
-void func_800D41FC(void) {
-}
+void func_800D41FC(void) {}
 
-void func_800D4204(void) {
-}
+void func_800D4204(void) {}
 
-void func_800D420C(void) {
-}
+void func_800D420C(void) {}
 
-void func_800D4214(void) {
-}
+void func_800D4214(void) {}
 
-void func_800D421C(void) {
-}
+void func_800D421C(void) {}
 
-void func_800D4224(void) {
-}
+void func_800D4224(void) {}
 
-void func_800D422C(void) {
-}
+void func_800D422C(void) {}
 
-void func_800D4234(void) {
-}
+void func_800D4234(void) {}
 
-void func_800D423C(void) {
-}
+void func_800D423C(void) {}
 
-void func_800D4244(void) {
-}
+void func_800D4244(void) {}
 
-void func_800D424C(void) {
-}
+void func_800D424C(void) {}
 
-void func_800D4254(void) {
-}
+void func_800D4254(void) {}
 
-void func_800D425C(void) {
-}
+void func_800D425C(void) {}
 
-void func_800D4264(void) {
-}
+void func_800D4264(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800D426C);
 
@@ -378,8 +330,7 @@ INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800D82B8);
 
 INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800D8714);
 
-void func_800D87FC(void) {
-}
+void func_800D87FC(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800D8804);
 
@@ -451,8 +402,7 @@ INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800DC3C8);
 
 INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800DC830);
 
-void func_800DC85C(void) {
-}
+void func_800DC85C(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800DC864);
 

--- a/src/maps/map0_s02/map0_s02.c
+++ b/src/maps/map0_s02/map0_s02.c
@@ -16,8 +16,7 @@ INCLUDE_ASM("asm/maps/map0_s02/nonmatchings/map0_s02", func_800CC260);
 
 INCLUDE_ASM("asm/maps/map0_s02/nonmatchings/map0_s02", func_800CC628);
 
-void func_800CC754(void) {
-}
+void func_800CC754(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s02/nonmatchings/map0_s02", func_800CC75C);
 
@@ -67,25 +66,19 @@ INCLUDE_ASM("asm/maps/map0_s02/nonmatchings/map0_s02", func_800CE724);
 
 INCLUDE_ASM("asm/maps/map0_s02/nonmatchings/map0_s02", func_800CE734);
 
-void func_800CE740(void) {
-}
+void func_800CE740(void) {}
 
-void func_800CE748(void) {
-}
+void func_800CE748(void) {}
 
-void func_800CE750(void) {
-}
+void func_800CE750(void) {}
 
-void func_800CE758(void) {
-}
+void func_800CE758(void) {}
 
-void func_800CE760(void) {
-}
+void func_800CE760(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s02/nonmatchings/map0_s02", func_800CE768);
 
-void func_800CE770(void) {
-}
+void func_800CE770(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s02/nonmatchings/map0_s02", func_800CE778);
 
@@ -103,13 +96,11 @@ INCLUDE_ASM("asm/maps/map0_s02/nonmatchings/map0_s02", func_800CE8B8);
 
 INCLUDE_ASM("asm/maps/map0_s02/nonmatchings/map0_s02", func_800CE934);
 
-void func_800CEBC0(void) {
-}
+void func_800CEBC0(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s02/nonmatchings/map0_s02", func_800CEBC8);
 
-void func_800CEC7C(void) {
-}
+void func_800CEC7C(void) {}
 
 INCLUDE_ASM("asm/maps/map0_s02/nonmatchings/map0_s02", func_800CEC84);
 

--- a/src/maps/map1_s00/map1_s00.c
+++ b/src/maps/map1_s00/map1_s00.c
@@ -16,8 +16,7 @@ INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800CCA64);
 
 INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800CCE2C);
 
-void func_800CCF40(void) {
-}
+void func_800CCF40(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800CCF48);
 
@@ -65,25 +64,19 @@ INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800CEF98);
 
 INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800CEFA8);
 
-void func_800CEFB4(void) {
-}
+void func_800CEFB4(void) {}
 
-void func_800CEFBC(void) {
-}
+void func_800CEFBC(void) {}
 
-void func_800CEFC4(void) {
-}
+void func_800CEFC4(void) {}
 
-void func_800CEFCC(void) {
-}
+void func_800CEFCC(void) {}
 
-void func_800CEFD4(void) {
-}
+void func_800CEFD4(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800CEFDC);
 
-void func_800CEFE4(void) {
-}
+void func_800CEFE4(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800CEFEC);
 
@@ -113,8 +106,7 @@ INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800D28F8);
 
 INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800D3134);
 
-void func_800D34E4(void) {
-}
+void func_800D34E4(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800D34EC);
 
@@ -132,8 +124,7 @@ INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800D575C);
 
 INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800D5B60);
 
-void func_800D5CDC(void) {
-}
+void func_800D5CDC(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800D5CE4);
 
@@ -155,8 +146,7 @@ INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800D7758);
 
 INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800D77F8);
 
-void func_800D7864(void) {
-}
+void func_800D7864(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s00/nonmatchings/map1_s00", func_800D786C);
 

--- a/src/maps/map1_s01/map1_s01.c
+++ b/src/maps/map1_s01/map1_s01.c
@@ -52,25 +52,19 @@ INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800CE590);
 
 INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800CE5A0);
 
-void func_800CE5AC(void) {
-}
+void func_800CE5AC(void) {}
 
-void func_800CE5B4(void) {
-}
+void func_800CE5B4(void) {}
 
-void func_800CE5BC(void) {
-}
+void func_800CE5BC(void) {}
 
-void func_800CE5C4(void) {
-}
+void func_800CE5C4(void) {}
 
-void func_800CE5CC(void) {
-}
+void func_800CE5CC(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800CE5D4);
 
-void func_800CE5DC(void) {
-}
+void func_800CE5DC(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800CE5E4);
 
@@ -100,8 +94,7 @@ INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800D1EF0);
 
 INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800D272C);
 
-void func_800D2ADC(void) {
-}
+void func_800D2ADC(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800D2AE4);
 
@@ -119,8 +112,7 @@ INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800D4D54);
 
 INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800D5158);
 
-void func_800D52D4(void) {
-}
+void func_800D52D4(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800D52DC);
 
@@ -144,8 +136,7 @@ INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800D6F44);
 
 INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800D6FE4);
 
-void func_800D7050(void) {
-}
+void func_800D7050(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s01/nonmatchings/map1_s01", func_800D7058);
 

--- a/src/maps/map1_s02/map1_s02.c
+++ b/src/maps/map1_s02/map1_s02.c
@@ -26,8 +26,7 @@ INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800CEFD0);
 
 INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800CF2B4);
 
-void func_800CF374(void) {
-}
+void func_800CF374(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800CF37C);
 
@@ -77,25 +76,19 @@ INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800D2890);
 
 INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800D28A0);
 
-void func_800D28AC(void) {
-}
+void func_800D28AC(void) {}
 
-void func_800D28B4(void) {
-}
+void func_800D28B4(void) {}
 
-void func_800D28BC(void) {
-}
+void func_800D28BC(void) {}
 
-void func_800D28C4(void) {
-}
+void func_800D28C4(void) {}
 
-void func_800D28CC(void) {
-}
+void func_800D28CC(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800D28D4);
 
-void func_800D28DC(void) {
-}
+void func_800D28DC(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800D28E4);
 
@@ -111,8 +104,7 @@ INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800D2D48);
 
 INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800D3584);
 
-void func_800D3934(void) {
-}
+void func_800D3934(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800D393C);
 
@@ -130,8 +122,7 @@ INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800D5BAC);
 
 INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800D5FB0);
 
-void func_800D612C(void) {
-}
+void func_800D612C(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800D6134);
 
@@ -177,8 +168,7 @@ INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800D9E1C);
 
 INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800D9EBC);
 
-void func_800DA018(void) {
-}
+void func_800DA018(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s02/nonmatchings/map1_s02", func_800DA020);
 

--- a/src/maps/map1_s03/map1_s03.c
+++ b/src/maps/map1_s03/map1_s03.c
@@ -38,8 +38,7 @@ INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D05D0);
 
 INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D0690);
 
-void func_800D07DC(void) {
-}
+void func_800D07DC(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D07E4);
 
@@ -89,25 +88,19 @@ INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D2D08);
 
 INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D2D18);
 
-void func_800D2D24(void) {
-}
+void func_800D2D24(void) {}
 
-void func_800D2D2C(void) {
-}
+void func_800D2D2C(void) {}
 
-void func_800D2D34(void) {
-}
+void func_800D2D34(void) {}
 
-void func_800D2D3C(void) {
-}
+void func_800D2D3C(void) {}
 
-void func_800D2D44(void) {
-}
+void func_800D2D44(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D2D4C);
 
-void func_800D2D54(void) {
-}
+void func_800D2D54(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D2D5C);
 
@@ -123,8 +116,7 @@ INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D31C0);
 
 INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D39FC);
 
-void func_800D3DAC(void) {
-}
+void func_800D3DAC(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D3DB4);
 
@@ -142,8 +134,7 @@ INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D6024);
 
 INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D6428);
 
-void func_800D65A4(void) {
-}
+void func_800D65A4(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800D65AC);
 
@@ -191,8 +182,7 @@ INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800DA434);
 
 INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800DA4D4);
 
-void func_800DA630(void) {
-}
+void func_800DA630(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s03/nonmatchings/map1_s03", func_800DA638);
 

--- a/src/maps/map1_s04/map1_s04.c
+++ b/src/maps/map1_s04/map1_s04.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map1_s04/nonmatchings/map1_s04", func_800CC760);
 
 INCLUDE_ASM("asm/maps/map1_s04/nonmatchings/map1_s04", func_800CC770);
 
-void func_800CC77C(void) {
-}
+void func_800CC77C(void) {}
 
-void func_800CC784(void) {
-}
+void func_800CC784(void) {}
 
-void func_800CC78C(void) {
-}
+void func_800CC78C(void) {}
 
-void func_800CC794(void) {
-}
+void func_800CC794(void) {}
 
-void func_800CC79C(void) {
-}
+void func_800CC79C(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s04/nonmatchings/map1_s04", func_800CC7A4);
 
-void func_800CC7AC(void) {
-}
+void func_800CC7AC(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s04/nonmatchings/map1_s04", func_800CC7B4);
 
@@ -76,12 +70,10 @@ INCLUDE_ASM("asm/maps/map1_s04/nonmatchings/map1_s04", func_800CC828);
 
 INCLUDE_ASM("asm/maps/map1_s04/nonmatchings/map1_s04", func_800CC8C8);
 
-void func_800CCA24(void) {
-}
+void func_800CCA24(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s04/nonmatchings/map1_s04", func_800CCA2C);
 
-void func_800CCE30(void) {
-}
+void func_800CCE30(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s04/nonmatchings/map1_s04", func_800CCE38);

--- a/src/maps/map1_s05/map1_s05.c
+++ b/src/maps/map1_s05/map1_s05.c
@@ -64,24 +64,19 @@ INCLUDE_ASM("asm/maps/map1_s05/nonmatchings/map1_s05", func_800CF3F0);
 
 INCLUDE_ASM("asm/maps/map1_s05/nonmatchings/map1_s05", func_800CF400);
 
-void func_800CF40C(void) {
-}
+void func_800CF40C(void) {}
 
-void func_800CF414(void) {
-}
+void func_800CF414(void) {}
 
-void func_800CF41C(void) {
-}
+void func_800CF41C(void) {}
 
-void func_800CF424(void) {
-}
+void func_800CF424(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s05/nonmatchings/map1_s05", func_800CF42C);
 
 INCLUDE_ASM("asm/maps/map1_s05/nonmatchings/map1_s05", func_800CF7A4);
 
-void func_800CF7AC(void) {
-}
+void func_800CF7AC(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s05/nonmatchings/map1_s05", func_800CF7B4);
 
@@ -143,8 +138,7 @@ INCLUDE_ASM("asm/maps/map1_s05/nonmatchings/map1_s05", func_800D48AC);
 
 INCLUDE_ASM("asm/maps/map1_s05/nonmatchings/map1_s05", func_800D494C);
 
-void func_800D49A4(void) {
-}
+void func_800D49A4(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s05/nonmatchings/map1_s05", func_800D49AC);
 

--- a/src/maps/map1_s06/map1_s06.c
+++ b/src/maps/map1_s06/map1_s06.c
@@ -28,8 +28,7 @@ INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800CDC4C);
 
 INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800CDFE8);
 
-void func_800CE114(void) {
-}
+void func_800CE114(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800CE11C);
 
@@ -79,25 +78,19 @@ INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800D0214);
 
 INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800D0224);
 
-void func_800D0230(void) {
-}
+void func_800D0230(void) {}
 
-void func_800D0238(void) {
-}
+void func_800D0238(void) {}
 
-void func_800D0240(void) {
-}
+void func_800D0240(void) {}
 
-void func_800D0248(void) {
-}
+void func_800D0248(void) {}
 
-void func_800D0250(void) {
-}
+void func_800D0250(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800D0258);
 
-void func_800D0260(void) {
-}
+void func_800D0260(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800D0268);
 
@@ -159,8 +152,7 @@ INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800D5360);
 
 INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800D5400);
 
-void func_800D5448(void) {
-}
+void func_800D5448(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800D5450);
 
@@ -168,8 +160,7 @@ INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800D54E4);
 
 INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800D5578);
 
-void func_800D560C(void) {
-}
+void func_800D560C(void) {}
 
 INCLUDE_ASM("asm/maps/map1_s06/nonmatchings/map1_s06", func_800D5614);
 

--- a/src/maps/map2_s00/map2_s00.c
+++ b/src/maps/map2_s00/map2_s00.c
@@ -16,8 +16,7 @@ INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800CF17C);
 
 INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800CF544);
 
-void func_800CF670(void) {
-}
+void func_800CF670(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800CF678);
 
@@ -67,20 +66,15 @@ INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800D1770);
 
 INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800D1780);
 
-void func_800D178C(void) {
-}
+void func_800D178C(void) {}
 
-void func_800D1794(void) {
-}
+void func_800D1794(void) {}
 
-void func_800D179C(void) {
-}
+void func_800D179C(void) {}
 
-void func_800D17A4(void) {
-}
+void func_800D17A4(void) {}
 
-void func_800D17AC(void) {
-}
+void func_800D17AC(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800D17B4);
 
@@ -234,23 +228,17 @@ INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800DB9B8);
 
 INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800DBDEC);
 
-void func_800DBEEC(void) {
-}
+void func_800DBEEC(void) {}
 
-void func_800DBEF4(void) {
-}
+void func_800DBEF4(void) {}
 
-void func_800DBEFC(void) {
-}
+void func_800DBEFC(void) {}
 
-void func_800DBF04(void) {
-}
+void func_800DBF04(void) {}
 
-void func_800DBF0C(void) {
-}
+void func_800DBF0C(void) {}
 
-void func_800DBF14(void) {
-}
+void func_800DBF14(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800DBF1C);
 
@@ -428,8 +416,7 @@ INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800E2A1C);
 
 INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800E2E78);
 
-void func_800E2F60(void) {
-}
+void func_800E2F60(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800E2F68);
 
@@ -469,8 +456,7 @@ INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800E76C8);
 
 INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800E7914);
 
-void func_800E7A1C(void) {
-}
+void func_800E7A1C(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", func_800E7A24);
 

--- a/src/maps/map2_s01/map2_s01.c
+++ b/src/maps/map2_s01/map2_s01.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map2_s01/nonmatchings/map2_s01", func_800CD154);
 
 INCLUDE_ASM("asm/maps/map2_s01/nonmatchings/map2_s01", func_800CD164);
 
-void func_800CD170(void) {
-}
+void func_800CD170(void) {}
 
-void func_800CD178(void) {
-}
+void func_800CD178(void) {}
 
-void func_800CD180(void) {
-}
+void func_800CD180(void) {}
 
-void func_800CD188(void) {
-}
+void func_800CD188(void) {}
 
-void func_800CD190(void) {
-}
+void func_800CD190(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s01/nonmatchings/map2_s01", func_800CD198);
 
-void func_800CD1A0(void) {
-}
+void func_800CD1A0(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s01/nonmatchings/map2_s01", func_800CD1A8);
 
@@ -120,8 +114,7 @@ INCLUDE_ASM("asm/maps/map2_s01/nonmatchings/map2_s01", func_800CE88C);
 
 INCLUDE_ASM("asm/maps/map2_s01/nonmatchings/map2_s01", func_800CE908);
 
-void func_800CEB94(void) {
-}
+void func_800CEB94(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s01/nonmatchings/map2_s01", func_800CEB9C);
 

--- a/src/maps/map2_s02/map2_s02.c
+++ b/src/maps/map2_s02/map2_s02.c
@@ -16,8 +16,7 @@ INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800CDD3C);
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800CE104);
 
-void func_800CE230(void) {
-}
+void func_800CE230(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800CE238);
 
@@ -67,20 +66,15 @@ INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800D0200);
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800D0210);
 
-void func_800D021C(void) {
-}
+void func_800D021C(void) {}
 
-void func_800D0224(void) {
-}
+void func_800D0224(void) {}
 
-void func_800D022C(void) {
-}
+void func_800D022C(void) {}
 
-void func_800D0234(void) {
-}
+void func_800D0234(void) {}
 
-void func_800D023C(void) {
-}
+void func_800D023C(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800D0244);
 
@@ -234,23 +228,17 @@ INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800DA1A0);
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800DA5D4);
 
-void func_800DA6D4(void) {
-}
+void func_800DA6D4(void) {}
 
-void func_800DA6DC(void) {
-}
+void func_800DA6DC(void) {}
 
-void func_800DA6E4(void) {
-}
+void func_800DA6E4(void) {}
 
-void func_800DA6EC(void) {
-}
+void func_800DA6EC(void) {}
 
-void func_800DA6F4(void) {
-}
+void func_800DA6F4(void) {}
 
-void func_800DA6FC(void) {
-}
+void func_800DA6FC(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800DA704);
 
@@ -428,8 +416,7 @@ INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800E1204);
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800E1660);
 
-void func_800E1748(void) {
-}
+void func_800E1748(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800E1750);
 
@@ -491,8 +478,7 @@ INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800E8158);
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800E83D4);
 
-void func_800E8478(void) {
-}
+void func_800E8478(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800E8480);
 
@@ -516,8 +502,7 @@ INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800E993C);
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800E9B38);
 
-void func_800E9C24(void) {
-}
+void func_800E9C24(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", func_800E9C2C);
 

--- a/src/maps/map2_s03/map2_s03.c
+++ b/src/maps/map2_s03/map2_s03.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map2_s03/nonmatchings/map2_s03", func_800CC708);
 
 INCLUDE_ASM("asm/maps/map2_s03/nonmatchings/map2_s03", func_800CC718);
 
-void func_800CC724(void) {
-}
+void func_800CC724(void) {}
 
-void func_800CC72C(void) {
-}
+void func_800CC72C(void) {}
 
-void func_800CC734(void) {
-}
+void func_800CC734(void) {}
 
-void func_800CC73C(void) {
-}
+void func_800CC73C(void) {}
 
-void func_800CC744(void) {
-}
+void func_800CC744(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s03/nonmatchings/map2_s03", func_800CC74C);
 
-void func_800CC754(void) {
-}
+void func_800CC754(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s03/nonmatchings/map2_s03", func_800CC75C);
 
@@ -76,11 +70,8 @@ INCLUDE_ASM("asm/maps/map2_s03/nonmatchings/map2_s03", func_800CC7D0);
 
 INCLUDE_ASM("asm/maps/map2_s03/nonmatchings/map2_s03", func_800CCA1C);
 
-void func_800CCB24(void) {
-}
+void func_800CCB24(void) {}
 
-void func_800CCB2C(void) {
-}
+void func_800CCB2C(void) {}
 
-void func_800CCB34(void) {
-}
+void func_800CCB34(void) {}

--- a/src/maps/map2_s04/map2_s04.c
+++ b/src/maps/map2_s04/map2_s04.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map2_s04/nonmatchings/map2_s04", func_800CC9D0);
 
 INCLUDE_ASM("asm/maps/map2_s04/nonmatchings/map2_s04", func_800CC9E0);
 
-void func_800CC9EC(void) {
-}
+void func_800CC9EC(void) {}
 
-void func_800CC9F4(void) {
-}
+void func_800CC9F4(void) {}
 
-void func_800CC9FC(void) {
-}
+void func_800CC9FC(void) {}
 
-void func_800CCA04(void) {
-}
+void func_800CCA04(void) {}
 
-void func_800CCA0C(void) {
-}
+void func_800CCA0C(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s04/nonmatchings/map2_s04", func_800CCA14);
 
-void func_800CCA1C(void) {
-}
+void func_800CCA1C(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s04/nonmatchings/map2_s04", func_800CCA24);
 
@@ -80,8 +74,7 @@ INCLUDE_ASM("asm/maps/map2_s04/nonmatchings/map2_s04", func_800CCB64);
 
 INCLUDE_ASM("asm/maps/map2_s04/nonmatchings/map2_s04", func_800CCBE0);
 
-void func_800CCE6C(void) {
-}
+void func_800CCE6C(void) {}
 
 INCLUDE_ASM("asm/maps/map2_s04/nonmatchings/map2_s04", func_800CCE74);
 

--- a/src/maps/map3_s00/map3_s00.c
+++ b/src/maps/map3_s00/map3_s00.c
@@ -16,8 +16,7 @@ INCLUDE_ASM("asm/maps/map3_s00/nonmatchings/map3_s00", func_800CC994);
 
 INCLUDE_ASM("asm/maps/map3_s00/nonmatchings/map3_s00", func_800CCD5C);
 
-void func_800CCE88(void) {
-}
+void func_800CCE88(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s00/nonmatchings/map3_s00", func_800CCE90);
 
@@ -67,25 +66,19 @@ INCLUDE_ASM("asm/maps/map3_s00/nonmatchings/map3_s00", func_800CF164);
 
 INCLUDE_ASM("asm/maps/map3_s00/nonmatchings/map3_s00", func_800CF174);
 
-void func_800CF180(void) {
-}
+void func_800CF180(void) {}
 
-void func_800CF188(void) {
-}
+void func_800CF188(void) {}
 
-void func_800CF190(void) {
-}
+void func_800CF190(void) {}
 
-void func_800CF198(void) {
-}
+void func_800CF198(void) {}
 
-void func_800CF1A0(void) {
-}
+void func_800CF1A0(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s00/nonmatchings/map3_s00", func_800CF1A8);
 
-void func_800CF1B0(void) {
-}
+void func_800CF1B0(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s00/nonmatchings/map3_s00", func_800CF1B8);
 
@@ -143,15 +136,13 @@ INCLUDE_ASM("asm/maps/map3_s00/nonmatchings/map3_s00", func_800D0994);
 
 INCLUDE_ASM("asm/maps/map3_s00/nonmatchings/map3_s00", func_800D09D4);
 
-void func_800D0B74(void) {
-}
+void func_800D0B74(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s00/nonmatchings/map3_s00", func_800D0B7C);
 
 INCLUDE_ASM("asm/maps/map3_s00/nonmatchings/map3_s00", func_800D0C10);
 
-void func_800D0CA4(void) {
-}
+void func_800D0CA4(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s00/nonmatchings/map3_s00", func_800D0CAC);
 

--- a/src/maps/map3_s01/map3_s01.c
+++ b/src/maps/map3_s01/map3_s01.c
@@ -16,8 +16,7 @@ INCLUDE_ASM("asm/maps/map3_s01/nonmatchings/map3_s01", func_800CC7A0);
 
 INCLUDE_ASM("asm/maps/map3_s01/nonmatchings/map3_s01", func_800CCB68);
 
-void func_800CCC94(void) {
-}
+void func_800CCC94(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s01/nonmatchings/map3_s01", func_800CCC9C);
 
@@ -67,25 +66,19 @@ INCLUDE_ASM("asm/maps/map3_s01/nonmatchings/map3_s01", func_800CED94);
 
 INCLUDE_ASM("asm/maps/map3_s01/nonmatchings/map3_s01", func_800CEDA4);
 
-void func_800CEDB0(void) {
-}
+void func_800CEDB0(void) {}
 
-void func_800CEDB8(void) {
-}
+void func_800CEDB8(void) {}
 
-void func_800CEDC0(void) {
-}
+void func_800CEDC0(void) {}
 
-void func_800CEDC8(void) {
-}
+void func_800CEDC8(void) {}
 
-void func_800CEDD0(void) {
-}
+void func_800CEDD0(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s01/nonmatchings/map3_s01", func_800CEDD8);
 
-void func_800CEDE0(void) {
-}
+void func_800CEDE0(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s01/nonmatchings/map3_s01", func_800CEDE8);
 
@@ -127,8 +120,7 @@ INCLUDE_ASM("asm/maps/map3_s01/nonmatchings/map3_s01", func_800D11AC);
 
 INCLUDE_ASM("asm/maps/map3_s01/nonmatchings/map3_s01", func_800D11EC);
 
-void func_800D138C(void) {
-}
+void func_800D138C(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s01/nonmatchings/map3_s01", func_800D1394);
 

--- a/src/maps/map3_s02/map3_s02.c
+++ b/src/maps/map3_s02/map3_s02.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map3_s02/nonmatchings/map3_s02", func_800CC95C);
 
 INCLUDE_ASM("asm/maps/map3_s02/nonmatchings/map3_s02", func_800CC96C);
 
-void func_800CC978(void) {
-}
+void func_800CC978(void) {}
 
-void func_800CC980(void) {
-}
+void func_800CC980(void) {}
 
-void func_800CC988(void) {
-}
+void func_800CC988(void) {}
 
-void func_800CC990(void) {
-}
+void func_800CC990(void) {}
 
-void func_800CC998(void) {
-}
+void func_800CC998(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s02/nonmatchings/map3_s02", func_800CC9A0);
 
-void func_800CC9A8(void) {
-}
+void func_800CC9A8(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s02/nonmatchings/map3_s02", func_800CC9B0);
 
@@ -144,15 +138,13 @@ INCLUDE_ASM("asm/maps/map3_s02/nonmatchings/map3_s02", func_800CFEAC);
 
 INCLUDE_ASM("asm/maps/map3_s02/nonmatchings/map3_s02", func_800CFEEC);
 
-void func_800D017C(void) {
-}
+void func_800D017C(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s02/nonmatchings/map3_s02", func_800D0184);
 
 INCLUDE_ASM("asm/maps/map3_s02/nonmatchings/map3_s02", func_800D0218);
 
-void func_800D02AC(void) {
-}
+void func_800D02AC(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s02/nonmatchings/map3_s02", func_800D02B4);
 

--- a/src/maps/map3_s03/map3_s03.c
+++ b/src/maps/map3_s03/map3_s03.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map3_s03/nonmatchings/map3_s03", func_800CD5F8);
 
 INCLUDE_ASM("asm/maps/map3_s03/nonmatchings/map3_s03", func_800CD608);
 
-void func_800CD614(void) {
-}
+void func_800CD614(void) {}
 
-void func_800CD61C(void) {
-}
+void func_800CD61C(void) {}
 
-void func_800CD624(void) {
-}
+void func_800CD624(void) {}
 
-void func_800CD62C(void) {
-}
+void func_800CD62C(void) {}
 
-void func_800CD634(void) {
-}
+void func_800CD634(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s03/nonmatchings/map3_s03", func_800CD63C);
 
-void func_800CD644(void) {
-}
+void func_800CD644(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s03/nonmatchings/map3_s03", func_800CD64C);
 
@@ -176,8 +170,7 @@ INCLUDE_ASM("asm/maps/map3_s03/nonmatchings/map3_s03", func_800D1244);
 
 INCLUDE_ASM("asm/maps/map3_s03/nonmatchings/map3_s03", func_800D1284);
 
-void func_800D1514(void) {
-}
+void func_800D1514(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s03/nonmatchings/map3_s03", func_800D151C);
 

--- a/src/maps/map3_s04/map3_s04.c
+++ b/src/maps/map3_s04/map3_s04.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map3_s04/nonmatchings/map3_s04", func_800CD4BC);
 
 INCLUDE_ASM("asm/maps/map3_s04/nonmatchings/map3_s04", func_800CD4CC);
 
-void func_800CD4D8(void) {
-}
+void func_800CD4D8(void) {}
 
-void func_800CD4E0(void) {
-}
+void func_800CD4E0(void) {}
 
-void func_800CD4E8(void) {
-}
+void func_800CD4E8(void) {}
 
-void func_800CD4F0(void) {
-}
+void func_800CD4F0(void) {}
 
-void func_800CD4F8(void) {
-}
+void func_800CD4F8(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s04/nonmatchings/map3_s04", func_800CD500);
 
-void func_800CD508(void) {
-}
+void func_800CD508(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s04/nonmatchings/map3_s04", func_800CD510);
 
@@ -202,8 +196,7 @@ INCLUDE_ASM("asm/maps/map3_s04/nonmatchings/map3_s04", func_800D1E58);
 
 INCLUDE_ASM("asm/maps/map3_s04/nonmatchings/map3_s04", func_800D1E98);
 
-void func_800D2128(void) {
-}
+void func_800D2128(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s04/nonmatchings/map3_s04", func_800D2130);
 

--- a/src/maps/map3_s05/map3_s05.c
+++ b/src/maps/map3_s05/map3_s05.c
@@ -52,25 +52,19 @@ INCLUDE_ASM("asm/maps/map3_s05/nonmatchings/map3_s05", func_800CFDF4);
 
 INCLUDE_ASM("asm/maps/map3_s05/nonmatchings/map3_s05", func_800CFE04);
 
-void func_800CFE10(void) {
-}
+void func_800CFE10(void) {}
 
-void func_800CFE18(void) {
-}
+void func_800CFE18(void) {}
 
-void func_800CFE20(void) {
-}
+void func_800CFE20(void) {}
 
-void func_800CFE28(void) {
-}
+void func_800CFE28(void) {}
 
-void func_800CFE30(void) {
-}
+void func_800CFE30(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s05/nonmatchings/map3_s05", func_800CFE38);
 
-void func_800CFE40(void) {
-}
+void func_800CFE40(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s05/nonmatchings/map3_s05", func_800CFE48);
 
@@ -194,8 +188,7 @@ INCLUDE_ASM("asm/maps/map3_s05/nonmatchings/map3_s05", func_800D5510);
 
 INCLUDE_ASM("asm/maps/map3_s05/nonmatchings/map3_s05", func_800D5550);
 
-void func_800D57E0(void) {
-}
+void func_800D57E0(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s05/nonmatchings/map3_s05", func_800D57E8);
 

--- a/src/maps/map3_s06/map3_s06.c
+++ b/src/maps/map3_s06/map3_s06.c
@@ -16,8 +16,7 @@ INCLUDE_ASM("asm/maps/map3_s06/nonmatchings/map3_s06", func_800CC86C);
 
 INCLUDE_ASM("asm/maps/map3_s06/nonmatchings/map3_s06", func_800CCC34);
 
-void func_800CCD60(void) {
-}
+void func_800CCD60(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s06/nonmatchings/map3_s06", func_800CCD68);
 
@@ -67,25 +66,19 @@ INCLUDE_ASM("asm/maps/map3_s06/nonmatchings/map3_s06", func_800CF040);
 
 INCLUDE_ASM("asm/maps/map3_s06/nonmatchings/map3_s06", func_800CF050);
 
-void func_800CF05C(void) {
-}
+void func_800CF05C(void) {}
 
-void func_800CF064(void) {
-}
+void func_800CF064(void) {}
 
-void func_800CF06C(void) {
-}
+void func_800CF06C(void) {}
 
-void func_800CF074(void) {
-}
+void func_800CF074(void) {}
 
-void func_800CF07C(void) {
-}
+void func_800CF07C(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s06/nonmatchings/map3_s06", func_800CF084);
 
-void func_800CF08C(void) {
-}
+void func_800CF08C(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s06/nonmatchings/map3_s06", func_800CF094);
 
@@ -143,15 +136,13 @@ INCLUDE_ASM("asm/maps/map3_s06/nonmatchings/map3_s06", func_800D07D4);
 
 INCLUDE_ASM("asm/maps/map3_s06/nonmatchings/map3_s06", func_800D0814);
 
-void func_800D09B4(void) {
-}
+void func_800D09B4(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s06/nonmatchings/map3_s06", func_800D09BC);
 
 INCLUDE_ASM("asm/maps/map3_s06/nonmatchings/map3_s06", func_800D0A50);
 
-void func_800D0AE4(void) {
-}
+void func_800D0AE4(void) {}
 
 INCLUDE_ASM("asm/maps/map3_s06/nonmatchings/map3_s06", func_800D0AEC);
 

--- a/src/maps/map4_s00/map4_s00.c
+++ b/src/maps/map4_s00/map4_s00.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map4_s00/nonmatchings/map4_s00", func_800CC6D8);
 
 INCLUDE_ASM("asm/maps/map4_s00/nonmatchings/map4_s00", func_800CC6E8);
 
-void func_800CC6F4(void) {
-}
+void func_800CC6F4(void) {}
 
-void func_800CC6FC(void) {
-}
+void func_800CC6FC(void) {}
 
-void func_800CC704(void) {
-}
+void func_800CC704(void) {}
 
-void func_800CC70C(void) {
-}
+void func_800CC70C(void) {}
 
-void func_800CC714(void) {
-}
+void func_800CC714(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s00/nonmatchings/map4_s00", func_800CC71C);
 
-void func_800CC724(void) {
-}
+void func_800CC724(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s00/nonmatchings/map4_s00", func_800CC72C);
 
@@ -76,11 +70,8 @@ INCLUDE_ASM("asm/maps/map4_s00/nonmatchings/map4_s00", func_800CC7A0);
 
 INCLUDE_ASM("asm/maps/map4_s00/nonmatchings/map4_s00", func_800CC99C);
 
-void func_800CCA88(void) {
-}
+void func_800CCA88(void) {}
 
-void func_800CCA90(void) {
-}
+void func_800CCA90(void) {}
 
-void func_800CCA98(void) {
-}
+void func_800CCA98(void) {}

--- a/src/maps/map4_s01/map4_s01.c
+++ b/src/maps/map4_s01/map4_s01.c
@@ -52,25 +52,19 @@ INCLUDE_ASM("asm/maps/map4_s01/nonmatchings/map4_s01", func_800CFD38);
 
 INCLUDE_ASM("asm/maps/map4_s01/nonmatchings/map4_s01", func_800CFD48);
 
-void func_800CFD54(void) {
-}
+void func_800CFD54(void) {}
 
-void func_800CFD5C(void) {
-}
+void func_800CFD5C(void) {}
 
-void func_800CFD64(void) {
-}
+void func_800CFD64(void) {}
 
-void func_800CFD6C(void) {
-}
+void func_800CFD6C(void) {}
 
-void func_800CFD74(void) {
-}
+void func_800CFD74(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s01/nonmatchings/map4_s01", func_800CFD7C);
 
-void func_800CFD84(void) {
-}
+void func_800CFD84(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s01/nonmatchings/map4_s01", func_800CFD8C);
 
@@ -128,15 +122,13 @@ INCLUDE_ASM("asm/maps/map4_s01/nonmatchings/map4_s01", func_800D1BAC);
 
 INCLUDE_ASM("asm/maps/map4_s01/nonmatchings/map4_s01", func_800D1C28);
 
-void func_800D1EB4(void) {
-}
+void func_800D1EB4(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s01/nonmatchings/map4_s01", func_800D1EBC);
 
 INCLUDE_ASM("asm/maps/map4_s01/nonmatchings/map4_s01", func_800D1F54);
 
-void func_800D1FE8(void) {
-}
+void func_800D1FE8(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s01/nonmatchings/map4_s01", func_800D1FF0);
 

--- a/src/maps/map4_s02/map4_s02.c
+++ b/src/maps/map4_s02/map4_s02.c
@@ -18,8 +18,7 @@ INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800CE258);
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800CE32C);
 
-void func_800CE478(void) {
-}
+void func_800CE478(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800CE480);
 
@@ -71,20 +70,15 @@ INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800D05FC);
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800D060C);
 
-void func_800D0618(void) {
-}
+void func_800D0618(void) {}
 
-void func_800D0620(void) {
-}
+void func_800D0620(void) {}
 
-void func_800D0628(void) {
-}
+void func_800D0628(void) {}
 
-void func_800D0630(void) {
-}
+void func_800D0630(void) {}
 
-void func_800D0638(void) {
-}
+void func_800D0638(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800D0640);
 
@@ -238,23 +232,17 @@ INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800DA59C);
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800DA9D0);
 
-void func_800DAAD0(void) {
-}
+void func_800DAAD0(void) {}
 
-void func_800DAAD8(void) {
-}
+void func_800DAAD8(void) {}
 
-void func_800DAAE0(void) {
-}
+void func_800DAAE0(void) {}
 
-void func_800DAAE8(void) {
-}
+void func_800DAAE8(void) {}
 
-void func_800DAAF0(void) {
-}
+void func_800DAAF0(void) {}
 
-void func_800DAAF8(void) {
-}
+void func_800DAAF8(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800DAB00);
 
@@ -432,8 +420,7 @@ INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800E1600);
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800E1A5C);
 
-void func_800E1B44(void) {
-}
+void func_800E1B44(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800E1B4C);
 
@@ -495,8 +482,7 @@ INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800E8554);
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800E87D0);
 
-void func_800E8874(void) {
-}
+void func_800E8874(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800E887C);
 
@@ -520,15 +506,13 @@ INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800E9D38);
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800E9F34);
 
-void func_800EA208(void) {
-}
+void func_800EA208(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800EA210);
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800EA2A4);
 
-void func_800EA338(void) {
-}
+void func_800EA338(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", func_800EA340);
 

--- a/src/maps/map4_s03/map4_s03.c
+++ b/src/maps/map4_s03/map4_s03.c
@@ -24,8 +24,7 @@ INCLUDE_ASM("asm/maps/map4_s03/nonmatchings/map4_s03", func_800CDD74);
 
 INCLUDE_ASM("asm/maps/map4_s03/nonmatchings/map4_s03", func_800CE058);
 
-void func_800CE12C(void) {
-}
+void func_800CE12C(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s03/nonmatchings/map4_s03", func_800CE134);
 
@@ -77,25 +76,19 @@ INCLUDE_ASM("asm/maps/map4_s03/nonmatchings/map4_s03", func_800D0404);
 
 INCLUDE_ASM("asm/maps/map4_s03/nonmatchings/map4_s03", func_800D0414);
 
-void func_800D0420(void) {
-}
+void func_800D0420(void) {}
 
-void func_800D0428(void) {
-}
+void func_800D0428(void) {}
 
-void func_800D0430(void) {
-}
+void func_800D0430(void) {}
 
-void func_800D0438(void) {
-}
+void func_800D0438(void) {}
 
-void func_800D0440(void) {
-}
+void func_800D0440(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s03/nonmatchings/map4_s03", func_800D0448);
 
-void func_800D0450(void) {
-}
+void func_800D0450(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s03/nonmatchings/map4_s03", func_800D0458);
 
@@ -307,8 +300,7 @@ INCLUDE_ASM("asm/maps/map4_s03/nonmatchings/map4_s03", func_800D607C);
 
 INCLUDE_ASM("asm/maps/map4_s03/nonmatchings/map4_s03", func_800D6278);
 
-void func_800D654C(void) {
-}
+void func_800D654C(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s03/nonmatchings/map4_s03", func_800D6554);
 

--- a/src/maps/map4_s04/map4_s04.c
+++ b/src/maps/map4_s04/map4_s04.c
@@ -18,8 +18,7 @@ INCLUDE_ASM("asm/maps/map4_s04/nonmatchings/map4_s04", func_800CD4E0);
 
 INCLUDE_ASM("asm/maps/map4_s04/nonmatchings/map4_s04", func_800CD5A0);
 
-void func_800CD6EC(void) {
-}
+void func_800CD6EC(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s04/nonmatchings/map4_s04", func_800CD6F4);
 
@@ -69,25 +68,19 @@ INCLUDE_ASM("asm/maps/map4_s04/nonmatchings/map4_s04", func_800CFDE8);
 
 INCLUDE_ASM("asm/maps/map4_s04/nonmatchings/map4_s04", func_800CFDF8);
 
-void func_800CFE04(void) {
-}
+void func_800CFE04(void) {}
 
-void func_800CFE0C(void) {
-}
+void func_800CFE0C(void) {}
 
-void func_800CFE14(void) {
-}
+void func_800CFE14(void) {}
 
-void func_800CFE1C(void) {
-}
+void func_800CFE1C(void) {}
 
-void func_800CFE24(void) {
-}
+void func_800CFE24(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s04/nonmatchings/map4_s04", func_800CFE2C);
 
-void func_800CFE34(void) {
-}
+void func_800CFE34(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s04/nonmatchings/map4_s04", func_800CFE3C);
 
@@ -145,15 +138,13 @@ INCLUDE_ASM("asm/maps/map4_s04/nonmatchings/map4_s04", func_800D1470);
 
 INCLUDE_ASM("asm/maps/map4_s04/nonmatchings/map4_s04", func_800D14B0);
 
-void func_800D1740(void) {
-}
+void func_800D1740(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s04/nonmatchings/map4_s04", func_800D1748);
 
 INCLUDE_ASM("asm/maps/map4_s04/nonmatchings/map4_s04", func_800D17DC);
 
-void func_800D1870(void) {
-}
+void func_800D1870(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s04/nonmatchings/map4_s04", func_800D1878);
 

--- a/src/maps/map4_s05/map4_s05.c
+++ b/src/maps/map4_s05/map4_s05.c
@@ -30,8 +30,7 @@ INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800CE2FC);
 
 INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800CE3BC);
 
-void func_800CE508(void) {
-}
+void func_800CE508(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800CE510);
 
@@ -81,25 +80,19 @@ INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D1644);
 
 INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D1654);
 
-void func_800D1660(void) {
-}
+void func_800D1660(void) {}
 
-void func_800D1668(void) {
-}
+void func_800D1668(void) {}
 
-void func_800D1670(void) {
-}
+void func_800D1670(void) {}
 
-void func_800D1678(void) {
-}
+void func_800D1678(void) {}
 
-void func_800D1680(void) {
-}
+void func_800D1680(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D1688);
 
-void func_800D1690(void) {
-}
+void func_800D1690(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D1698);
 
@@ -119,8 +112,7 @@ INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D1BF8);
 
 INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D2B90);
 
-void func_800D341C(void) {
-}
+void func_800D341C(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D3424);
 
@@ -148,8 +140,7 @@ INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D5B0C);
 
 INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D5D08);
 
-void func_800D5FDC(void) {
-}
+void func_800D5FDC(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D5FE4);
 
@@ -157,8 +148,7 @@ INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D607C);
 
 INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D6110);
 
-void func_800D61A4(void) {
-}
+void func_800D61A4(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s05/nonmatchings/map4_s05", func_800D61AC);
 

--- a/src/maps/map4_s06/map4_s06.c
+++ b/src/maps/map4_s06/map4_s06.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map4_s06/nonmatchings/map4_s06", func_800CC6D8);
 
 INCLUDE_ASM("asm/maps/map4_s06/nonmatchings/map4_s06", func_800CC6E8);
 
-void func_800CC6F4(void) {
-}
+void func_800CC6F4(void) {}
 
-void func_800CC6FC(void) {
-}
+void func_800CC6FC(void) {}
 
-void func_800CC704(void) {
-}
+void func_800CC704(void) {}
 
-void func_800CC70C(void) {
-}
+void func_800CC70C(void) {}
 
-void func_800CC714(void) {
-}
+void func_800CC714(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s06/nonmatchings/map4_s06", func_800CC71C);
 
-void func_800CC724(void) {
-}
+void func_800CC724(void) {}
 
 INCLUDE_ASM("asm/maps/map4_s06/nonmatchings/map4_s06", func_800CC72C);
 
@@ -76,11 +70,8 @@ INCLUDE_ASM("asm/maps/map4_s06/nonmatchings/map4_s06", func_800CC7A0);
 
 INCLUDE_ASM("asm/maps/map4_s06/nonmatchings/map4_s06", func_800CC99C);
 
-void func_800CCA88(void) {
-}
+void func_800CCA88(void) {}
 
-void func_800CCA90(void) {
-}
+void func_800CCA90(void) {}
 
-void func_800CCA98(void) {
-}
+void func_800CCA98(void) {}

--- a/src/maps/map5_s00/map5_s00.c
+++ b/src/maps/map5_s00/map5_s00.c
@@ -22,8 +22,7 @@ INCLUDE_ASM("asm/maps/map5_s00/nonmatchings/map5_s00", func_800CD5C0);
 
 INCLUDE_ASM("asm/maps/map5_s00/nonmatchings/map5_s00", func_800CD680);
 
-void func_800CD7CC(void) {
-}
+void func_800CD7CC(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s00/nonmatchings/map5_s00", func_800CD7D4);
 
@@ -73,25 +72,19 @@ INCLUDE_ASM("asm/maps/map5_s00/nonmatchings/map5_s00", func_800CFB6C);
 
 INCLUDE_ASM("asm/maps/map5_s00/nonmatchings/map5_s00", func_800CFB7C);
 
-void func_800CFB88(void) {
-}
+void func_800CFB88(void) {}
 
-void func_800CFB90(void) {
-}
+void func_800CFB90(void) {}
 
-void func_800CFB98(void) {
-}
+void func_800CFB98(void) {}
 
-void func_800CFBA0(void) {
-}
+void func_800CFBA0(void) {}
 
-void func_800CFBA8(void) {
-}
+void func_800CFBA8(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s00/nonmatchings/map5_s00", func_800CFBB0);
 
-void func_800CFBB8(void) {
-}
+void func_800CFBB8(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s00/nonmatchings/map5_s00", func_800CFBC0);
 
@@ -201,8 +194,7 @@ INCLUDE_ASM("asm/maps/map5_s00/nonmatchings/map5_s00", func_800D6508);
 
 INCLUDE_ASM("asm/maps/map5_s00/nonmatchings/map5_s00", func_800D6790);
 
-void func_800D67EC(void) {
-}
+void func_800D67EC(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s00/nonmatchings/map5_s00", func_800D67F4);
 

--- a/src/maps/map5_s01/map5_s01.c
+++ b/src/maps/map5_s01/map5_s01.c
@@ -36,8 +36,7 @@ INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800CF870);
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800CFC38);
 
-void func_800CFD64(void) {
-}
+void func_800CFD64(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800CFD6C);
 
@@ -87,20 +86,15 @@ INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800D1D34);
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800D1D44);
 
-void func_800D1D50(void) {
-}
+void func_800D1D50(void) {}
 
-void func_800D1D58(void) {
-}
+void func_800D1D58(void) {}
 
-void func_800D1D60(void) {
-}
+void func_800D1D60(void) {}
 
-void func_800D1D68(void) {
-}
+void func_800D1D68(void) {}
 
-void func_800D1D70(void) {
-}
+void func_800D1D70(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800D1D78);
 
@@ -254,23 +248,17 @@ INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800DBCD4);
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800DC108);
 
-void func_800DC208(void) {
-}
+void func_800DC208(void) {}
 
-void func_800DC210(void) {
-}
+void func_800DC210(void) {}
 
-void func_800DC218(void) {
-}
+void func_800DC218(void) {}
 
-void func_800DC220(void) {
-}
+void func_800DC220(void) {}
 
-void func_800DC228(void) {
-}
+void func_800DC228(void) {}
 
-void func_800DC230(void) {
-}
+void func_800DC230(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800DC238);
 
@@ -448,8 +436,7 @@ INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800E2D38);
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800E3194);
 
-void func_800E327C(void) {
-}
+void func_800E327C(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800E3284);
 
@@ -511,8 +498,7 @@ INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800E9C8C);
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800E9F08);
 
-void func_800E9FAC(void) {
-}
+void func_800E9FAC(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800E9FB4);
 
@@ -536,8 +522,7 @@ INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800EB470);
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800EB6B0);
 
-void func_800EB874(void) {
-}
+void func_800EB874(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", func_800EB87C);
 

--- a/src/maps/map5_s02/map5_s02.c
+++ b/src/maps/map5_s02/map5_s02.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800CDB50);
 
 INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800CDB60);
 
-void func_800CDB6C(void) {
-}
+void func_800CDB6C(void) {}
 
-void func_800CDB74(void) {
-}
+void func_800CDB74(void) {}
 
-void func_800CDB7C(void) {
-}
+void func_800CDB7C(void) {}
 
-void func_800CDB84(void) {
-}
+void func_800CDB84(void) {}
 
-void func_800CDB8C(void) {
-}
+void func_800CDB8C(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800CDB94);
 
-void func_800CDB9C(void) {
-}
+void func_800CDB9C(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800CDBA4);
 
@@ -78,8 +72,7 @@ INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800CE008);
 
 INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800CE844);
 
-void func_800CEBF4(void) {
-}
+void func_800CEBF4(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800CEBFC);
 
@@ -97,8 +90,7 @@ INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800D0E6C);
 
 INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800D1270);
 
-void func_800D143C(void) {
-}
+void func_800D143C(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800D1444);
 
@@ -164,8 +156,7 @@ INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800D45E8);
 
 INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800D4664);
 
-void func_800D48F0(void) {
-}
+void func_800D48F0(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s02/nonmatchings/map5_s02", func_800D48F8);
 

--- a/src/maps/map5_s03/map5_s03.c
+++ b/src/maps/map5_s03/map5_s03.c
@@ -16,8 +16,7 @@ INCLUDE_ASM("asm/maps/map5_s03/nonmatchings/map5_s03", func_800CCD54);
 
 INCLUDE_ASM("asm/maps/map5_s03/nonmatchings/map5_s03", func_800CD11C);
 
-void func_800CD248(void) {
-}
+void func_800CD248(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s03/nonmatchings/map5_s03", func_800CD250);
 
@@ -67,25 +66,19 @@ INCLUDE_ASM("asm/maps/map5_s03/nonmatchings/map5_s03", func_800CF824);
 
 INCLUDE_ASM("asm/maps/map5_s03/nonmatchings/map5_s03", func_800CF834);
 
-void func_800CF840(void) {
-}
+void func_800CF840(void) {}
 
-void func_800CF848(void) {
-}
+void func_800CF848(void) {}
 
-void func_800CF850(void) {
-}
+void func_800CF850(void) {}
 
-void func_800CF858(void) {
-}
+void func_800CF858(void) {}
 
-void func_800CF860(void) {
-}
+void func_800CF860(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s03/nonmatchings/map5_s03", func_800CF868);
 
-void func_800CF870(void) {
-}
+void func_800CF870(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s03/nonmatchings/map5_s03", func_800CF878);
 
@@ -143,8 +136,7 @@ INCLUDE_ASM("asm/maps/map5_s03/nonmatchings/map5_s03", func_800D1038);
 
 INCLUDE_ASM("asm/maps/map5_s03/nonmatchings/map5_s03", func_800D10B4);
 
-void func_800D1340(void) {
-}
+void func_800D1340(void) {}
 
 INCLUDE_ASM("asm/maps/map5_s03/nonmatchings/map5_s03", func_800D1348);
 

--- a/src/maps/map6_s00/map6_s00.c
+++ b/src/maps/map6_s00/map6_s00.c
@@ -20,8 +20,7 @@ INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800CECDC);
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800CEDF0);
 
-void func_800CEF3C(void) {
-}
+void func_800CEF3C(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800CEF44);
 
@@ -71,20 +70,15 @@ INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800D13D4);
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800D13E4);
 
-void func_800D13F0(void) {
-}
+void func_800D13F0(void) {}
 
-void func_800D13F8(void) {
-}
+void func_800D13F8(void) {}
 
-void func_800D1400(void) {
-}
+void func_800D1400(void) {}
 
-void func_800D1408(void) {
-}
+void func_800D1408(void) {}
 
-void func_800D1410(void) {
-}
+void func_800D1410(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800D1418);
 
@@ -238,23 +232,17 @@ INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800DB374);
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800DB7A8);
 
-void func_800DB8A8(void) {
-}
+void func_800DB8A8(void) {}
 
-void func_800DB8B0(void) {
-}
+void func_800DB8B0(void) {}
 
-void func_800DB8B8(void) {
-}
+void func_800DB8B8(void) {}
 
-void func_800DB8C0(void) {
-}
+void func_800DB8C0(void) {}
 
-void func_800DB8C8(void) {
-}
+void func_800DB8C8(void) {}
 
-void func_800DB8D0(void) {
-}
+void func_800DB8D0(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800DB8D8);
 
@@ -432,8 +420,7 @@ INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800E23D8);
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800E2834);
 
-void func_800E291C(void) {
-}
+void func_800E291C(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800E2924);
 
@@ -495,8 +482,7 @@ INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800E932C);
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800E95A8);
 
-void func_800E964C(void) {
-}
+void func_800E964C(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800E9654);
 
@@ -520,8 +506,7 @@ INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800EAB10);
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800EAD0C);
 
-void func_800EAFF0(void) {
-}
+void func_800EAFF0(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", func_800EAFF8);
 

--- a/src/maps/map6_s01/map6_s01.c
+++ b/src/maps/map6_s01/map6_s01.c
@@ -48,25 +48,19 @@ INCLUDE_ASM("asm/maps/map6_s01/nonmatchings/map6_s01", func_800CE444);
 
 INCLUDE_ASM("asm/maps/map6_s01/nonmatchings/map6_s01", func_800CE454);
 
-void func_800CE460(void) {
-}
+void func_800CE460(void) {}
 
-void func_800CE468(void) {
-}
+void func_800CE468(void) {}
 
-void func_800CE470(void) {
-}
+void func_800CE470(void) {}
 
-void func_800CE478(void) {
-}
+void func_800CE478(void) {}
 
-void func_800CE480(void) {
-}
+void func_800CE480(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s01/nonmatchings/map6_s01", func_800CE488);
 
-void func_800CE490(void) {
-}
+void func_800CE490(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s01/nonmatchings/map6_s01", func_800CE498);
 
@@ -134,8 +128,7 @@ INCLUDE_ASM("asm/maps/map6_s01/nonmatchings/map6_s01", func_800D0EAC);
 
 INCLUDE_ASM("asm/maps/map6_s01/nonmatchings/map6_s01", func_800D0EF8);
 
-void func_800D1184(void) {
-}
+void func_800D1184(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s01/nonmatchings/map6_s01", func_800D118C);
 

--- a/src/maps/map6_s02/map6_s02.c
+++ b/src/maps/map6_s02/map6_s02.c
@@ -48,25 +48,19 @@ INCLUDE_ASM("asm/maps/map6_s02/nonmatchings/map6_s02", func_800CD67C);
 
 INCLUDE_ASM("asm/maps/map6_s02/nonmatchings/map6_s02", func_800CD68C);
 
-void func_800CD698(void) {
-}
+void func_800CD698(void) {}
 
-void func_800CD6A0(void) {
-}
+void func_800CD6A0(void) {}
 
-void func_800CD6A8(void) {
-}
+void func_800CD6A8(void) {}
 
-void func_800CD6B0(void) {
-}
+void func_800CD6B0(void) {}
 
-void func_800CD6B8(void) {
-}
+void func_800CD6B8(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s02/nonmatchings/map6_s02", func_800CD6C0);
 
-void func_800CD6C8(void) {
-}
+void func_800CD6C8(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s02/nonmatchings/map6_s02", func_800CD6D0);
 
@@ -120,8 +114,7 @@ INCLUDE_ASM("asm/maps/map6_s02/nonmatchings/map6_s02", func_800CE88C);
 
 INCLUDE_ASM("asm/maps/map6_s02/nonmatchings/map6_s02", func_800CEA88);
 
-void func_800CED6C(void) {
-}
+void func_800CED6C(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s02/nonmatchings/map6_s02", func_800CED74);
 
@@ -129,8 +122,7 @@ INCLUDE_ASM("asm/maps/map6_s02/nonmatchings/map6_s02", func_800CEF88);
 
 INCLUDE_ASM("asm/maps/map6_s02/nonmatchings/map6_s02", func_800CF01C);
 
-void func_800CF0B0(void) {
-}
+void func_800CF0B0(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s02/nonmatchings/map6_s02", func_800CF0B8);
 

--- a/src/maps/map6_s03/map6_s03.c
+++ b/src/maps/map6_s03/map6_s03.c
@@ -18,8 +18,7 @@ INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800CCB00);
 
 INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800CCBC0);
 
-void func_800CCD0C(void) {
-}
+void func_800CCD0C(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800CCD14);
 
@@ -69,25 +68,19 @@ INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800CEF14);
 
 INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800CEF24);
 
-void func_800CEF30(void) {
-}
+void func_800CEF30(void) {}
 
-void func_800CEF38(void) {
-}
+void func_800CEF38(void) {}
 
-void func_800CEF40(void) {
-}
+void func_800CEF40(void) {}
 
-void func_800CEF48(void) {
-}
+void func_800CEF48(void) {}
 
-void func_800CEF50(void) {
-}
+void func_800CEF50(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800CEF58);
 
-void func_800CEF60(void) {
-}
+void func_800CEF60(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800CEF68);
 
@@ -103,8 +96,7 @@ INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800CF414);
 
 INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800CFC50);
 
-void func_800D0000(void) {
-}
+void func_800D0000(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800D0008);
 
@@ -122,8 +114,7 @@ INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800D2278);
 
 INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800D267C);
 
-void func_800D27F8(void) {
-}
+void func_800D27F8(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800D2800);
 
@@ -195,8 +186,7 @@ INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800D7F24);
 
 INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800D7F98);
 
-void func_800D81A4(void) {
-}
+void func_800D81A4(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800D81AC);
 
@@ -210,5 +200,4 @@ INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800D8818);
 
 INCLUDE_ASM("asm/maps/map6_s03/nonmatchings/map6_s03", func_800D89A0);
 
-void func_800D936C(void) {
-}
+void func_800D936C(void) {}

--- a/src/maps/map6_s04/map6_s04.c
+++ b/src/maps/map6_s04/map6_s04.c
@@ -52,24 +52,19 @@ INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800CFFA8);
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800CFFB8);
 
-void func_800CFFC4(void) {
-}
+void func_800CFFC4(void) {}
 
-void func_800CFFCC(void) {
-}
+void func_800CFFCC(void) {}
 
-void func_800CFFD4(void) {
-}
+void func_800CFFD4(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800CFFDC);
 
-void func_800D003C(void) {
-}
+void func_800D003C(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800D0044);
 
-void func_800D004C(void) {
-}
+void func_800D004C(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800D0054);
 
@@ -99,8 +94,7 @@ INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800D3960);
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800D419C);
 
-void func_800D454C(void) {
-}
+void func_800D454C(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800D4554);
 
@@ -118,8 +112,7 @@ INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800D67C4);
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800D6BC8);
 
-void func_800D6D44(void) {
-}
+void func_800D6D44(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800D6D4C);
 
@@ -155,8 +148,7 @@ INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800D9790);
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800D99E4);
 
-void func_800D9AAC(void) {
-}
+void func_800D9AAC(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800D9AB4);
 
@@ -234,8 +226,7 @@ INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800DE0C4);
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800DE1CC);
 
-void func_800DE26C(void) {
-}
+void func_800DE26C(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800DE274);
 
@@ -351,8 +342,7 @@ INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800E1290);
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800E12D0);
 
-void func_800E155C(void) {
-}
+void func_800E155C(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800E1564);
 
@@ -360,8 +350,7 @@ INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800E15FC);
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800E1CA0);
 
-void func_800E1D48(void) {
-}
+void func_800E1D48(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s04/nonmatchings/map6_s04", func_800E1D50);
 

--- a/src/maps/map6_s05/map6_s05.c
+++ b/src/maps/map6_s05/map6_s05.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map6_s05/nonmatchings/map6_s05", func_800CC6EC);
 
 INCLUDE_ASM("asm/maps/map6_s05/nonmatchings/map6_s05", func_800CC6FC);
 
-void func_800CC708(void) {
-}
+void func_800CC708(void) {}
 
-void func_800CC710(void) {
-}
+void func_800CC710(void) {}
 
-void func_800CC718(void) {
-}
+void func_800CC718(void) {}
 
-void func_800CC720(void) {
-}
+void func_800CC720(void) {}
 
-void func_800CC728(void) {
-}
+void func_800CC728(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s05/nonmatchings/map6_s05", func_800CC730);
 
-void func_800CC738(void) {
-}
+void func_800CC738(void) {}
 
 INCLUDE_ASM("asm/maps/map6_s05/nonmatchings/map6_s05", func_800CC740);
 
@@ -80,5 +74,4 @@ INCLUDE_ASM("asm/maps/map6_s05/nonmatchings/map6_s05", func_800CC930);
 
 INCLUDE_ASM("asm/maps/map6_s05/nonmatchings/map6_s05", func_800CC970);
 
-void func_800CCBFC(void) {
-}
+void func_800CCBFC(void) {}

--- a/src/maps/map7_s00/map7_s00.c
+++ b/src/maps/map7_s00/map7_s00.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map7_s00/nonmatchings/map7_s00", func_800CE980);
 
 INCLUDE_ASM("asm/maps/map7_s00/nonmatchings/map7_s00", func_800CE990);
 
-void func_800CE99C(void) {
-}
+void func_800CE99C(void) {}
 
-void func_800CE9A4(void) {
-}
+void func_800CE9A4(void) {}
 
-void func_800CE9AC(void) {
-}
+void func_800CE9AC(void) {}
 
-void func_800CE9B4(void) {
-}
+void func_800CE9B4(void) {}
 
-void func_800CE9BC(void) {
-}
+void func_800CE9BC(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s00/nonmatchings/map7_s00", func_800CE9C4);
 
-void func_800CE9CC(void) {
-}
+void func_800CE9CC(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s00/nonmatchings/map7_s00", func_800CE9D4);
 
@@ -124,15 +118,13 @@ INCLUDE_ASM("asm/maps/map7_s00/nonmatchings/map7_s00", func_800D00D0);
 
 INCLUDE_ASM("asm/maps/map7_s00/nonmatchings/map7_s00", func_800D0110);
 
-void func_800D0994(void) {
-}
+void func_800D0994(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s00/nonmatchings/map7_s00", func_800D099C);
 
 INCLUDE_ASM("asm/maps/map7_s00/nonmatchings/map7_s00", func_800D0A30);
 
-void func_800D0AC4(void) {
-}
+void func_800D0AC4(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s00/nonmatchings/map7_s00", func_800D0ACC);
 

--- a/src/maps/map7_s01/map7_s01.c
+++ b/src/maps/map7_s01/map7_s01.c
@@ -48,25 +48,19 @@ INCLUDE_ASM("asm/maps/map7_s01/nonmatchings/map7_s01", func_800D15EC);
 
 INCLUDE_ASM("asm/maps/map7_s01/nonmatchings/map7_s01", func_800D15FC);
 
-void func_800D1608(void) {
-}
+void func_800D1608(void) {}
 
-void func_800D1610(void) {
-}
+void func_800D1610(void) {}
 
-void func_800D1618(void) {
-}
+void func_800D1618(void) {}
 
-void func_800D1620(void) {
-}
+void func_800D1620(void) {}
 
-void func_800D1628(void) {
-}
+void func_800D1628(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s01/nonmatchings/map7_s01", func_800D1630);
 
-void func_800D1638(void) {
-}
+void func_800D1638(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s01/nonmatchings/map7_s01", func_800D1640);
 
@@ -230,8 +224,7 @@ INCLUDE_ASM("asm/maps/map7_s01/nonmatchings/map7_s01", func_800D68F8);
 
 INCLUDE_ASM("asm/maps/map7_s01/nonmatchings/map7_s01", func_800D6938);
 
-void func_800D71BC(void) {
-}
+void func_800D71BC(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s01/nonmatchings/map7_s01", func_800D71C4);
 

--- a/src/maps/map7_s02/map7_s02.c
+++ b/src/maps/map7_s02/map7_s02.c
@@ -44,25 +44,19 @@ INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D0640);
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D0650);
 
-void func_800D065C(void) {
-}
+void func_800D065C(void) {}
 
-void func_800D0664(void) {
-}
+void func_800D0664(void) {}
 
-void func_800D066C(void) {
-}
+void func_800D066C(void) {}
 
-void func_800D0674(void) {
-}
+void func_800D0674(void) {}
 
-void func_800D067C(void) {
-}
+void func_800D067C(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D0684);
 
-void func_800D068C(void) {
-}
+void func_800D068C(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D0694);
 
@@ -78,8 +72,7 @@ INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D0AF8);
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D1334);
 
-void func_800D16E4(void) {
-}
+void func_800D16E4(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D16EC);
 
@@ -97,8 +90,7 @@ INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D395C);
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D3D60);
 
-void func_800D3F2C(void) {
-}
+void func_800D3F2C(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D3F34);
 
@@ -140,13 +132,11 @@ INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D6B8C);
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D6C20);
 
-void func_800D6C38(void) {
-}
+void func_800D6C38(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D6C40);
 
-void func_800D6C8C(void) {
-}
+void func_800D6C8C(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D6C94);
 
@@ -234,8 +224,7 @@ INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D98E4);
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800D9924);
 
-void func_800DA1A8(void) {
-}
+void func_800DA1A8(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800DA1B0);
 
@@ -269,8 +258,7 @@ INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800DC14C);
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800DC778);
 
-void func_800DC94C(void) {
-}
+void func_800DC94C(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800DC954);
 
@@ -284,8 +272,7 @@ INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800DDEC8);
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800DE1FC);
 
-void func_800DF1E8(void) {
-}
+void func_800DF1E8(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s02/nonmatchings/map7_s02", func_800DF1F0);
 

--- a/src/maps/map7_s03/map7_s03.c
+++ b/src/maps/map7_s03/map7_s03.c
@@ -64,25 +64,19 @@ INCLUDE_ASM("asm/maps/map7_s03/nonmatchings/map7_s03", func_800D0FE0);
 
 INCLUDE_ASM("asm/maps/map7_s03/nonmatchings/map7_s03", func_800D0FF0);
 
-void func_800D0FFC(void) {
-}
+void func_800D0FFC(void) {}
 
-void func_800D1004(void) {
-}
+void func_800D1004(void) {}
 
-void func_800D100C(void) {
-}
+void func_800D100C(void) {}
 
-void func_800D1014(void) {
-}
+void func_800D1014(void) {}
 
-void func_800D101C(void) {
-}
+void func_800D101C(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s03/nonmatchings/map7_s03", func_800D1024);
 
-void func_800D102C(void) {
-}
+void func_800D102C(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s03/nonmatchings/map7_s03", func_800D1034);
 
@@ -296,8 +290,7 @@ INCLUDE_ASM("asm/maps/map7_s03/nonmatchings/map7_s03", func_800D87D4);
 
 INCLUDE_ASM("asm/maps/map7_s03/nonmatchings/map7_s03", func_800D8858);
 
-void func_800D88C4(void) {
-}
+void func_800D88C4(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s03/nonmatchings/map7_s03", func_800D88CC);
 
@@ -609,8 +602,7 @@ INCLUDE_ASM("asm/maps/map7_s03/nonmatchings/map7_s03", func_800E0C10);
 
 INCLUDE_ASM("asm/maps/map7_s03/nonmatchings/map7_s03", func_800E0C50);
 
-void func_800E14D4(void) {
-}
+void func_800E14D4(void) {}
 
 INCLUDE_ASM("asm/maps/map7_s03/nonmatchings/map7_s03", func_800E14DC);
 

--- a/src/screens/stream/stream.c
+++ b/src/screens/stream/stream.c
@@ -327,7 +327,7 @@ void strKickCD(CdlLOC* loc) // 0x801E31CC
 
 int strNextVlc(DECENV* dec) // 0x801E3298
 {
-    u_long *next, *strNext();
+    u_long* next, *strNext();
 
     u_long cnt = 2000;
     while ((next = strNext(dec)) == 0)

--- a/src/screens/stream/stream.c
+++ b/src/screens/stream/stream.c
@@ -8,76 +8,11 @@
 
 #include "bodyprog/bodyprog.h"
 #include "main/fileinfo.h"
+#include "screens/stream/stream.h"
 
-extern int StCdIntrFlag; // Not included in SDK docs/headers, but movie player sample code (and moviesys) uses it?
-
-extern s32 D_800B5C30;
-extern s32 D_801E3F3C;
-
-extern s32 D_800BCD0C;
-extern u8  D_800A900C[];
-
-typedef struct
-{
-    /* 0x00 */ u_long*  vlcbuf[2];
-    /* 0x08 */ int      vlcid;
-    /* 0x0C */ u_short* imgbuf;
-    /* 0x10 */ RECT     rect[2];
-    /* 0x20 */ int      rectid;
-    /* 0x24 */ RECT     slice;
-    /* 0x2C */ int      isdone;
-} DECENV;
-
-typedef struct
-{
-    /* 0x00000 */ CdlLOC  loc;
-    /* 0x00004 */ DECENV  dec;
-    /* 0x00034 */ int     Rewind_Switch; // or Clear_Flag
-    /* 0x00038 */ int     width;
-    /* 0x0003C */ int     height;
-    /* 0x00040 */ u_short imgbuf0[5760];
-    /* 0x02D40 */ u_short imgbuf1[5760];
-    /* 0x05A40 */ u_long  sect_buff[11776];
-    /* 0x11240 */ u_long  vlcbuf0[14336];
-    /* 0x1F240 */ u_long  vlcbuf1[14336];
-} MOVIE_STR;
-
-// Customised StHEADER?
-typedef struct
-{
-    u_short id;
-    u_short type;
-    u_short secCount;
-    u_short nSectors;
-    u_long  frameCount;
-    u_long  frameSize;
-    u_short width;
-    u_short height;
-    u_long  headm;
-    u_long  headv;
-    u_long  user;
-} CDSECTOR;
-
-#define RING_SIZE 23
-#define MOVIE_WAIT 2000
-#define PPW 3 / 2
-
-extern MOVIE_STR* m;
-extern s32        frame_cnt;
-
-void    open_main(s32 file_idx, s16 num_frames);
-void    movie_main(char* file_name, int f_size, int sector);
-void    strSetDefDecEnv(DECENV* dec, int x0, int y0, int x1, int y1);
-void    strInit(CdlLOC* loc, void (*callback)());
-void    strCallback();
-void    strKickCD(CdlLOC* loc);
-int     strNextVlc(DECENV* dec);
-u_long* strNext(DECENV* dec);
-void    strSync(DECENV* dec);
-
+// Old IDB name: MainLoopState3_StartMovieIntro_801E2654
 void func_801E2654(void)
 {
-    // Old IDB name MainLoopState3_StartMovieIntro_801E2654
     s32 prev_594;
 
     switch (g_GameWork.field_598)
@@ -124,10 +59,9 @@ void func_801E2654(void)
     func_800314EC(D_800A900C);
 }
 
+// Old IDB name: MainLoopState6_Movie_PlayIntro_801E279C
 void func_801E279C(void)
 {
-    // Old IDB name MainLoopState6_Movie_PlayIntro_801E279C
-
     s32 prev_594;
     s32 file_idx = 2053; // XA/C1_20670
 
@@ -157,9 +91,9 @@ void func_801E279C(void)
     D_800B5C30           = 0x1000;
 }
 
+// Old IDB name: MainLoopState9_Movie_PlayOpening_801E2838
 void func_801E2838(void)
 {
-    // Old IDB name MainLoopState9_Movie_PlayOpening_801E2838
     s32 prev_594;
 
     open_main(2055, 0); // XA/M1_03500
@@ -181,9 +115,9 @@ void func_801E2838(void)
     g_GameWork.field_598 = 0;
 }
 
+// Old IDB name: MainLoopStateD_ReturnToGame_801E28B0
 void func_801E28B0(void)
 {
-    // old IDB name MainLoopStateD_ReturnToGame_801E28B0
     s32 prev_594;
 
     prev_594             = g_GameWork.field_594;
@@ -204,9 +138,9 @@ void func_801E28B0(void)
     g_GameWork.field_598 = 0;
 }
 
+// Old IDB name: MainLoopState11_Movie_PlayEnding_801E2908
 void func_801E2908(void)
 {
-    // Old IDB name MainLoopState11_Movie_PlayEnding_801E2908
     s_GameWork*       gameWork   = g_pGameWork0;
     s_ControllerData* controller = g_pController1;
     s32               prev_594;
@@ -248,9 +182,9 @@ void func_801E2908(void)
     }
 }
 
+// Old IDB name: MainLoopState5_Movie_PlayIntroAlternate_801E2A24
 void func_801E2A24(void)
 {
-    // Old IDB name MainLoopState5_Movie_PlayIntroAlternate_801E2A24
     s32 prev_594;
 
     open_main(2053, 2060); // XA/C1_20670
@@ -290,7 +224,7 @@ void open_main(s32 file_idx, s16 num_frames) // 0x801E2AA4
 
 INCLUDE_ASM("asm/screens/stream/nonmatchings/stream", movie_main);
 
-void strSetDefDecEnv(DECENV* dec, int x0, int y0, int x1, int y1) // 0x801E2F8C
+void strSetDefDecEnv(DECENV* dec, s32 x0, s32 y0, s32 x1, s32 y1) // 0x801E2F8C
 {
     dec->rect[0].w = 480;
     dec->rect[1].w = 480;
@@ -324,7 +258,7 @@ void strInit(CdlLOC* loc, void (*callback)()) // 0x801E300C
 void strCallback() // 0x801E307C
 {
     RECT snap_rect;
-    int  id;
+    s32  id;
     u16* imgbuf;
 
     if (StCdIntrFlag)
@@ -365,8 +299,8 @@ void strCallback() // 0x801E307C
 
 void strKickCD(CdlLOC* loc) // 0x801E31CC
 {
-    char   v2[8];
-    u_char param;
+    s8 v2[8];
+    u8 param;
 
     while (!CdControlB(CdlNop, 0, v2) || (v2[0] & 2) == 0)
     {
@@ -376,13 +310,19 @@ void strKickCD(CdlLOC* loc) // 0x801E31CC
 
     param = 0x80;
     while (!CdControl(CdlSetmode, &param, 0))
+    {
         ;
+    }
 
     while (!CdControl(CdlSeekL, loc, 0))
+    {
         VSync(0);
+    }
 
     while (!CdRead2(CdlModeStream | CdlModeSpeed | CdlModeRT | CdlModeSize1))
+    {
         VSync(0);
+    }
 }
 
 int strNextVlc(DECENV* dec) // 0x801E3298
@@ -394,7 +334,9 @@ int strNextVlc(DECENV* dec) // 0x801E3298
     {
         cnt--;
         if (!cnt)
+        {
             return -1;
+        }
     }
 
     dec->vlcid = dec->vlcid ^ 1;


### PR DESCRIPTION
- Move declarations from `stream.c` to `stream.h`
- Compact stub functions.
- Use the project's primitive type aliases in a few places that don't use them yet.