### PR TITLE
Add savegame structs & matches, GameState inline funcs.

### DIFF
--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -9,6 +9,7 @@ g_pController2 = 0x80024D50; // type:u32
 g_pGameWork0 = 0x80024D54; // type:u32 same as g_pGameWork ?
 
 g_CurDeltaTime = 0x800B5CC0; // type:s32 - Q20.12 fixed point, usually 0x44 (0.0166..) or 0x88 (0.033..).
+g_CurMapEventNum = 0x800A9A14; // type:u32
 
 // sh "view" / "vw" / "vc" / "vb" code
 // Most names from SH2, functions seem to match pretty close between it and SH1 besides a few missing/extra funcs.
@@ -135,11 +136,16 @@ g_Demo_CurControllerPacket = 0x800C4890;
 g_Demo_CurrDemoStep = 0x800C4894;
 g_Demo_VideoPresentInterval = 0x800C4898;
 
+SaveGame_CopyWithChecksum = 0x8002FCCC; // type:func
 SaveGame_ChecksumUpdate = 0x8002FF30; // type:func
 SaveGame_ChecksumValidate = 0x8002FF74; // type:func
 SaveGame_ChecksumGenerate = 0x8002FFD0; // type:func
-SaveGame_InventoryCopy = 0x8002FCCC; // type:func
 Game_SaveGameClear = 0x800350BC; // type:func
+
+SysWork_SaveGameUpdatePlayer = 0x8003A120; // type:func
+SysWork_SaveGameReadPlayer = 0x8003A1F4; // type:func
+
+Game_SaveGameResetPlayer = 0x8007E530; // type:func
 
 GFX_ClearRectInterlaced = 0x80032358; // type:func
 GFX_Init = 0x80032428; // type:func

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -102,6 +102,13 @@ extern s16 D_800C391E;
 /** Unknown bodyprog var. Set in `Fs_QueueDoThingWhenEmpty`. */
 extern s32 D_800C489C;
 
+extern s32 D_800A8FEC;
+extern s32 D_800A9A14;
+extern s32 D_800A9A68;
+
+/** "\x07PAUSED" string */
+extern char D_80025394[];
+
 /** Initializer for something before the game loop. */
 void func_8002E630();
 
@@ -177,6 +184,18 @@ void func_80089128(void);
 void func_800892A4(s32);
 
 void func_801E2D8C();
+
+/** Sets position of next string drawn by GFX_StringDraw */
+void GFX_StringPosition(s32 x, s32 y);
+
+/** Draws a string to screen */
+void GFX_StringDraw(char* str, s32 arg1);
+
+/** Passes a command to sound driver */
+void SD_EngineCmd(s32 cmd);
+
+void func_8004C8DC();
+void func_80091380();
 
 /** Updates the footer with the checksum of the given data */
 void SaveGame_ChecksumUpdate(s_ShSaveGameFooter* saveFooter, s8* saveData, s32 saveDataLength);

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -103,7 +103,6 @@ extern s16 D_800C391E;
 extern s32 D_800C489C;
 
 extern s32 D_800A8FEC;
-extern s32 D_800A9A14;
 extern s32 D_800A9A68;
 
 /** "\x07PAUSED" string */
@@ -185,26 +184,38 @@ void func_800892A4(s32);
 
 void func_801E2D8C();
 
-/** Sets position of next string drawn by GFX_StringDraw */
+/** Sets position of next string drawn by GFX_StringDraw. */
 void GFX_StringPosition(s32 x, s32 y);
 
-/** Draws a string to screen */
+/** Draws a string to screen. */
 void GFX_StringDraw(char* str, s32 arg1);
 
-/** Passes a command to sound driver */
+/** Passes a command to sound driver. */
 void SD_EngineCmd(s32 cmd);
 
 void func_8004C8DC();
 void func_80091380();
 
-/** Updates the footer with the checksum of the given data */
+/** Updates savegame buffer with current player SysWork info (position/rotation/health/event num) */
+void SysWork_SaveGameUpdatePlayer();
+
+/** Updates SysWork with player info from savegame buffer (position/rotation/health) */
+void SysWork_SaveGameReadPlayer();
+
+/** Resets player info inside savegame buffer (health/game timer/inventory) */
+void Game_SaveGameResetPlayer();
+
+/** Copies savegame into an s_ShSaveGameContainer and calculates footer checksum. */
+void SaveGame_CopyWithChecksum(s_ShSaveGameContainer* dest, s_ShSaveGame* src);
+
+/** Updates the footer with the checksum of the given data. */
 void SaveGame_ChecksumUpdate(s_ShSaveGameFooter* saveFooter, s8* saveData, s32 saveDataLength);
 
-/** Generates checksum of the given saveData and compares against checksum value in the footer
-    Return 1 if checksum matches, otherwise 0 */
+/** Generates checksum of the given saveData and compares against checksum value in the footer.
+    Returns 1 if checksum matches, otherwise 0. */
 s32 SaveGame_ChecksumValidate(s_ShSaveGameFooter* saveFooter, s8* saveData, s32 saveDataLength);
 
-/** Generates an 8-bit XOR checksum over the given data, only appears used with s_ShSaveGame data */
+/** Generates an 8-bit XOR checksum over the given data, only appears used with s_ShSaveGame data. */
 u8 SaveGame_ChecksumGenerate(s8* saveData, s32 saveDataLength);
 
 #endif

--- a/include/game.h
+++ b/include/game.h
@@ -248,28 +248,58 @@ extern s_ControllerData* g_pController2;
 extern s32 g_CurDeltaTime;
 extern s32 g_CurOTNum;
 
+/** Sets the SysState to use in the next game update. */
+static inline void SysWork_StateSetNext(e_SysState sysState)
+{
+    g_SysWork.sysState_8     = sysState;
+    g_SysWork.field_24       = 0;
+    g_SysWork.sysStateStep_C = 0;
+    g_SysWork.field_28       = 0;
+    g_SysWork.field_10       = 0;
+    g_SysWork.field_2C       = 0;
+    g_SysWork.field_14       = 0;
+}
+
 /** Sets the GameState to use in the next game update.
     Inlined into stream & b_konami.
 */
-static inline Game_StateSetNext(e_GameState gameState)
+static inline void Game_StateSetNext(e_GameState gameState)
 {
     e_GameState prevState = g_GameWork.gameState_594;
 
     g_GameWork.gameState_594        = gameState;
+
     g_SysWork.field_1C              = 0;
     g_SysWork.field_20              = 0;
+
     g_GameWork.gameStateStep_598[1] = 0;
     g_GameWork.gameStateStep_598[2] = 0;
-    g_SysWork.sysState_8            = SysState_Gameplay;
-    g_SysWork.field_24              = 0;
-    g_SysWork.sysStateStep_C        = 0;
-    g_SysWork.field_28              = 0;
-    g_SysWork.field_10              = 0;
-    g_SysWork.field_2C              = 0;
-    g_SysWork.field_14              = 0;
+
+    SysWork_StateSetNext(SysState_Gameplay);
+
     g_GameWork.gameStateStep_598[0] = prevState;
     g_GameWork.gameStatePrev_590    = prevState;
     g_GameWork.gameStateStep_598[0] = 0;
 }
 
+/** Sets GameState to the previous state.
+    Inlined into credits.
+ */
+static inline void Game_StateSetPrevious()
+{
+    e_GameState prevState = g_GameWork.gameState_594;
+
+    g_SysWork.field_1C = 0;
+    g_SysWork.field_20 = 0;
+
+    g_GameWork.gameStateStep_598[1] = 0;
+    g_GameWork.gameStateStep_598[2] = 0;
+
+    SysWork_StateSetNext(SysState_Gameplay);
+
+    g_GameWork.gameStateStep_598[0] = prevState;
+    g_GameWork.gameState_594        = g_GameWork.gameStatePrev_590;
+    g_GameWork.gameStatePrev_590    = prevState;
+    g_GameWork.gameStateStep_598[0] = 0;
+}
 #endif

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -170,7 +170,13 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FBB4);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FC3C);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SaveGame_InventoryCopy);
+void SaveGame_CopyWithChecksum(s_ShSaveGameContainer* dest, s_ShSaveGame* src) // 0x8002FCCC
+{
+    bzero(dest, sizeof(s_ShSaveGameContainer));
+
+    memcpy(&dest->saveGame_0, src, sizeof(s_ShSaveGame));
+    SaveGame_ChecksumUpdate(&dest->footer_27C, &dest->saveGame_0, sizeof(s_ShSaveGameContainer));
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8002FD5C);
 
@@ -538,7 +544,7 @@ void func_800391E8()
     {
         D_800A9A68 = 0;
         SD_EngineCmd(4);
-        D_800A9A14 = 0;
+        g_CurMapEventNum = 0;
         SysWork_StateSetNext(SysState_SaveMenu2);
         return;
     }
@@ -575,11 +581,35 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80039F90);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80039FB8);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003A120);
+void SysWork_SaveGameUpdatePlayer() // 0x8003A120
+{
+    s_ShSaveGame* save      = g_pSaveGame;
+    save->curMapEventNum_A8 = g_CurMapEventNum;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003A16C);
+    save->playerPosX_244        = g_SysWork.player_4C.c.position_18.vx;
+    save->playerPosZ_24C        = g_SysWork.player_4C.c.position_18.vz;
+    save->playerRotationYaw_248 = g_SysWork.player_4C.c.rotation_24.vy;
+    save->playerHealth_240      = g_SysWork.player_4C.c.health_B0;
+}
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003A1F4);
+void func_8003A16C() // 0x8003A16C
+{
+    if (!(g_SysWork.flags_22A4 & 2))
+    {
+        // update saveGame_30C with player info
+        SysWork_SaveGameUpdatePlayer();
+        // TODO: what is saveGame_90 used for?
+        g_GameWork.saveGame_90 = g_GameWork.saveGame_30C;
+    }
+}
+
+void SysWork_SaveGameReadPlayer() // 0x8003A1F4
+{
+    g_SysWork.player_4C.c.position_18.vx = g_pSaveGame->playerPosX_244;
+    g_SysWork.player_4C.c.position_18.vz = g_pSaveGame->playerPosZ_24C;
+    g_SysWork.player_4C.c.rotation_24.vy = g_pSaveGame->playerRotationYaw_248;
+    g_SysWork.player_4C.c.health_B0      = g_pSaveGame->playerHealth_240;
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003A230);
 

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -512,7 +512,44 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80038BD4);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80038F6C);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_800391E8);
+// SysState_GamePaused handler
+void func_800391E8()
+{
+    D_800A9A68 += D_800A8FEC;
+    if (((D_800A9A68 >> 0xB) & 1) == 0)
+    {
+        GFX_StringPosition(125, 104);
+        GFX_StringDraw(D_80025394, 99); // "\x07PAUSED"
+    }
+
+    func_80091380();
+    func_8004C8DC();
+
+    if (g_SysWork.sysStateStep_C == 0)
+    {
+        SD_EngineCmd(3);
+        g_SysWork.sysStateStep_C += 1;
+    }
+
+    // Debug button combo to bring up save screen from pause screen
+    // DPad-Left + L2 + L1 + LS-Left + RS-Left + L3
+    if ((g_pController1->btns_held_C == (Pad_BtnL3 | Pad_BtnDpadLeft | Pad_BtnL2 | Pad_BtnL1 | Pad_LSLeft2 | Pad_RSLeft | Pad_LSLeft)) &&
+        (g_pController1->btns_new_10 & Pad_BtnL3))
+    {
+        D_800A9A68 = 0;
+        SD_EngineCmd(4);
+        D_800A9A14 = 0;
+        SysWork_StateSetNext(SysState_SaveMenu2);
+        return;
+    }
+
+    if (g_pController1->btns_new_10 & g_pGameWork0->controllerBinds_0.pause)
+    {
+        D_800A9A68 = 0;
+        SD_EngineCmd(4);
+        SysWork_StateSetNext(SysState_Gameplay);
+    }
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80039344);
 

--- a/src/bodyprog/bodyprog_8004A87C.c
+++ b/src/bodyprog/bodyprog_8004A87C.c
@@ -668,7 +668,36 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8007D6F0);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8007D970);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8007E530);
+// TODO: Can this work without needing inlined func?
+static inline SaveGame_PlayerReset(s_ShSaveGame* save)
+{
+    save->playerHealth_240  = 0x64000; // (100 << 0xC)?
+    save->field_A0          = 0;
+    save->field_AA          = 0;
+    save->field_238         = 0;
+    save->gameplayTimer_250 = 0;
+    save->field_254         = 0;
+    save->field_258         = 0;
+    save->field_23C         = 0;
+    save->field_24A         = 0;
+    save->field_25C &= ~6;
+}
+
+void Game_SaveGameResetPlayer() // 0x8007E530
+{
+    s_ShSaveGame* save = g_pSaveGame;
+    s32           i;
+
+    g_pSaveGame->field_AB = 8;
+
+    for (i = 0; i < GAME_INVENTORY_SIZE; i++)
+    {
+        save->items_0[i].id    = 0xFF;
+        save->items_0[i].count = 0;
+    }
+
+    SaveGame_PlayerReset(g_pSaveGame);
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8007E5AC);
 

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -20,8 +20,8 @@ void vcSetCameraUseWarp(VECTOR3* chr_pos, s16 chr_ang_y) // 0x800400D4
     cam_pos.vy = chr_pos->vy - 0x1B33;
     cam_pos.vz = chr_pos->vz - ((shRcos(chr_ang_y) * 0x1800) >> FP_SIN_Q);
 
-    vcSetFirstCamWork(&cam_pos, chr_ang_y, g_SysWork.field_22A4 & 0x40);
-    g_SysWork.field_22A4 &= ~0x40;
+    vcSetFirstCamWork(&cam_pos, chr_ang_y, g_SysWork.flags_22A4 & 0x40);
+    g_SysWork.flags_22A4 &= ~0x40;
 }
 
 int vcRetCamMvSmoothF() // 0x80040190

--- a/src/screens/credits/credits.c
+++ b/src/screens/credits/credits.c
@@ -132,8 +132,6 @@ s32 func_801E3124(void)
 
 s32 func_801E3304(void)
 {
-    e_GameState prevState;
-
     if (g_GameWork.gameStatePrev_590 == GameState_InGame)
     {
         if (g_GameWork.gameStateStep_598[1] == 0)
@@ -154,28 +152,7 @@ s32 func_801E3304(void)
             DrawSync(0);
             VSync(2);
 
-            // TODO: this doesn't match inline Game_StateSetNext
-            // maybe a different Game_StateSetPrevious?
-            prevState = g_GameWork.gameState_594;
-
-            g_SysWork.field_1C = 0;
-            g_SysWork.field_20 = 0;
-
-            g_GameWork.gameStateStep_598[1] = 0;
-            g_GameWork.gameStateStep_598[2] = 0;
-
-            g_SysWork.sysState_8     = SysState_Gameplay;
-            g_SysWork.field_24 = 0;
-            g_SysWork.sysStateStep_C = 0;
-            g_SysWork.field_28 = 0;
-            g_SysWork.field_10 = 0;
-            g_SysWork.field_2C = 0;
-            g_SysWork.field_14 = 0;
-
-            g_GameWork.gameStateStep_598[0] = prevState;
-            g_GameWork.gameState_594        = g_GameWork.gameStatePrev_590;
-            g_GameWork.gameStatePrev_590    = prevState;
-            g_GameWork.gameStateStep_598[0] = 0;
+            Game_StateSetPrevious();
         }
         
         return 0;


### PR DESCRIPTION
Started on `s_ShSaveGame`, matched a couple more savegame funcs around it, added some more gamestate inline funcs.

Seems s_GameWork has two instances of s_ShSaveGame inside, not really sure what the reason is yet though.

Also adds match for `SysState_GamePaused` state handler, but not really sure how to name it yet.