### PR TITLE
objdiff_generate: allow objdiff auto-build when files change

### DIFF
--- a/tools/objdiff/objdiff_generate.py
+++ b/tools/objdiff/objdiff_generate.py
@@ -25,6 +25,8 @@ class ProgressCategory:
 class Config:
     build_base: bool
     build_target: bool
+    custom_make: str
+    custom_args: list[str]
     units: list[Unit]
     progress_categories: list[ProgressCategory]
 
@@ -88,7 +90,7 @@ def main():
         categories.append(ProgressCategory(category["id"], category["name"]))
     
     with (Path(config["output"])).open("w") as json_file:
-        json.dump(asdict(Config(False, False, units, categories)), json_file, indent=2)
+        json.dump(asdict(Config(True, False, "make", ["build", "NON_MATCHING=1", "SKIP_ASM=1"], units, categories)), json_file, indent=2)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Updated objdiff_generate.py so that it adds these lines to objdiff.json, with that you can use `make progress` & then load project into the objdiff GUI to let it auto-build changed files for you, useful for doing local work on some small matches:
```
  "build_base": true,
  "custom_make": "make",
  "custom_args": ["build", "NON_MATCHING=1", "SKIP_ASM=1"],
```

There is `make build-cn` which also runs `make build NON_MATCHING=1 SKIP_ASM=1` but that does a full regenerate too, maybe some `make progress-update` or `make build-progress` that just calls `build NON_MATCHING=1 SKIP_ASM=1` would be nicer.

Not sure how this might affect CI, I did see some other decomp.dev projects were using custom_make too though: https://github.com/bfbbdecomp/bfbb/blob/5ad9b58fc3586227faea9b59703e14862b80a999/tools/project.py#L1002 https://github.com/projectPiki/pikmin/blob/983b9a9da3849bc321ef4fca2c4b3a42f99c7c19/tools/project.py#L1285