### PR TITLE
Revise math macros

### DIFF
--- a/include/bodyprog/math.h
+++ b/include/bodyprog/math.h
@@ -6,21 +6,25 @@
 #define Q12_SHIFT      12    /** Used for Q19.12 trigonometry. */
 #define FP_ANGLE_COUNT 65536 /** Number of possible fixed-point angles in Q1.15 format. */
 
-/** Converts a value to a fixed-point Q format. */
-#define TO_FIXED(value, shift) \
-	((value) << (shift))
+/** Multiplies two integers and converts the result from a fixed-point Q format. */
+#define MUL_FIXED(val0, val1, shift) \
+    (((val0) * (val1)) >> (shift))
 
-/** Converts a value from a fixed-point Q format. */
-#define FROM_FIXED(value, shift) \
-	((value) >> (shift))
+/** Converts an integer to a fixed-point Q format. */
+#define TO_FIXED(val, shift) \
+	((val) << (shift))
+
+/** Converts an integer from a fixed-point Q format. */
+#define FROM_FIXED(val, shift) \
+	((val) >> (shift))
 
 /** Converts degrees to fixed-point angles in Q1.15 format (used at Q4.12 resolution). */
 #define DEG_TO_FPA(deg) \
 	(s16)((deg) * ((FP_ANGLE_COUNT) / 360.0f))
 
 /** Clamps a value to the range [min, max]. */
-#define CLAMP(value, min, max) \
-    (((value) < (min)) ? (min) : (((value) > (max)) ? (max) : (value)))
+#define CLAMP(val, min, max) \
+    (((val) < (min)) ? (min) : (((val) > (max)) ? (max) : (val)))
 
 void func_80096C94(SVECTOR* vec, MATRIX* mat); // Custom vwRotMatrix...?
 void func_80096E78(SVECTOR* vec, MATRIX* mat); // Another custom vwRotMatrix...]?

--- a/include/bodyprog/math.h
+++ b/include/bodyprog/math.h
@@ -1,27 +1,31 @@
 #ifndef _BODYPROG_MATH_H
 #define _BODYPROG_MATH_H
 
-/** Quotient value used to shift fixed-point positions. */
-#define FP_POS_Q 4
+#define Q4_SHIFT       4     /** Used for Q27.4 positions. */
+#define Q8_SHIFT       8     /** Used for Q8.8 range limits. */
+#define Q12_SHIFT      12    /** Used for Q19.12 trigonometry. */
+#define FP_ANGLE_COUNT 65536 /** Number of possible fixed-point angles in Q1.15 format. */
 
-/** Quotient value used to shift fixed-point sin/cos. */
-#define FP_SIN_Q 12
+/** Converts a value to a fixed-point Q format. */
+#define TO_FIXED(value, shift) \
+	((value) << (shift))
 
-/** Number of possible fixed-point angles in Q15 format. */
-#define FP_ANGLE_COUNT 65536
+/** Converts a value from a fixed-point Q format. */
+#define FROM_FIXED(value, shift) \
+	((value) >> (shift))
 
-/** Converts degrees to fixed-point angles in Q15 format (used at Q12.4 resolution). */
+/** Converts degrees to fixed-point angles in Q1.15 format (used at Q4.12 resolution). */
 #define DEG_TO_FPA(deg) \
 	(s16)((deg) * ((FP_ANGLE_COUNT) / 360.0f))
 
-/** Clamps the input value to the range [min, max]. */
+/** Clamps a value to the range [min, max]. */
 #define CLAMP(value, min, max) \
-    ((value) < (min)) ? (min) : (((value) > (max)) ? (max) : (value))
+    (((value) < (min)) ? (min) : (((value) > (max)) ? (max) : (value)))
 
 void func_80096C94(SVECTOR* vec, MATRIX* mat); // Custom vwRotMatrix...?
 void func_80096E78(SVECTOR* vec, MATRIX* mat); // Another custom vwRotMatrix...]?
 
-s32 shRcos(s32);
 s32 shRsin(s32);
+s32 shRcos(s32);
 
 #endif

--- a/include/types.h
+++ b/include/types.h
@@ -26,7 +26,8 @@ typedef enum { false, true } bool;
 // Slightly modified VECTOR with padding int removed. Seems to be used through much of SH code.
 typedef struct
 {
-    long vx, vy;
+    long vx;
+    long vy;
     long vz;
 } VECTOR3;
 

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -300,9 +300,9 @@ void vcAutoRenewalWatchTgtPosAndAngZ(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type, V
         vcMakeNormalWatchTgtPos(&w_p->watch_tgt_pos_7C, &w_p->watch_tgt_ang_z_8C, w_p, cam_mv_type, cur_rd_area_size);
         if (far_watch_rate != 0)
         {
-            w_p->watch_tgt_pos_7C.vx += FROM_FIXED(far_watch_rate * (far_watch_pos.vx - w_p->watch_tgt_pos_7C.vx), Q12_SHIFT);
-            w_p->watch_tgt_pos_7C.vy += FROM_FIXED(far_watch_rate * (far_watch_pos.vy - w_p->watch_tgt_pos_7C.vy), Q12_SHIFT);
-            w_p->watch_tgt_pos_7C.vz += FROM_FIXED(far_watch_rate * (far_watch_pos.vz - w_p->watch_tgt_pos_7C.vz), Q12_SHIFT);
+            w_p->watch_tgt_pos_7C.vx += MUL_FIXED(far_watch_rate, far_watch_pos.vx - w_p->watch_tgt_pos_7C.vx, Q12_SHIFT);
+            w_p->watch_tgt_pos_7C.vy += MUL_FIXED(far_watch_rate, far_watch_pos.vy - w_p->watch_tgt_pos_7C.vy, Q12_SHIFT);
+            w_p->watch_tgt_pos_7C.vz += MUL_FIXED(far_watch_rate, far_watch_pos.vz - w_p->watch_tgt_pos_7C.vz, Q12_SHIFT);
         }
     }
     else
@@ -476,8 +476,8 @@ void vcMakeIdealCamPosByHeadPos(VECTOR3* ideal_pos, VC_WORK* w_p, VC_AREA_SIZE_T
         ideal_pos->vy   = w_p->chara_head_pos_130.vy + TILE_UNIT(1.6f);
     }
 
-    ideal_pos->vx = w_p->chara_head_pos_130.vx + FROM_FIXED(shRsin(chara2cam_ang_y) * DEG_TO_FPA(4.05f), Q12_SHIFT);
-    ideal_pos->vz = w_p->chara_head_pos_130.vz + FROM_FIXED(shRcos(chara2cam_ang_y) * DEG_TO_FPA(4.05f), Q12_SHIFT);
+    ideal_pos->vx = w_p->chara_head_pos_130.vx + MUL_FIXED(shRsin(chara2cam_ang_y), DEG_TO_FPA(4.05f), Q12_SHIFT);
+    ideal_pos->vz = w_p->chara_head_pos_130.vz + MUL_FIXED(shRcos(chara2cam_ang_y), DEG_TO_FPA(4.05f), Q12_SHIFT);
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeIdealCamPosForFixAngCam);
@@ -539,8 +539,8 @@ void vcMakeBasicCamTgtMvVec(VECTOR3* tgt_mv_vec, VECTOR3* ideal_pos, VC_WORK* w_
     }
     else
     {
-        tgt_mv_vec->vx = FROM_FIXED(max_tgt_mv_xz_len * shRsin(now2ideal_tgt_ang_y), Q12_SHIFT);
-        tgt_mv_vec->vz = FROM_FIXED(max_tgt_mv_xz_len * shRcos(now2ideal_tgt_ang_y), Q12_SHIFT);
+        tgt_mv_vec->vx = MUL_FIXED(max_tgt_mv_xz_len, shRsin(now2ideal_tgt_ang_y), Q12_SHIFT);
+        tgt_mv_vec->vz = MUL_FIXED(max_tgt_mv_xz_len, shRcos(now2ideal_tgt_ang_y), Q12_SHIFT);
     }
 
     if (g_CurDeltaTime == 0 && !(vcWork.flags_8 & VC_WARP_CAM_TGT_F))
@@ -603,8 +603,8 @@ void vcCamTgtMvVecIsFlipedFromCharaFront(VECTOR3* tgt_mv_vec, VC_WORK* w_p, s32 
             use_nearest_p = &w_p->cur_near_road_2B8;
         }
 
-        post_tgt_pos.vx = pre_tgt_pos.vx + FROM_FIXED(flip_dist * shRsin(flip_ang_y), Q12_SHIFT);
-        post_tgt_pos.vz = pre_tgt_pos.vz + FROM_FIXED(flip_dist * shRcos(flip_ang_y), Q12_SHIFT);
+        post_tgt_pos.vx = pre_tgt_pos.vx + MUL_FIXED(flip_dist, shRsin(flip_ang_y), Q12_SHIFT);
+        post_tgt_pos.vz = pre_tgt_pos.vz + MUL_FIXED(flip_dist, shRcos(flip_ang_y), Q12_SHIFT);
 
         min_x = TO_FIXED(use_nearest_p->rd_14.min_hx, Q8_SHIFT) + MIN_IN_ROAD_DIST;
         max_x = TO_FIXED(use_nearest_p->rd_14.max_hx, Q8_SHIFT) - MIN_IN_ROAD_DIST;
@@ -921,10 +921,10 @@ s32 vcCamMatNoise(s32 noise_w, s32 ang_spd1, s32 ang_spd2, s32 vcSelfViewTimer) 
 {
     s32 noise;
 
-    noise = shRcos(FROM_FIXED(ang_spd1 * (s64)vcSelfViewTimer, Q12_SHIFT)) + shRcos(FROM_FIXED(ang_spd2 * (s64)vcSelfViewTimer, Q12_SHIFT));
+    noise = shRcos(MUL_FIXED(ang_spd1, (s64)vcSelfViewTimer, Q12_SHIFT)) + shRcos(MUL_FIXED(ang_spd2, (s64)vcSelfViewTimer, Q12_SHIFT));
     noise = noise >> 1;
 
-    return FROM_FIXED(noise_w * noise, Q12_SHIFT);
+    return MUL_FIXED(noise_w, noise, Q12_SHIFT);
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", Math_VectorMagnitude);

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -16,9 +16,9 @@ void vcSetCameraUseWarp(VECTOR3* chr_pos, s16 chr_ang_y) // 0x800400D4
     cam_ang.vy = chr_ang_y;
     cam_ang.vz = 0;
 
-    cam_pos.vx = chr_pos->vx - FROM_FIXED(shRsin(chr_ang_y) * 0x1800, Q12_SHIFT);
+    cam_pos.vx = chr_pos->vx - MUL_FIXED(shRsin(chr_ang_y), 0x1800, Q12_SHIFT);
     cam_pos.vy = chr_pos->vy - TILE_UNIT(27.2f);
-    cam_pos.vz = chr_pos->vz - FROM_FIXED(shRcos(chr_ang_y) * 0x1800, Q12_SHIFT);
+    cam_pos.vz = chr_pos->vz - MUL_FIXED(shRcos(chr_ang_y), 0x1800, Q12_SHIFT);
 
     vcSetFirstCamWork(&cam_pos, chr_ang_y, g_SysWork.flags_22A4 & 0x40);
     g_SysWork.flags_22A4 &= ~0x40;
@@ -73,8 +73,8 @@ void vcMakeHeroHeadPos(VECTOR3* head_pos) // 0x8004047C
 
 void vcAddOfsToPos(VECTOR3* out_pos, VECTOR3* in_pos, s16 ofs_xz_r, s16 ang_y, s32 ofs_y) // 0x80040518
 {
-    out_pos->vx = in_pos->vx + FROM_FIXED(ofs_xz_r * shRsin(ang_y), Q12_SHIFT);
-    out_pos->vz = in_pos->vz + FROM_FIXED(ofs_xz_r * shRcos(ang_y), Q12_SHIFT);
+    out_pos->vx = in_pos->vx + MUL_FIXED(ofs_xz_r, shRsin(ang_y), Q12_SHIFT);
+    out_pos->vz = in_pos->vz + MUL_FIXED(ofs_xz_r, shRcos(ang_y), Q12_SHIFT);
     out_pos->vy = in_pos->vy + ofs_y;
 }
 

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -16,9 +16,9 @@ void vcSetCameraUseWarp(VECTOR3* chr_pos, s16 chr_ang_y) // 0x800400D4
     cam_ang.vy = chr_ang_y;
     cam_ang.vz = 0;
 
-    cam_pos.vx = chr_pos->vx - ((shRsin(chr_ang_y) * 0x1800) >> FP_SIN_Q);
+    cam_pos.vx = chr_pos->vx - FROM_FIXED(shRsin(chr_ang_y) * 0x1800, Q12_SHIFT);
     cam_pos.vy = chr_pos->vy - TILE_UNIT(27.2f);
-    cam_pos.vz = chr_pos->vz - ((shRcos(chr_ang_y) * 0x1800) >> FP_SIN_Q);
+    cam_pos.vz = chr_pos->vz - FROM_FIXED(shRcos(chr_ang_y) * 0x1800, Q12_SHIFT);
 
     vcSetFirstCamWork(&cam_pos, chr_ang_y, g_SysWork.flags_22A4 & 0x40);
     g_SysWork.flags_22A4 &= ~0x40;
@@ -61,20 +61,20 @@ void vcMakeHeroHeadPos(VECTOR3* head_pos) // 0x8004047C
 
     func_80049984(&g_SysWork.hero_neck_930, &neck_lwm);
 
-    fpos.vx = 0;
+    fpos.vx = TILE_UNIT(0.0f);
     fpos.vy = TILE_UNIT(-0.1f);
-    fpos.vz = 0;
+    fpos.vz = TILE_UNIT(0.0f);
     ApplyMatrix(&neck_lwm, &fpos, &sp38);
 
-    head_pos->vx = (sp38.vx + neck_lwm.t[0]) << FP_POS_Q;
-    head_pos->vy = ((sp38.vy + neck_lwm.t[1]) << FP_POS_Q) - TILE_UNIT(4.8f);
-    head_pos->vz = (sp38.vz + neck_lwm.t[2]) << FP_POS_Q;
+    head_pos->vx = TO_FIXED(sp38.vx + neck_lwm.t[0], Q4_SHIFT);
+    head_pos->vy = TO_FIXED(sp38.vy + neck_lwm.t[1], Q4_SHIFT) - TILE_UNIT(4.8f);
+    head_pos->vz = TO_FIXED(sp38.vz + neck_lwm.t[2], Q4_SHIFT);
 }
 
 void vcAddOfsToPos(VECTOR3* out_pos, VECTOR3* in_pos, s16 ofs_xz_r, s16 ang_y, s32 ofs_y) // 0x80040518
 {
-    out_pos->vx = in_pos->vx + ((ofs_xz_r * shRsin(ang_y)) >> FP_SIN_Q);
-    out_pos->vz = in_pos->vz + ((ofs_xz_r * shRcos(ang_y)) >> FP_SIN_Q);
+    out_pos->vx = in_pos->vx + FROM_FIXED(ofs_xz_r * shRsin(ang_y), Q12_SHIFT);
+    out_pos->vz = in_pos->vz + FROM_FIXED(ofs_xz_r * shRcos(ang_y), Q12_SHIFT);
     out_pos->vy = in_pos->vy + ofs_y;
 }
 
@@ -130,9 +130,9 @@ void vcSetRefPosAndCamPosAngByPad(VECTOR3* ref_pos, s_SysWork* sys_p) // 0x80040
 
     vwGetViewPosition(&cam_pos);
 
-    sp18.vx = cam_pos.vx >> FP_POS_Q;
-    sp18.vy = cam_pos.vy >> FP_POS_Q;
-    sp18.vz = cam_pos.vz >> FP_POS_Q;
+    sp18.vx = FROM_FIXED(cam_pos.vx, Q4_SHIFT);
+    sp18.vy = FROM_FIXED(cam_pos.vy, Q4_SHIFT);
+    sp18.vz = FROM_FIXED(cam_pos.vz, Q4_SHIFT);
 
     vwGetViewAngle(&cam_ang);
 
@@ -176,14 +176,14 @@ void vcSetRefPosAndCamPosAngByPad(VECTOR3* ref_pos, s_SysWork* sys_p) // 0x80040
                 var_v1 += 0xFFF;
             }
 
-            sp18.vx += var_v1 >> FP_SIN_Q;
+            sp18.vx += FROM_FIXED(var_v1, Q12_SHIFT);
             var_v1_4 = var_s0 * shRcos(cam_ang.vy);
             if (var_v1_4 < 0)
             {
                 var_v1_4 += 0xFFF;
             }
 
-            sp18.vz += var_v1_4 >> FP_SIN_Q;
+            sp18.vz += FROM_FIXED(var_v1_4, Q12_SHIFT);
         }
     }
     else
@@ -215,14 +215,14 @@ void vcSetRefPosAndCamPosAngByPad(VECTOR3* ref_pos, s_SysWork* sys_p) // 0x80040
                 var_v1 += 0xFFF;
             }
 
-            sp18.vx += var_v1 >> FP_SIN_Q;
+            sp18.vx += FROM_FIXED(var_v1, Q12_SHIFT);
 
             var_v1_4 = var_s0 * shRcos(cam_ang.vy + DEG_TO_FPA(5.625f));
             if (var_v1_4 < 0)
             {
                 var_v1_4 += 0xFFF;
             }
-            sp18.vz += var_v1_4 >> FP_SIN_Q;
+            sp18.vz += FROM_FIXED(var_v1_4, Q12_SHIFT);
         }
     }
 
@@ -239,12 +239,12 @@ void vcSetRefPosAndCamPosAngByPad(VECTOR3* ref_pos, s_SysWork* sys_p) // 0x80040
 
         vwAngleToVector(&sp58, &cam_ang, TILE_UNIT(5.0f));
 
-        ref_pos->vx = (sp18.vx + sp58.vx) << FP_POS_Q;
-        ref_pos->vy = (sp18.vy + sp58.vy) << FP_POS_Q;
-        ref_pos->vz = (sp18.vz + sp58.vz) << FP_POS_Q;
+        ref_pos->vx = TO_FIXED(sp18.vx + sp58.vx, Q4_SHIFT);
+        ref_pos->vy = TO_FIXED(sp18.vy + sp58.vy, Q4_SHIFT);
+        ref_pos->vz = TO_FIXED(sp18.vz + sp58.vz, Q4_SHIFT);
 
         sys_p->cam_ang_y_237A = ((cam_ang.vy + DEG_TO_FPA(11.25f)) << 0x14) >> 0x14;
-        sys_p->cam_y_2384     = -sp58.vy << FP_POS_Q;
-        sys_p->cam_r_xz_2380  = SquareRoot0((sp58.vx * sp58.vx) + (sp58.vz * sp58.vz)) << FP_POS_Q;
+        sys_p->cam_y_2384     = TO_FIXED(-sp58.vy, Q4_SHIFT);
+        sys_p->cam_r_xz_2380  = TO_FIXED(SquareRoot0((sp58.vx * sp58.vx) + (sp58.vz * sp58.vz)), Q4_SHIFT);
     }
 }

--- a/src/bodyprog/view/vw_calc.c
+++ b/src/bodyprog/view/vw_calc.c
@@ -42,8 +42,8 @@ void vwRenewalXZVelocityToTargetPos(s32* velo_x, s32* velo_z, VECTOR3* now_pos, 
     ratan2(*velo_x, *velo_z);
 
     add_spd = Math_MulFixed(accel, g_CurDeltaTime, Q12_SHIFT);
-    *velo_x += FROM_FIXED(add_spd * shRsin(temp_v0), Q12_SHIFT);
-    *velo_z += FROM_FIXED(add_spd * shRcos(temp_v0), Q12_SHIFT);
+    *velo_x += MUL_FIXED(add_spd, shRsin(temp_v0), Q12_SHIFT);
+    *velo_z += MUL_FIXED(add_spd, shRcos(temp_v0), Q12_SHIFT);
 
     temp_v0_2 = Math_VectorMagnitude(*velo_x, 0, *velo_z);
     if (total_max_spd < temp_v0_2)
@@ -185,10 +185,10 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_8004A54C);
 
 void vwAngleToVector(SVECTOR* vec, SVECTOR* ang, s32 r) // 0x8004A66C
 {
-    s32 entou_r = FROM_FIXED(r * shRcos(ang->vx), Q12_SHIFT);
-    vec->vy     = FROM_FIXED(-r * shRsin(ang->vx), Q12_SHIFT);
-    vec->vx     = FROM_FIXED(entou_r * shRsin(ang->vy), Q12_SHIFT);
-    vec->vz     = FROM_FIXED(entou_r * shRcos(ang->vy), Q12_SHIFT);
+    s32 entou_r = MUL_FIXED(r, shRcos(ang->vx), Q12_SHIFT);
+    vec->vy = MUL_FIXED(-r, shRsin(ang->vx), Q12_SHIFT);
+    vec->vx = MUL_FIXED(entou_r, shRsin(ang->vy), Q12_SHIFT);
+    vec->vz = MUL_FIXED(entou_r, shRcos(ang->vy), Q12_SHIFT);
 }
 
 s32 vwVectorToAngle(SVECTOR* ang, SVECTOR* vec) // 0x8004A714

--- a/src/bodyprog/view/vw_calc.c
+++ b/src/bodyprog/view/vw_calc.c
@@ -41,29 +41,29 @@ void vwRenewalXZVelocityToTargetPos(s32* velo_x, s32* velo_z, VECTOR3* now_pos, 
 
     ratan2(*velo_x, *velo_z);
 
-    add_spd = Math_MulFixed(accel, g_CurDeltaTime, FP_SIN_Q);
-    *velo_x += (add_spd * shRsin(temp_v0)) >> FP_SIN_Q;
-    *velo_z += (add_spd * shRcos(temp_v0)) >> FP_SIN_Q;
+    add_spd = Math_MulFixed(accel, g_CurDeltaTime, Q12_SHIFT);
+    *velo_x += FROM_FIXED(add_spd * shRsin(temp_v0), Q12_SHIFT);
+    *velo_z += FROM_FIXED(add_spd * shRcos(temp_v0), Q12_SHIFT);
 
     temp_v0_2 = Math_VectorMagnitude(*velo_x, 0, *velo_z);
     if (total_max_spd < temp_v0_2)
     {
         temp_s1_2 = temp_v0_2 - total_max_spd;
         ang_y     = ratan2(*velo_x, *velo_z);
-        *velo_x -= Math_MulFixed(temp_s1_2, shRsin(ang_y), FP_SIN_Q);
-        *velo_z -= Math_MulFixed(temp_s1_2, shRcos(ang_y), FP_SIN_Q);
+        *velo_x -= Math_MulFixed(temp_s1_2, shRsin(ang_y), Q12_SHIFT);
+        *velo_z -= Math_MulFixed(temp_s1_2, shRcos(ang_y), Q12_SHIFT);
     }
 
     temp_s1_3    = tgt_pos->vx - now_pos->vx;
     temp_s0      = tgt_pos->vz - now_pos->vz;
     to_tgt_ang_y = ratan2(temp_s1_3, temp_s0);
-    var_s1       = Math_MulFixed(dec_forwd_lim_spd, Math_VectorMagnitude(temp_s1_3, 0, temp_s0) - tgt_r, FP_SIN_Q);
+    var_s1       = Math_MulFixed(dec_forwd_lim_spd, Math_VectorMagnitude(temp_s1_3, 0, temp_s0) - tgt_r, Q12_SHIFT);
 
     if (var_s1 < 0)
         var_s1 = 0;
 
     vwLimitOverLimVector(velo_x, velo_z, var_s1, to_tgt_ang_y);
-    vwDecreaseSideOfVector(velo_x, velo_z, Math_MulFixed(dec_accel_side, g_CurDeltaTime, FP_SIN_Q), var_s1 >> 1, to_tgt_ang_y);
+    vwDecreaseSideOfVector(velo_x, velo_z, Math_MulFixed(dec_accel_side, g_CurDeltaTime, Q12_SHIFT), var_s1 >> 1, to_tgt_ang_y);
 }
 
 void vwLimitOverLimVector(s32* vec_x, s32* vec_z, s32 lim_vec_len, s16 lim_vec_ang_y) // 0x8004914C
@@ -75,11 +75,11 @@ void vwLimitOverLimVector(s32* vec_x, s32* vec_z, s32 lim_vec_len, s16 lim_vec_a
     lim_spd_dir_x = shRsin(lim_vec_ang_y);
     lim_spd_dir_z = shRcos(lim_vec_ang_y);
 
-    over_spd = (Math_MulFixed(*vec_x, lim_spd_dir_x, FP_SIN_Q) + Math_MulFixed(*vec_z, lim_spd_dir_z, FP_SIN_Q)) - lim_vec_len;
+    over_spd = (Math_MulFixed(*vec_x, lim_spd_dir_x, Q12_SHIFT) + Math_MulFixed(*vec_z, lim_spd_dir_z, Q12_SHIFT)) - lim_vec_len;
     if (over_spd > 0)
     {
-        *vec_x -= Math_MulFixed(over_spd, lim_spd_dir_x, FP_SIN_Q);
-        *vec_z -= Math_MulFixed(over_spd, lim_spd_dir_z, FP_SIN_Q);
+        *vec_x -= Math_MulFixed(over_spd, lim_spd_dir_x, Q12_SHIFT);
+        *vec_z -= Math_MulFixed(over_spd, lim_spd_dir_z, Q12_SHIFT);
     }
 }
 
@@ -185,10 +185,10 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_8004A54C);
 
 void vwAngleToVector(SVECTOR* vec, SVECTOR* ang, s32 r) // 0x8004A66C
 {
-    s32 entou_r = (r * shRcos(ang->vx)) >> FP_SIN_Q;
-    vec->vy     = (-r * shRsin(ang->vx)) >> FP_SIN_Q;
-    vec->vx     = (entou_r * shRsin(ang->vy)) >> FP_SIN_Q;
-    vec->vz     = (entou_r * shRcos(ang->vy)) >> FP_SIN_Q;
+    s32 entou_r = FROM_FIXED(r * shRcos(ang->vx), Q12_SHIFT);
+    vec->vy     = FROM_FIXED(-r * shRsin(ang->vx), Q12_SHIFT);
+    vec->vx     = FROM_FIXED(entou_r * shRsin(ang->vy), Q12_SHIFT);
+    vec->vz     = FROM_FIXED(entou_r * shRcos(ang->vy), Q12_SHIFT);
 }
 
 s32 vwVectorToAngle(SVECTOR* ang, SVECTOR* vec) // 0x8004A714

--- a/src/bodyprog/view/vw_main.c
+++ b/src/bodyprog/view/vw_main.c
@@ -49,9 +49,9 @@ void vwSetCoordRefAndEntou(GsCOORDINATE2* parent_p, s32 ref_x, s32 ref_y, s32 re
 
     func_80096E78(&view_ang, view_mtx);
 
-    view_mtx->t[0] = (ref_x >> FP_POS_Q) + (((cam_xz_r >> FP_POS_Q) * shRsin(cam_ang_y)) >> FP_SIN_Q);
-    view_mtx->t[1] = (ref_y >> FP_POS_Q) + (cam_y >> FP_POS_Q);
-    view_mtx->t[2] = (ref_z >> FP_POS_Q) + (((cam_xz_r >> FP_POS_Q) * shRcos(cam_ang_y)) >> FP_SIN_Q);
+    view_mtx->t[0] = FROM_FIXED(ref_x, Q4_SHIFT) + FROM_FIXED(FROM_FIXED(cam_xz_r, Q4_SHIFT) * shRsin(cam_ang_y), Q12_SHIFT);
+    view_mtx->t[1] = FROM_FIXED(ref_y, Q4_SHIFT) + FROM_FIXED(cam_y, Q4_SHIFT);
+    view_mtx->t[2] = FROM_FIXED(ref_z, Q4_SHIFT) + FROM_FIXED(FROM_FIXED(cam_xz_r, Q4_SHIFT) * shRcos(cam_ang_y), Q12_SHIFT);
 }
 
 void vwSetViewInfoDirectMatrix(GsCOORDINATE2* pcoord, MATRIX* cammat) // 0x80048CF0
@@ -64,9 +64,9 @@ void vwSetViewInfoDirectMatrix(GsCOORDINATE2* pcoord, MATRIX* cammat) // 0x80048
 // Inlined into vwSetViewInfo, maybe vwMatrixToPosition?
 static inline void Math_MatrixToPosition(VECTOR3* pos, MATRIX* workm)
 {
-    pos->vx = workm->t[0] << FP_POS_Q;
-    pos->vy = workm->t[1] << FP_POS_Q;
-    pos->vz = workm->t[2] << FP_POS_Q;
+    pos->vx = TO_FIXED(workm->t[0], Q4_SHIFT);
+    pos->vy = TO_FIXED(workm->t[1], Q4_SHIFT);
+    pos->vz = TO_FIXED(workm->t[2], Q4_SHIFT);
 }
 
 void vwSetViewInfo() // 0x80048D48


### PR DESCRIPTION
- Add `TO_FIXED()` and `FROM_FIXED()` function macros for conversion to and from fixed-point Q formats.
- Add `MUL_FIXED()` function macro.
- Add `Q4_SHIFT`, `Q8_SHIFT`, and `Q12_SHIFT` constant macros for use in fixed-point conversion: Q4_SHIFT for positions, Q8_SHIFT for range limits, and Q12_SHIFT for trigonometric calculations.
- Remove `FP_POS_Q` and `FP_SIN_Q`.