### PR TITLE
Macros, fields

### DIFF
--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -10,7 +10,7 @@
 typedef struct
 {
     s32 field_0;
-    s32 field_4;
+    s32 field_4; // Maybe index?
     s32 field_8;
 } s_80041CB4;
 

--- a/include/bodyprog/math.h
+++ b/include/bodyprog/math.h
@@ -10,9 +10,13 @@
 /** Number of possible fixed-point angles in Q15 format. */
 #define FP_ANGLE_COUNT 65536
 
-/** Convert degrees to fixed-point angles in Q15 format (used at Q12.4 resolution). */
+/** Converts degrees to fixed-point angles in Q15 format (used at Q12.4 resolution). */
 #define DEG_TO_FPA(deg) \
-	(s16)(deg * (FP_ANGLE_COUNT / 360.0f))
+	(s16)((deg) * ((FP_ANGLE_COUNT) / 360.0f))
+
+/** Clamps the input value to the range [min, max]. */
+#define CLAMP(value, min, max) \
+    ((value) < (min)) ? (min) : (((value) > (max)) ? (max) : (value))
 
 void func_80096C94(SVECTOR* vec, MATRIX* mat); // Custom vwRotMatrix...?
 void func_80096E78(SVECTOR* vec, MATRIX* mat); // Another custom vwRotMatrix...]?

--- a/include/common.h
+++ b/include/common.h
@@ -12,10 +12,10 @@
 #define SECTION(x) \
     __attribute__((section(x)))
 
-#define STATIC_ASSERT(COND, MSG) \
-    typedef char static_assertion_##MSG[(COND) ? 1 : -1]
+#define STATIC_ASSERT(cond, msg) \
+    typedef char static_assertion_##msg[(cond) ? 1 : -1]
 
-#define STATIC_ASSERT_SIZEOF(TYPE, SIZE) \
-    typedef char static_assertion_sizeof_##TYPE[(sizeof(TYPE) == (SIZE)) ? 1 : -1]
+#define STATIC_ASSERT_SIZEOF(type, size) \
+    typedef char static_assertion_sizeof_##type[(sizeof(type) == (size)) ? 1 : -1]
 
 #endif

--- a/include/common.h
+++ b/include/common.h
@@ -6,14 +6,16 @@
 
 #define PSX_SCRATCH ((void*)0x1F800000)
 
-#define ALIGN(x, a) (((u32)(x) + ((a)-1)) & ~((a)-1))
+#define ALIGN(x, a) \
+    (((u32)(x) + ((a)-1)) & ~((a)-1))
 
-#define SECTION(x) __attribute__((section(x)))
+#define SECTION(x) \
+    __attribute__((section(x)))
 
-#define STATIC_ASSERT(COND, MSG) typedef char static_assertion_##MSG[(COND) ? 1 : -1]
-#define STATIC_ASSERT_SIZEOF(TYPE, SIZE) typedef char static_assertion_sizeof_##TYPE[(sizeof(TYPE) == (SIZE)) ? 1 : -1]
+#define STATIC_ASSERT(COND, MSG) \
+    typedef char static_assertion_##MSG[(COND) ? 1 : -1]
 
-#define CLAMP(val, min, max) \
-    (((val) < (min)) ? (min) : ((val) > (max)) ? (max) : (val))
+#define STATIC_ASSERT_SIZEOF(TYPE, SIZE) \
+    typedef char static_assertion_sizeof_##TYPE[(sizeof(TYPE) == (SIZE)) ? 1 : -1]
 
 #endif

--- a/include/game.h
+++ b/include/game.h
@@ -7,7 +7,8 @@
 #define TILE_UNIT(value) \
 	(s32)(value * 256.0f)
 
-#define GAME_INVENTORY_SIZE 40
+#define SAVEGAME_FOOTER_MAGIC 0xDCDC
+#define GAME_INVENTORY_SIZE   40
 
 typedef enum _PadButton
 {
@@ -203,10 +204,9 @@ typedef struct _ShSaveGame
 STATIC_ASSERT_SIZEOF(s_ShSaveGame, 0x27C);
 
 /** 
- * s_ShSaveGameFooter: Appended to ShSaveGame during game save. Contains 8-bit XOR checksum + magic
+ * Appended to ShSaveGame during game save. Contains 8-bit XOR checksum + magic
  * checksum generated via the SaveGame_ChecksumGenerate function .
  */
-#define SAVEGAME_FOOTER_MAGIC 0xDCDC
 typedef struct _ShSaveGameFooter
 {
     u8  checksum_0[2];
@@ -214,7 +214,7 @@ typedef struct _ShSaveGameFooter
 } s_ShSaveGameFooter;
 STATIC_ASSERT_SIZEOF(s_ShSaveGameFooter, 4);
 
-/** s_ShSaveGameContainer: Contains s_ShSaveGame data with the footer appended to the end containing the checksum + magic. */
+/** Contains s_ShSaveGame data with the footer appended to the end containing the checksum + magic. */
 typedef struct _ShSaveGameContainer
 {
     s_ShSaveGame       saveGame_0;
@@ -347,7 +347,7 @@ extern u32 g_CurMapEventNum;
 extern s32 g_CurDeltaTime;
 extern s32 g_CurOTNum;
 
-/** Sets the SysState to use in the next game update. */
+/** Sets the SysState to be used in the next game update. */
 static inline void SysWork_StateSetNext(e_SysState sysState)
 {
     g_SysWork.sysState_8     = sysState;

--- a/include/game.h
+++ b/include/game.h
@@ -276,8 +276,10 @@ typedef struct _SubCharacter
     u8  maybeSomeState_5;
     s16 flags_6; // Bit 1: movement unlockled? Bit 2: visible.
 
-    s32 animFrameIdx_8;
-    u8  flags_12[12];
+    s32 animFrameIdx_8;       // Rapidly incrementing anim frame index. Maybe interpolated frame index?
+    s16 animFrameIdx_C;       // Slowly incrementing anim frame index. Maybe actual frame data index of frame to be interpolated?
+    s16 interpolationAlpha_E; // Something to do with linear anim interpolation. Maybe alpha value in Q format.
+    u8  flags_12[8];
 
     VECTOR3 position_18;
     SVECTOR rotation_24;
@@ -290,29 +292,34 @@ typedef struct _SubCharacter
     s32     health_B0; // Bits 3-4 contain s16 associated with player's rate of heavy breathing, always set to 6. Can't split into s16s? Maybe packed data.
     s8      unk_B4[52];  
 
-    // These might be part of an array of multi-purpose s32 elements used for storing unique data per-character.
+    // These might be part of a multi-purpose array of s32 elements used for storing unique data for each character type.
     // For player, mostly used for counters as far as I could see. --Sezz
 
-    s32     afkCounter_E8;    // Player AFK counter. Increments every tick(?) for 10 seconds before player starts AFK anim. Purpose for other characters unknown.
-    s32     field_EC;         // Copy of player Y position. No discernible purpose. Purpose for other characters unknown.
-    s8      unk_F0[8];        // 2 more s32 for custom data?
-    s32     runCounter_F8;    // Player run counter. Increments more slowly than runCounter_108. Purpose for other characters unknown.
-    s32     windedCounter_FC; // Player winded counter. Counts 20 seconds worth of ticks(?) and caps at 0x23000. Purpose for other characters unknown.
-    s8      unk_FC[8];        // 2 more s32 for custom data?
-    s32     runCounter_108;   // Player run counter. Increments every tick(?) indefinitely. Purpose for other characters unknown.
+    s32 field_E8;  // Player AFK counter. Increments every tick(?) for 10 seconds before player starts AFK anim. Purpose for other characters unknown.
+    s32 field_EC;  // Copy of player Y position. Purpose for other characters unknown.
+    s8  unk_F0[8]; // 2 more s32 for custom data?
+    s32 field_F8;  // Player run counter. Increments more slowly than runCounter_108. Purpose for other characters unknown.
+    s32 field_FC;  // Player winded counter. Counts 20 seconds worth of ticks(?) and caps at 0x23000. Purpose for other characters unknown.
+    s8  unk_FC[8]; // 2 more s32 for custom data?
+    s32 field_108; // Player run counter. Increments every tick(?) indefinitely. Purpose for other characters unknown.
 
-    s8      _unk_EC[28]; 
+    s8 unk_EC[28]; 
 } s_SubCharacter;
 STATIC_ASSERT_SIZEOF(s_SubCharacter, 296);
 
 typedef struct _MainCharacter
 {
-    /* 0x000 */ s_SubCharacter character;
-    /* 0x128 */ u8             field_128;
-    /* 0x129 */ u8             field_129;
-    /* 0x12A */ u8             field_12A;
-    /* 0x12B */ u8             field_12B; // Related to anim state.
-    /* 0x12C */ u8             extra[40];
+    s_SubCharacter character;
+    u8             field_128;
+    u8             field_129;
+    u8             field_12A;
+    u8             field_12B;    // isPrevAnimStateSame? Always 1, set to 0 for 1 tick when anim state changes.
+    s8             copy_12C[20]; // Duplicate data. Sequentially opies all fields from 0x4 to 0x18 of s_SubCharacter.
+    s8             field_140[4];
+    s8             field_144[4]; // s32? Some kind of anim state. Set to 2 when player is in AFK anim, 0 otherwise.
+    s8             field_148[4]; // s32? Some kind of anim state.
+    s8             field_14C[4]; // s32? Some kind of anim state.
+    s8             unk_150[4];
 } s_MainCharacter;
 STATIC_ASSERT_SIZEOF(s_MainCharacter, 0x154);
 

--- a/include/main/rng.h
+++ b/include/main/rng.h
@@ -29,7 +29,8 @@ u32 Rng_Rand32(void);
  * shifts the result right to produce a value within the range
  * of [0, 0x7FFF].
  *
- * @return A random positive 16-bit unsigned integer (u32).
+ * @return A random positive 16-bit unsigned integer as a 32-bit unsigned
+ * integer (u32).
  */
 u32 Rng_Rand16(void);
 

--- a/include/types.h
+++ b/include/types.h
@@ -21,8 +21,11 @@ typedef unsigned long long u64;
 typedef enum { false, true } bool;
 #endif
 
-// lightly modified VECTOR with padding int removed, seems used through a lot of SH code
-typedef struct {
+#define NO_VALUE -1
+
+// Slightly modified VECTOR with padding int removed. Seems to be used through much of SH code.
+typedef struct
+{
     long vx, vy;
     long vz;
 } VECTOR3;

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -537,7 +537,7 @@ void func_800391E8()
     if (g_SysWork.sysStateStep_C == 0)
     {
         SD_EngineCmd(3);
-        g_SysWork.sysStateStep_C += 1;
+        g_SysWork.sysStateStep_C++;
     }
 
     // Debug button combo to bring up save screen from pause screen.

--- a/src/bodyprog/bodyprog_80040A64.c
+++ b/src/bodyprog/bodyprog_80040A64.c
@@ -24,7 +24,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80040A64", func_800414E0);
 
 s32 func_80041ADC(s32 queueIdx)
 {
-    if (queueIdx == -1)
+    if (queueIdx == NO_VALUE)
         return 0;
     
     if (Fs_QueueIsEntryLoaded(queueIdx) == 0)
@@ -45,7 +45,7 @@ void func_80041CB4(s_80041CB4* arg0, s_80041CEC* arg1)
     func_80041CEC(arg1);
     
     arg0->field_8 = 0;
-    arg0->field_4 = -1;
+    arg0->field_4 = NO_VALUE;
 }
 
 void func_80041CEC(s_80041CEC* arg0)
@@ -62,7 +62,7 @@ void func_80041D10(s_80041D10* array, s32 size)
     s_80041D10* end = array + size;
     while (array < end)
     {
-        array->field_4 = -1;
+        array->field_4 = NO_VALUE;
         array = (s_80041D10*)((u8*)array + sizeof(s_80041D10)); 
     }
 }

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -238,7 +238,7 @@ void vcSetTHROUGH_DOOR_CAM_PARAM_in_VC_WORK(VC_WORK* w_p, enum _THROUGH_DOOR_SET
             prm_p->timer_4                  = 0;
             prm_p->rail_ang_y_8             = w_p->chara_eye_ang_y_144;
             prm_p->rail_sta_pos_C.vx        = w_p->chara_pos_114.vx;
-            prm_p->rail_sta_pos_C.vy        = w_p->chara_grnd_y_12C - 7987;
+            prm_p->rail_sta_pos_C.vy        = w_p->chara_grnd_y_12C - TILE_UNIT(31.2f);
             prm_p->rail_sta_pos_C.vz        = w_p->chara_pos_114.vz;
             break;
 
@@ -358,13 +358,13 @@ void vcSetWatchTgtYParam(VECTOR3* watch_pos, VC_WORK* w_p, s32 cam_mv_type, s32 
 
 void vcAdjustWatchYLimitHighWhenFarView(VECTOR3* watch_pos, VECTOR3* cam_pos, s16 sy) // 0x800835E0
 {
-    s16 max_cam_ang_x = ratan2(cam_pos->vy + 0x5000, 0xD000) - ratan2(g_GameWork.gsScreenHeight_58A / 2, sy);
+    s16 max_cam_ang_x = ratan2(cam_pos->vy + TILE_UNIT(80.0f), TILE_UNIT(208.0f)) - ratan2(g_GameWork.gsScreenHeight_58A / 2, sy);
     s32 dist          = Math_VectorMagnitude(watch_pos->vx - cam_pos->vx, 0, watch_pos->vz - cam_pos->vz);
     s32 cam_ang_x     = ratan2(-watch_pos->vy + cam_pos->vy, dist) * FP_ANGLE_COUNT;
 
     if ((max_cam_ang_x * FP_ANGLE_COUNT) < cam_ang_x)
     {
-        s32 ofs_y     = (((dist >> FP_POS_Q) * shRsin(max_cam_ang_x)) / shRcos(max_cam_ang_x)) * 16;
+        s32 ofs_y     = (((dist >> FP_POS_Q) * shRsin(max_cam_ang_x)) / shRcos(max_cam_ang_x)) << FP_POS_Q;
         watch_pos->vy = cam_pos->vy - ofs_y;
     }
 }
@@ -419,7 +419,7 @@ void vcAutoRenewalCamTgtPos(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type, VC_CAM_MV_
             break;
 
         case 1:
-            vcMakeBasicCamTgtMvVec(&tgt_vec, &ideal_pos, w_p, 0x1000);
+            vcMakeBasicCamTgtMvVec(&tgt_vec, &ideal_pos, w_p, TILE_UNIT(16.0f));
             break;
     }
 
@@ -448,8 +448,8 @@ s32 vcRetMaxTgtMvXzLen(VC_WORK* w_p, VC_CAM_MV_PARAM* cam_mv_prm_p) // 0x8008395
 {
     s32 max_spd_xz;
 
-    max_spd_xz = w_p->chara_mv_spd_13C + 0x1000 + abs(w_p->chara_ang_spd_y_142 * 8);
-    max_spd_xz = (max_spd_xz < 0x2333) ? 0x2333 : max_spd_xz;
+    max_spd_xz = w_p->chara_mv_spd_13C + TILE_UNIT(16.0f) + abs(w_p->chara_ang_spd_y_142 * 8);
+    max_spd_xz = (max_spd_xz < TILE_UNIT(35.2f)) ? TILE_UNIT(35.2f) : max_spd_xz;
     max_spd_xz = (cam_mv_prm_p->max_spd_xz > max_spd_xz) ? max_spd_xz : cam_mv_prm_p->max_spd_xz;
 
     return Math_MulFixed(max_spd_xz, g_CurDeltaTime, FP_SIN_Q);
@@ -470,12 +470,12 @@ void vcMakeIdealCamPosByHeadPos(VECTOR3* ideal_pos, VC_WORK* w_p, VC_AREA_SIZE_T
     if (g_GameWorkPtr0->optViewMode_29)
     {
         chara2cam_ang_y = w_p->chara_eye_ang_y_144 + DEG_TO_FPA(8.75f);
-        ideal_pos->vy   = w_p->chara_head_pos_130.vy + 286;
+        ideal_pos->vy   = w_p->chara_head_pos_130.vy + TILE_UNIT(1.1175f);
     }
     else
     {
         chara2cam_ang_y = w_p->chara_eye_ang_y_144 + DEG_TO_FPA(10.625f);
-        ideal_pos->vy   = w_p->chara_head_pos_130.vy + 409;
+        ideal_pos->vy   = w_p->chara_head_pos_130.vy + TILE_UNIT(1.6f);
     }
 
     ideal_pos->vx = w_p->chara_head_pos_130.vx + ((shRsin(chara2cam_ang_y) * DEG_TO_FPA(4.05f)) >> FP_SIN_Q);
@@ -565,7 +565,7 @@ void vcCamTgtMvVecIsFlipedFromCharaFront(VECTOR3* tgt_mv_vec, VC_WORK* w_p, s32 
     s16                flip_ang_y;
     VC_NEAR_ROAD_DATA* use_nearest_p;
     s16                ang_y;
-    s32                flip_dist; // todo: name maybe switched with mv_len
+    s32                flip_dist; // TODO: Name maybe switched with mv_len.
     s32                chk_near_dist;
     s32                mv_len;
     s32                min_z;
@@ -579,9 +579,9 @@ void vcCamTgtMvVecIsFlipedFromCharaFront(VECTOR3* tgt_mv_vec, VC_WORK* w_p, s32 
     if (flip_dist > 0)
     {
         mv_len = flip_dist;
-        if (flip_dist > 0x800)
+        if (flip_dist > TILE_UNIT(8.0f))
         {
-            mv_len = 0x800;
+            mv_len = TILE_UNIT(8.0f);
         }
 
         // chk_pos is unused?
@@ -884,7 +884,7 @@ void vcSetDataToVwSystem(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type) // 0x80085884
     if (w_p->field_D8 != 0)
     {
         w_p->field_D8 = 0;
-        vwSetCoordRefAndEntou(&g_SysWork.hero_neck_930, 0, -204, 1228, DEG_TO_FPA(11.25f), DEG_TO_FPA(0.0f), -0x333, 0x1000);
+        vwSetCoordRefAndEntou(&g_SysWork.hero_neck_930, 0, TILE_UNIT(-0.8f), TILE_UNIT(4.8f), DEG_TO_FPA(11.25f), DEG_TO_FPA(0.0f), TILE_UNIT(-3.2f), 0x1000);
     }
     else if (w_p->field_FC != 0)
     {

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -17,7 +17,7 @@ void vcSetCameraUseWarp(VECTOR3* chr_pos, s16 chr_ang_y) // 0x800400D4
     cam_ang.vz = 0;
 
     cam_pos.vx = chr_pos->vx - ((shRsin(chr_ang_y) * 0x1800) >> FP_SIN_Q);
-    cam_pos.vy = chr_pos->vy - 0x1B33;
+    cam_pos.vy = chr_pos->vy - TILE_UNIT(27.2f);
     cam_pos.vz = chr_pos->vz - ((shRcos(chr_ang_y) * 0x1800) >> FP_SIN_Q);
 
     vcSetFirstCamWork(&cam_pos, chr_ang_y, g_SysWork.flags_22A4 & 0x40);
@@ -33,7 +33,7 @@ void func_800401A0(s32 arg0) // 0x800401A0
 {
     if (arg0)
     {
-        vcCameraInternalInfo.ev_cam_rate = 4096;
+        vcCameraInternalInfo.ev_cam_rate = 4096; // TODO: If angle, replace magic value with DEG_TO_FPA(22.5f).
     }
     else
     {
@@ -62,13 +62,13 @@ void vcMakeHeroHeadPos(VECTOR3* head_pos) // 0x8004047C
     func_80049984(&g_SysWork.hero_neck_930, &neck_lwm);
 
     fpos.vx = 0;
-    fpos.vy = -25;
+    fpos.vy = TILE_UNIT(-0.1f);
     fpos.vz = 0;
     ApplyMatrix(&neck_lwm, &fpos, &sp38);
 
-    head_pos->vx = (sp38.vx + neck_lwm.t[0]) * 16;
-    head_pos->vy = ((sp38.vy + neck_lwm.t[1]) * 16) - 0x4CC;
-    head_pos->vz = (sp38.vz + neck_lwm.t[2]) * 16;
+    head_pos->vx = (sp38.vx + neck_lwm.t[0]) << FP_POS_Q;
+    head_pos->vy = ((sp38.vy + neck_lwm.t[1]) << FP_POS_Q) - TILE_UNIT(4.8f);
+    head_pos->vz = (sp38.vz + neck_lwm.t[2]) << FP_POS_Q;
 }
 
 void vcAddOfsToPos(VECTOR3* out_pos, VECTOR3* in_pos, s16 ofs_xz_r, s16 ang_y, s32 ofs_y) // 0x80040518
@@ -82,12 +82,12 @@ void vcSetRefPosAndSysRef2CamParam(VECTOR3* ref_pos, s_SysWork* sys_p, s32 for_f
 {
     if (for_f != 0)
     {
-        sys_p->cam_r_xz_2380 -= 0x199;
+        sys_p->cam_r_xz_2380 -= TILE_UNIT(1.6f);
     }
 
     if (back_f != 0)
     {
-        sys_p->cam_r_xz_2380 += 0x199;
+        sys_p->cam_r_xz_2380 += TILE_UNIT(1.6f);
     }
 
     if (right_f != 0)
@@ -102,20 +102,20 @@ void vcSetRefPosAndSysRef2CamParam(VECTOR3* ref_pos, s_SysWork* sys_p, s32 for_f
 
     if (up_f != 0)
     {
-        sys_p->cam_y_2384 -= 0x199;
+        sys_p->cam_y_2384 -= TILE_UNIT(1.6f);
     }
 
     if (down_f != 0)
     {
-        sys_p->cam_y_2384 += 0x199;
+        sys_p->cam_y_2384 += TILE_UNIT(1.6f);
     }
 
-    if (sys_p->cam_r_xz_2380 < 0x1000)
+    if (sys_p->cam_r_xz_2380 < TILE_UNIT(16.0f))
     {
-        sys_p->cam_r_xz_2380 = 0x1000;
+        sys_p->cam_r_xz_2380 = TILE_UNIT(16.0f);
     }
 
-    vcAddOfsToPos(ref_pos, &g_SysWork.player_4C.character.position_18, 2048, g_SysWork.player_4C.character.rotation_24.vy, -4096);
+    vcAddOfsToPos(ref_pos, &g_SysWork.player_4C.character.position_18, TILE_UNIT(8.0f), g_SysWork.player_4C.character.rotation_24.vy, TILE_UNIT(-16.0f));
 }
 
 void vcSetRefPosAndCamPosAngByPad(VECTOR3* ref_pos, s_SysWork* sys_p) // 0x800406D4
@@ -237,12 +237,14 @@ void vcSetRefPosAndCamPosAngByPad(VECTOR3* ref_pos, s_SysWork* sys_p) // 0x80040
     {
         SVECTOR sp58;
 
-        vwAngleToVector(&sp58, &cam_ang, 0x500);
-        ref_pos->vx           = (sp18.vx + sp58.vx) * 16;
-        ref_pos->vy           = (sp18.vy + sp58.vy) * 16;
-        ref_pos->vz           = (sp18.vz + sp58.vz) * 16;
+        vwAngleToVector(&sp58, &cam_ang, TILE_UNIT(5.0f));
+
+        ref_pos->vx = (sp18.vx + sp58.vx) << FP_POS_Q;
+        ref_pos->vy = (sp18.vy + sp58.vy) << FP_POS_Q;
+        ref_pos->vz = (sp18.vz + sp58.vz) << FP_POS_Q;
+
         sys_p->cam_ang_y_237A = ((cam_ang.vy + DEG_TO_FPA(11.25f)) << 0x14) >> 0x14;
-        sys_p->cam_y_2384     = -sp58.vy * 16;
-        sys_p->cam_r_xz_2380  = SquareRoot0((sp58.vx * sp58.vx) + (sp58.vz * sp58.vz)) * 16;
+        sys_p->cam_y_2384     = -sp58.vy << FP_POS_Q;
+        sys_p->cam_r_xz_2380  = SquareRoot0((sp58.vx * sp58.vx) + (sp58.vz * sp58.vz)) << FP_POS_Q;
     }
 }

--- a/src/bodyprog/view/vw_calc.c
+++ b/src/bodyprog/view/vw_calc.c
@@ -101,12 +101,12 @@ void vwMatrixToAngleYXZ(SVECTOR* ang, MATRIX* mat) // 0x800495D4
     s32 r_xz = SquareRoot0((mat->m[0][2] * mat->m[0][2]) + (mat->m[2][2] * mat->m[2][2]));
     ang->vx  = ratan2(-mat->m[1][2], r_xz);
 
-    if (ang->vx == 1024)
+    if (ang->vx == DEG_TO_FPA(5.625f))
     {
         ang->vz = 0;
         ang->vy = ratan2(mat->m[0][1], mat->m[2][1]);
     }
-    else if (ang->vx == -1024)
+    else if (ang->vx == DEG_TO_FPA(-5.625f))
     {
         ang->vz = 0;
         ang->vy = ratan2(-mat->m[0][1], -mat->m[2][1]);

--- a/src/bodyprog/view/vw_main.c
+++ b/src/bodyprog/view/vw_main.c
@@ -10,7 +10,7 @@ void vwInitViewInfo() // 0x80048A38
     vwViewPointInfo.rview.vp.vx = 0;
     vwViewPointInfo.rview.vr.vx = 0;
     vwViewPointInfo.rview.vr.vy = 0;
-    vwViewPointInfo.rview.vr.vz = 4096;
+    vwViewPointInfo.rview.vr.vz = TILE_UNIT(16.0f);
     vwViewPointInfo.rview.rz    = 0;
     vwViewPointInfo.rview.super = &vwViewPointInfo.vwcoord;
     GsInitCoordinate2(NULL, &vwViewPointInfo.vwcoord);
@@ -64,9 +64,9 @@ void vwSetViewInfoDirectMatrix(GsCOORDINATE2* pcoord, MATRIX* cammat) // 0x80048
 // Inlined into vwSetViewInfo, maybe vwMatrixToPosition?
 static inline void Math_MatrixToPosition(VECTOR3* pos, MATRIX* workm)
 {
-    pos->vx = workm->t[0] * 16;
-    pos->vy = workm->t[1] * 16;
-    pos->vz = workm->t[2] * 16;
+    pos->vx = workm->t[0] << FP_POS_Q;
+    pos->vy = workm->t[1] << FP_POS_Q;
+    pos->vz = workm->t[2] << FP_POS_Q;
 }
 
 void vwSetViewInfo() // 0x80048D48

--- a/src/main/fileinfo.c
+++ b/src/main/fileinfo.c
@@ -188,7 +188,6 @@ s32 Fs_FindNextFileOfType(s32 fileType, s32 startIdx, s32 dir)
 
     i = 0;
     currentIdx = startIdx + inc;
-
     while (i < FS_FILE_COUNT)
     {
         if (currentIdx >= FS_FILE_COUNT)
@@ -201,7 +200,7 @@ s32 Fs_FindNextFileOfType(s32 fileType, s32 startIdx, s32 dir)
         i++;
     }
 
-    return -1;
+    return NO_VALUE;
 }
 
 s32 Fs_FindNextFile(const char* name, s32 fileType, s32 startIdx)
@@ -212,7 +211,7 @@ s32 Fs_FindNextFile(const char* name, s32 fileType, s32 startIdx)
     s32 name4567;
 
     s32 i = startIdx;
-    s32 foundIdx = -1;
+    s32 foundIdx = NO_VALUE;
 
     Fs_EncodeFileName(&name0123, &name4567, name);
 

--- a/src/main/fsqueue_1.c
+++ b/src/main/fsqueue_1.c
@@ -77,11 +77,11 @@ s32 Fs_QueueStartReadTim(s32 fileIdx, void* dest, s_FsImageDesc* image)
     }
     else
     {
-        // u == 0xFF (-1) is a special case for "image descriptor not set".
+        // u == 0xFF (NO_VALUE) is a special case for "image descriptor not set".
         extra.image.u = 0xFF;
-        extra.image.clutX = -1;
+        extra.image.clutX = NO_VALUE;
         extra.image.v = 0xFF;
-        extra.image.clutY = -1;
+        extra.image.clutY = NO_VALUE;
     }
 
     return Fs_QueueEnqueue(fileIdx, FS_OP_READ, FS_POST_LOAD_TIM, false, dest, 0, &extra);
@@ -133,7 +133,7 @@ s32 Fs_QueueEnqueue(s32 fileIdx, u8 op, u8 postLoad, u8 alloc, void* data, u32 u
 void Fs_QueueInitialize(void)
 {
     bzero(&g_FsQueue, sizeof(g_FsQueue));
-    g_FsQueue.last.idx = -1;
+    g_FsQueue.last.idx = NO_VALUE;
     g_FsQueue.last.ptr = &g_FsQueue.entries[FS_QUEUE_LENGTH - 1];
     g_FsQueue.read.idx = 0;
     g_FsQueue.read.ptr = g_FsQueue.entries;

--- a/src/main/fsqueue_2.c
+++ b/src/main/fsqueue_2.c
@@ -73,7 +73,7 @@ s32 Fs_QueueUpdateRead(s_FsQueueEntry* entry)
             switch (CdReadSync(1, NULL))
             {
                 // CdReadSync failed; reset CD.
-                case -1:
+                case NO_VALUE:
                     g_FsQueue.state = FSQS_READ_RESET;
                     break;
 

--- a/src/main/fsqueue_3.c
+++ b/src/main/fsqueue_3.c
@@ -147,13 +147,13 @@ s32 Fs_QueueTickReadPcDvr(s_FsQueueEntry* entry)
     for (retry = 0; retry <= 2; retry++)
     {
         handle = open(pathBuffer, 0x4001);
-        if (handle == -1)
+        if (handle == NO_VALUE)
         {
             continue;
         }
 
         temp = read(handle,entry->data, ALIGN(file->blockCount * FS_BLOCK_SIZE, FS_SECTOR_SIZE));
-        if (temp == -1)
+        if (temp == NO_VALUE)
         {
             continue;
         }
@@ -162,7 +162,7 @@ s32 Fs_QueueTickReadPcDvr(s_FsQueueEntry* entry)
         {
             temp = close(handle);
         }
-        while (temp == -1);
+        while (temp == NO_VALUE);
 
         result = 1;
         break;
@@ -251,7 +251,7 @@ s32 Fs_QueuePostLoadTim(s_FsQueueEntry* entry)
     if (tim.caddr != NULL)
     {
         tempRect = *tim.crect;
-        if (entry->extra.image.clutX != -1)
+        if (entry->extra.image.clutX != NO_VALUE)
         {
             tempRect.x = entry->extra.image.clutX;
             tempRect.y = entry->extra.image.clutY;

--- a/src/screens/stream/stream.c
+++ b/src/screens/stream/stream.c
@@ -163,7 +163,7 @@ void movie_main(char* file_name, s32 f_size, s32 sector)
     VSync(0);
     strInit(&m->loc, strCallback);
 
-    while (strNextVlc(&m->dec) == -1)
+    while (strNextVlc(&m->dec) == NO_VALUE)
     {
         loc = file.pos;
         strKickCD(&loc);
@@ -196,7 +196,7 @@ void movie_main(char* file_name, s32 f_size, s32 sector)
         DecDCTin(m->dec.vlcbuf[m->dec.vlcid], 3);
         DecDCTout((u_long* ) m->dec.imgbuf, m->dec.slice.w * m->dec.slice.h / 2);
 
-        while (strNextVlc(&m->dec) == -1)
+        while (strNextVlc(&m->dec) == NO_VALUE)
         {
             frame_no = StGetBackloc(&loc);
             if (max_frame < frame_no || frame_no <= 0)
@@ -338,13 +338,13 @@ int strNextVlc(DECENV* dec) // 0x801E3298
 {
     u_long* next, *strNext();
 
-    u_long cnt = 2000;
+    u_long count = 2000;
     while ((next = strNext(dec)) == 0)
     {
-        cnt--;
-        if (!cnt)
+        count--;
+        if (!count)
         {
-            return -1;
+            return NO_VALUE;
         }
     }
 
@@ -359,11 +359,11 @@ u_long* strNext(DECENV* dec) // 0x801E331C
 {
     u_long*   addr;
     CDSECTOR* sector;
-    int       cnt = MOVIE_WAIT;
+    int       count = MOVIE_WAIT;
 
     while (StGetNext((u_long**)&addr, (u_long**)&sector))
     {
-        if (--cnt == 0)
+        if (--count == 0)
         {
             return 0;
         }
@@ -391,11 +391,11 @@ u_long* strNext(DECENV* dec) // 0x801E331C
 
 void strSync(DECENV* dec) // 0x801E3438
 {
-    volatile u_long cnt = WAIT_TIME;
+    volatile u_long count = WAIT_TIME;
 
     while (dec->isdone == 0)
     {
-        if (--cnt == 0)
+        if (--count == 0)
         {
             dec->isdone  = 1;
             dec->rectid  = dec->rectid ^ 1;


### PR DESCRIPTION
- Use `TILE_UNIT()` and `FP_POS_Q` macros in place of magic numbers.
- Add `NO_VALUE` macro as a non-magic alias for invalid values (-1).
- Figure out some fields in `s_MainCharacter` and `s_SubCharacter`, mostly related to the animation system.
- General housekeeping.