### PR TITLE
libsd: more midi matches, start SMF_MIDI / SMF_PORT structs

### DIFF
--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -385,6 +385,7 @@ sd_int_flag2 = 0x800B2594;
 smf_start_flag = 0x800B2598;
 sd_timer_sync = 0x800B259C;
 timer_count = 0x800B25A0;
+sd_timer_flag = 0x800B25B4; // type:s32 guessed name
 time_flag = 0x800B25B8;
 smf_file_no = 0x800B25BC;
 print_start = 0x800B25C0;

--- a/include/bodyprog/libsd.h
+++ b/include/bodyprog/libsd.h
@@ -18,7 +18,7 @@ extern s16 sd_keyoff_mode;
 extern s32 sd_interrupt_start_flag;
 extern s32 sd_tick_mode;
 extern u8  sd_vb_malloc_rec[];
-extern u32 sd_reserved_voice;
+extern s32 sd_reserved_voice;
 extern s32 sd_mono_st_flag;
 extern s32 sd_int_flag;
 extern s32 sd_int_flag2;
@@ -26,8 +26,10 @@ extern s32 sd_timer_sync;
 extern s32 smf_start_flag;
 extern u32 sd_vab_transfer_offset;
 extern s16 sd_seq_loop_mode;
+extern s32 sd_timer_event;
+extern s32 smf_file_no;
 
-extern s32 spu_ch_tbl[24];
+extern u32 spu_ch_tbl[24];
 
 typedef struct _VAB_S // Pachinko Dream uses similar VAB_S struct
 {
@@ -42,6 +44,7 @@ typedef struct _VAB_S // Pachinko Dream uses similar VAB_S struct
     char           field_1A; // rvol? ^
     s8             master_pan_1B;
 } s_VAB_S;
+STATIC_ASSERT_SIZEOF(s_VAB_S, 0x1C);
 
 extern s_VAB_S vab_h[0x10];
 
@@ -67,6 +70,7 @@ typedef struct _SMF_TRACK_S
     u8  byte26;
     u8  byte27;
 } s_SMF_TRACK_S;
+STATIC_ASSERT_SIZEOF(s_SMF_TRACK_S, 0x28);
 
 typedef struct _SMF_S // Standard MIDI File
 {
@@ -90,14 +94,154 @@ typedef struct _SMF_S // Standard MIDI File
     u8            field_52D;
     u8            beat2_52E;
     u8            control_status_52F;
-    s16           field_530;
+    u16           field_530;
     u16           field_532;
-    s16           seq_wide_534;
+    u16           seq_wide_534;
     u16           field_536;
     u16           field_538;
     u8            unk_53A[2];
 } s_SMF_S;
+STATIC_ASSERT_SIZEOF(s_SMF_S, 0x53C);
 
+/** s_SMF_MIDI fields are mainly changed by control_change(), which takes in a MIDI control change ID and adjusts appropriate field
+ * Seems that func accepts some change IDs that are undefined in MIDI specs though... */
+typedef struct _SMF_MIDI
+{
+    u8  vabProgNum_0;
+    u8  pan_1;
+    u8  field_2;
+    u8  vol_3;
+    u8  field_4;
+    u8  expression_5;
+    u8  damperPedalEnabled_6;
+    u8  pitchBendFine_7;
+    u32 field_8;
+    u32 field_C;
+    u8  footPedal_10;
+    u8  effect1Controller_11;
+    u8  monoMode_12;
+    u8  field_13;
+    u16 field_14;
+    u8  unk_16[2];
+    u16 field_18;
+    s16 field_1A;
+    s16 field_1C;
+    s16 field_1E;
+    u8  field_20;
+    u8  field_21;
+    u16 field_22;
+    u8  effect1Depth_24;
+    u8  nrpnLsb_25;
+    u8  nrpnMsb_26;
+    u8  nrpnData_27;
+    s16 portamentoTime_28;
+    s16 field_2A;
+    s16 field_2C;
+    u16 field_2E;
+    u16 field_30;
+    u16 field_32;
+    u8  field_34;
+    u8  unk_35[1];
+    u8  field_36;
+    u8  field_37;
+    u8  field_38;
+    u8  field_39;
+    u8  field_3A;
+    u8  field_3B;
+    u16 field_3C;
+    u16 field_3E;
+    u16 field_40;
+    u8  unk_42[2];
+    u8  field_44;
+    u8  field_45;
+    u8  field_46;
+    u8  field_47;
+    u16 field_48;
+    u16 field_4A;
+    u16 field_4C;
+    u8  unk_4E[2];
+    u8  field_50;
+    u8  field_51;
+    u8  field_52;
+    u8  field_53;
+    u16 field_54;
+    u8  field_56;
+    u8  effect2Controller_57;
+    u8  field_58;
+    u8  field_59;
+    u8  bank_idx_5A;
+    u8  unk_5B[1];
+} s_SMF_MIDI;
+STATIC_ASSERT_SIZEOF(s_SMF_MIDI, 0x5C);
+
+typedef struct _SMF_PORT
+{
+    u8  field_0;
+    u8  unk_1[1];
+    u8  midiProgramNum_2;
+    u8  smf_midi_num_3;
+    u16 field_4;
+    u16 midiKeyNum_6;
+    u16 field_8;
+    u8  unk_A[2];
+    u16 vol_left_C;
+    u16 vol_right_E;
+    u8  field_10;
+    u8  field_11;
+    u8  field_12;
+    u8  field_13;
+    u16 field_14;
+    u16 field_16;
+    u8  unk_18[2];
+    u8  field_1A;
+    u8  field_1B;
+    u8  field_1C;
+    u8  field_1D;
+    u8  field_1E;
+    u8  field_1F;
+    u8  field_20;
+    u8  field_21[1];
+    u8  field_22;
+    u8  field_23;
+    u16 field_24;
+    u16 field_26;
+    u8  field_28;
+    u8  field_29;
+    u8  field_2A;
+    u8  field_2B;
+    u16 field_2C;
+    u16 field_2E;
+    u8  field_30;
+    u8  unk_31[1];
+    u8  field_32;
+    u8  field_33;
+    u16 field_34;
+    u16 field_36;
+    u8  field_38;
+    u8  field_39;
+    u8  field_3A;
+    u8  field_3B;
+    u16 field_3C;
+    s16 field_3E;
+    u16 field_40;
+    u8  randomTblIndex_42;
+    u8  field_43;
+    u8  field_44;
+    u8  field_45;
+    u16 field_46;
+    u16 field_48;
+    u16 field_4A;
+    s16 field_4C;
+    u16 field_4E;
+    u16 field_50;
+    u8  vabId_52;
+    u8  unk_53[1];
+} s_SMF_PORT;
+STATIC_ASSERT_SIZEOF(s_SMF_PORT, 0x54);
+
+extern s_SMF_MIDI smf_midi[2 * 16]; // 2 devices with 16 channels each?
+extern s_SMF_MIDI D_800C82B8;       // smf_midi[32] ? used in sound_off
+extern s_SMF_PORT smf_port[24];
 extern s_SMF_S smf_song[2];
 
 // sdmain.c
@@ -132,7 +276,8 @@ s16  SdSeqOpenWithAccNum(s32* addr, s16 vab_id, s16 seq_access_num);
 void SdSeqPlay(s16 seq_access_num, u8 play_mode, s16 l_count);
 void SdSeqStop(s16 seq_access_num);
 void SdSeqClose(s16 seq_access_num);
-
+void SdSeqPause(s16 seq_access_num);
+void SdSeqReplay(s16 seq_access_num);
 void SdSeqSetVol(s16 seq_access_num, s16 voll, s16 volr);
 void SdSeqGetVol(s16 seq_access_num, s16* voll, s16* volr);
 void SdUtFlush(void);
@@ -141,15 +286,25 @@ void SdUtReverbOff(void);
 s16  SdUtSetReverbType(s16 type);
 void SdUtSetReverbDepth(s16 left, s16 right);
 void SdSetRVol(s16 left, s16 right);
-
+void SdUtSEAllKeyOff();
 void SdUtAllKeyOff(s16 mode);
+
+void SdVoKeyOff(s32 vab_pro, s32 pitch);
+void SdVoKeyOffWithRROff(s32 vab_pro, s32 pitch);
 
 s16 SdGetSeqStatus(s16 seq_access_num);
 
 u16  SdGetTempo(s16 seq_access_num);
 void SdSetTempo(s16 seq_access_num, s16 tempo);
-void SdSetSeqWide(s16 seq_access_num, s16 seq_wide);
-
+void SdSetSeqWide(s16 seq_access_num, u16 seq_wide);
+u8   SdGetMidiVol(s16 device, s16 channel);
+void SdSetMidiVol(s16 device, s16 channel, s32 vol);
+void SdSetMidiExpress(s16 device, s16 channel, s32 expression);
+u8   SdGetMidiExpress(s16 device, s16 channel);
+u8   SdGetMidiPan(s16 device, s16 channel);
+void SdSetMidiPan(s16 device, s16 channel, s32 pan);
+u8   SdGetMidiPitchBendFine(s16 device, s16 channel);
+s32  SdSetMidiPitchBendFine(s16 device, s16 channel, u8 pitchBendFine);
 s32 SdGetTrackTranspause();
 s32 SdSetTrackTranspause();
 s32 SdGetTrackMute(s16 seq_access_num, s32 channel);
@@ -161,23 +316,46 @@ s32 SdGetSeqBeat2(s16 seq_access_num);
 
 // sdmidi.c
 
-void midi_vsync();
+void tre_calc(s_SMF_PORT*);
+void vib_calc(s_SMF_PORT*);
+void random_calc(s_SMF_PORT* midiPort);
+void volume_calc(s_SMF_PORT*, s_SMF_MIDI*);
+void smf_vol_set(s32 midiChannel, s32 voice, s32 volLeft, s32 volRight);
+void master_vol_set();
+void seq_master_vol_set(s32 seq_access_num);
+void toremoro_set();
 
+void pitch_calc(s_SMF_PORT*, s32);
+void midi_mod(s_SMF_MIDI* midiTrack);
+void midi_porta(s_SMF_MIDI* midiTrack);
+void replay_reverb_set(s16 seq_access_num);
+void midi_vsync();
+void sound_seq_off(s32);
 void sound_off();
 void set_note_on_mb(void);
+void adsr_set(s32 voice, s_SMF_PORT* midiPort);
+void rr_off(s32 voice);
 
+void key_off(u8 midiNum, u8 keyNum);
 void key_press(void);
 
+void control_change(u8, s32, s32);
+void program_change(u8 midiChannel, u8 progNum);
 void chan_press(void);
 
-void control_code_set(void);
+void control_code_set(s32 seq_access_num);
 
 // sdmidi2.c
 
-s32  smf_timer(void);
+s32  smf_timer();
 void smf_timer_set();
-
+void smf_timer_end();
+void smf_timer_stop();
 void smf_vsync(void);
+s32  MemCmp(u8* str1, u8* str2, s32 count);
+s32  readMThd(u32 offset);
+s32  readMTrk(u32 offset);
+s32  readEOF(u32 offset);
 
 // to32bit/to16bit/len_add only seem used inside sdmidi2.c, can probably be removed from header.
 s32  to32bit(char arg0, char arg1, char arg2, char arg3);

--- a/src/bodyprog/libsd/sdmidi.c
+++ b/src/bodyprog/libsd/sdmidi.c
@@ -1,4 +1,9 @@
 #include "common.h"
+#include "bodyprog/libsd.h"
+
+#include <libspu.h>
+
+extern SpuVoiceAttr s_attr;
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", func_800A397C);
 
@@ -10,45 +15,366 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", tre_calc);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", vib_calc);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", random_calc);
+void random_calc(s_SMF_PORT* midiPort) // 0x800A3E70
+{
+    extern u8 random_tbl[];
+
+    s32 var_v0;
+    s8  randValue;
+
+    if (!midiPort->field_43)
+        return;
+
+    midiPort->field_44 += midiPort->field_43;
+
+    if (midiPort->field_44 < 0x7F && midiPort->field_43 != 127)
+        return;
+
+    midiPort->field_44 = midiPort->field_44 & 0x7F;
+
+    randValue = random_tbl[midiPort->randomTblIndex_42];
+    midiPort->randomTblIndex_42++;
+
+    if (randValue)
+    {
+        var_v0 = randValue * midiPort->field_45;
+        if (var_v0 < 0)
+        {
+            var_v0 += 3;
+        }
+        midiPort->field_40 = (var_v0 >> 2);
+    }
+    else
+    {
+        midiPort->field_40 = 0;
+    }
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", volume_calc);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", smf_vol_set);
+void smf_vol_set(s32 midiChannel, s32 voice, s32 volLeft, s32 volRight) // 0x800A4150
+{
+    s_attr.mask  = (SPU_VOICE_VOLL | SPU_VOICE_VOLR | SPU_VOICE_VOLMODEL | SPU_VOICE_VOLMODER);
+    s_attr.voice = spu_ch_tbl[voice];
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", master_vol_set);
+    if (volLeft | volRight)
+    {
+        s_attr.volume.left  = (volLeft * smf_song[midiChannel >> 4].vol_left_50C) >> 7;
+        s_attr.volume.right = (volRight * smf_song[midiChannel >> 4].vol_right_50E) >> 7;
+        if (smf_midi[midiChannel].field_21 || smf_song[midiChannel >> 4].seq_wide_534) // seq_wide s16 -> u16
+        {
+            s_attr.volume.right = -s_attr.volume.right;
+        }
+    }
+    else
+    {
+        s_attr.volume.right = 0;
+        s_attr.volume.left  = 0;
+    }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", seq_master_vol_set);
+    s_attr.volmode.left  = 0;
+    s_attr.volmode.right = 0;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", toremoro_set);
+    SpuSetVoiceAttr(&s_attr);
+}
+
+void master_vol_set() // 0x800A4260
+{
+    s32 i;
+
+    sd_int_flag = 1;
+
+    for (i = 0; i < sd_reserved_voice; i++)
+    {
+        volume_calc(&smf_port[i], &smf_midi[smf_port[i].smf_midi_num_3]);
+        smf_vol_set(smf_port[i].smf_midi_num_3, i, smf_port[i].vol_left_C, smf_port[i].vol_right_E);
+    }
+
+    sd_int_flag = 0;
+}
+
+void seq_master_vol_set(s32 seq_access_num) // 0x800A4314
+{
+    s32 i;
+
+    for (i = 0; i < sd_reserved_voice; i++)
+    {
+        if ((smf_port[i].smf_midi_num_3 >> 4) == seq_access_num)
+        {
+            smf_vol_set(smf_port[i].smf_midi_num_3, i, smf_port[i].vol_left_C, smf_port[i].vol_right_E);
+        }
+    }
+}
+
+void toremoro_set() // 0x800A439C
+{
+    s16 temp_v1;
+    s32 i;
+
+    for (i = 0; i < sd_reserved_voice; i++)
+    {
+        temp_v1 = smf_port[i].field_3E;
+        if (smf_port[i].field_4C != temp_v1)
+        {
+            smf_vol_set(smf_port[i].smf_midi_num_3, i, smf_port[i].vol_left_C + temp_v1, smf_port[i].vol_right_E + temp_v1);
+        }
+    }
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", pitch_bend_calc);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", pitch_calc);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", midi_mod);
+void midi_mod(s_SMF_MIDI* midiTrack) // 0x800A4608
+{
+    if (midiTrack->field_2 != 0)
+    {
+        if (midiTrack->field_14 != 0)
+        {
+            if ((midiTrack->field_1C + midiTrack->field_1A) < midiTrack->field_1E)
+            {
+                midiTrack->field_1C = midiTrack->field_1C + midiTrack->field_1A;
+            }
+            else
+            {
+                midiTrack->field_14 = 0;
+                midiTrack->field_1C = midiTrack->field_1E;
+            }
+        }
+        else if ((midiTrack->field_1C - midiTrack->field_1A) > -midiTrack->field_1E)
+        {
+            midiTrack->field_1C = midiTrack->field_1C - midiTrack->field_1A;
+        }
+        else
+        {
+            midiTrack->field_14 = 1;
+            midiTrack->field_1C = -midiTrack->field_1E;
+        }
+    }
+    else
+    {
+        midiTrack->field_1C = 0;
+    }
+}
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", midi_porta);
+void midi_porta(s_SMF_MIDI* midiTrack) // 0x800A46B8
+{
+    if (midiTrack->portamentoTime_28 != 0)
+    {
+        if (midiTrack->field_30 != 0)
+        {
+            if ((midiTrack->field_2A + midiTrack->field_2C) < midiTrack->field_2E)
+            {
+                midiTrack->field_2A = midiTrack->field_2A + midiTrack->field_2C;
+            }
+            else
+            {
+                midiTrack->field_2A = midiTrack->field_2E;
+            }
+        }
+        else
+        {
+            if ((midiTrack->field_2C - midiTrack->field_2A) < midiTrack->field_2E)
+            {
+                midiTrack->field_2A = midiTrack->field_2A - midiTrack->field_2C;
+            }
+            else
+            {
+                midiTrack->field_2A = -midiTrack->field_2E;
+            }
+        }
+    }
+}
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", replay_reverb_set);
+void replay_reverb_set(s16 seq_access_num) // 0x800A4748
+{
+    SpuReverbAttr reverb;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", midi_vsync);
+    if (smf_song[seq_access_num].field_532 != 0)
+    {
+        if (smf_song[seq_access_num].field_532 & 1)
+        {
+            reverb.mask = SPU_REV_DEPTHL | SPU_REV_DEPTHR;
+            if (smf_song[seq_access_num].field_532 << 8 < smf_song[seq_access_num].field_536)
+            {
+                reverb.depth.left = reverb.depth.right = smf_song[seq_access_num].field_532 << 8;
+            }
+            else
+            {
+                reverb.depth.left = reverb.depth.right = smf_song[seq_access_num].field_536;
+                smf_song[seq_access_num].field_532     = 0;
+                return; // BUG: returns before it sets field_536 as reverb?
+            }
+            SpuSetReverbModeParam(&reverb);
+            SpuSetReverb(1);
+        }
+        smf_song[seq_access_num].field_532 += 2;
+    }
+}
+
+void midi_vsync() // 0x800A4838
+{
+    s32 device;
+    s32 channel;
+
+    for (device = 0; device < 2; device++)
+    {
+        if (smf_song[device].play_status_50A == 1)
+        {
+            for (channel = 0; channel < 0x10; channel++)
+            {
+                midi_mod(&smf_midi[channel + (device * 0x10)]);
+                midi_porta(&smf_midi[channel + (device * 0x10)]);
+            }
+        }
+    }
+
+    for (channel = 0; channel < sd_reserved_voice; channel++)
+    {
+        u8 midi_num = smf_port[channel].smf_midi_num_3;
+        if (midi_num < 32 && smf_song[midi_num >> 4].play_status_50A == 1)
+        {
+            vib_calc(&smf_port[channel]);
+            tre_calc(&smf_port[channel]);
+            random_calc(&smf_port[channel]);
+            pitch_calc(&smf_port[channel], 0);
+            if (smf_song[(u8)smf_port[channel].smf_midi_num_3 >> 4].field_530 != 0)
+            {
+                smf_vol_set(smf_port[channel].smf_midi_num_3, channel, smf_port[channel].vol_left_C, smf_port[channel].vol_right_E);
+            }
+        }
+    }
+
+    for (device = 0; device < 2; device++)
+    {
+        if (smf_song[device].play_status_50A == 1)
+        {
+            replay_reverb_set(device);
+            if (smf_song[device].field_530 != 0)
+            {
+                smf_song[device].field_530 = 0;
+            }
+        }
+    }
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", sound_seq_off);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", sound_off);
+void sound_off() // 0x800A4D20
+{
+    u32 voice;
+    s32 keyStatus;
+    s32 i;
+    u32 voices;
+
+    voices = 0;
+
+    for (i = 0; i < 2; i++)
+    {
+        sound_seq_off(i);
+    }
+
+    for (i = 0; i < sd_reserved_voice; i++)
+    {
+        smf_vol_set(0, i, 0, 0);
+        smf_port[i].field_0  = i;
+        smf_port[i].field_16 = 0;
+        smf_port[i].field_14 = 0x40;
+        smf_port[i].field_4E = 0x40;
+        smf_port[i].field_50 = 0x40;
+        voice                = spu_ch_tbl[i];
+        voices |= voice;
+        rr_off(i);
+        do
+        {
+            SpuSetKey(0, voice);
+            keyStatus = SpuGetKeyStatus(voice);
+        } while (keyStatus != 2 && keyStatus != 0);
+    }
+
+    D_800C82B8.vol_3                = 0x7F;
+    D_800C82B8.pan_1                = 0x40;
+    D_800C82B8.pitchBendFine_7      = 0x40;
+    D_800C82B8.damperPedalEnabled_6 = 0;
+    D_800C82B8.expression_5         = 0x7F;
+    D_800C82B8.field_8              = 0x7F;
+    D_800C82B8.field_C              = 0x7F;
+    D_800C82B8.field_2              = 0;
+    D_800C82B8.field_32             = 0;
+    D_800C82B8.portamentoTime_28    = 0;
+
+    do
+    {
+        SpuSetKey(0, voices);
+        keyStatus = SpuGetKeyStatus(voices);
+    } while (keyStatus != 2 && keyStatus != 0);
+}
 
 void set_note_on_mb(void) {} // 0x800A4E90
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", adsr_set);
+void adsr_set(s32 voice, s_SMF_PORT* midiPort) // 0x800A4E98
+{
+    s_attr.mask   = SPU_VOICE_ADSR_AMODE | SPU_VOICE_ADSR_ADSR1 | SPU_VOICE_ADSR_ADSR2;
+    s_attr.voice  = spu_ch_tbl[voice];
+    s_attr.adsr1  = midiPort->field_46;
+    s_attr.adsr2  = midiPort->field_48;
+    s_attr.a_mode = midiPort->field_4A;
+    SpuSetVoiceAttr(&s_attr);
+}
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", rr_off);
+void rr_off(s32 voice) // 0x800A4F08
+{
+    s_attr.mask   = SPU_VOICE_ADSR_AMODE | SPU_VOICE_ADSR_ADSR1 | SPU_VOICE_ADSR_ADSR2;
+    s_attr.voice  = spu_ch_tbl[voice];
+    s_attr.adsr1  = 0;
+    s_attr.adsr2  = 0;
+    s_attr.a_mode = 5;
+    SpuSetVoiceAttr(&s_attr);
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", voice_check);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", key_on);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", key_off);
+void key_off(u8 midiNum, u8 keyNum)
+{
+    s32 keyStatus;
+    s32 i;
+    u32 voices;
+
+    voices = 0;
+
+    for (i = 0; i < sd_reserved_voice; i++)
+    {
+        if (midiNum == smf_port[i].smf_midi_num_3 && keyNum == smf_port[i].midiKeyNum_6)
+        {
+            if (smf_port[i].field_1B == 0)
+            {
+                adsr_set(i, &smf_port[i]);
+                voices |= spu_ch_tbl[i];
+                do
+                {
+                    SpuSetKey(0, spu_ch_tbl[i]);
+                    keyStatus = SpuGetKeyStatus(spu_ch_tbl[i]);
+                } while (keyStatus != 2 && keyStatus != 0);
+                smf_port[i].field_16 = 0;
+            }
+            else
+            {
+                smf_port[i].field_1A |= 0x80;
+            }
+        }
+    }
+
+    if (voices != 0)
+    {
+        do
+        {
+            SpuSetKey(0, voices);
+            keyStatus = SpuGetKeyStatus(voices);
+        } while (keyStatus != 2 && keyStatus != 0);
+    }
+}
 
 void key_press(void) {} // 0x800A5DCC
 
@@ -58,10 +384,13 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", smf_data_entry);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", control_change);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", program_change);
+void program_change(u8 midiChannel, u8 progNum) // 0x800A6C2C
+{
+    smf_midi[midiChannel].vabProgNum_0 = progNum;
+}
 
 void chan_press(void) {} // 0x800A6C58
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/libsd/sdmidi", pitch_bend);
 
-void control_code_set(void) {} // 0x800A6CB0
+void control_code_set(s32 seq_access_num) {} // 0x800A6CB0


### PR DESCRIPTION
Added a bunch more libsd midi funcs, started on structs but haven't really mapped much out for them yet, seems the midi stuff is all custom and not based on libsnd :(

Updated maspsx submodule to include nop fix needed for `smf_vol_set`