### PR TITLE
splat: add global_vram_start & sym.bodyprog to configs

### DIFF
--- a/configs/bodyprog.yaml
+++ b/configs/bodyprog.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -16,6 +16,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map0_s00.yaml
+++ b/configs/maps/map0_s00.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map0_s00.txt
   reloc_addrs_path:
     - configs/maps/rel.map0_s00.txt

--- a/configs/maps/map0_s01.yaml
+++ b/configs/maps/map0_s01.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map0_s01.txt
   reloc_addrs_path:
     - configs/maps/rel.map0_s01.txt

--- a/configs/maps/map0_s02.yaml
+++ b/configs/maps/map0_s02.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map0_s02.txt
   reloc_addrs_path:
     - configs/maps/rel.map0_s02.txt

--- a/configs/maps/map1_s00.yaml
+++ b/configs/maps/map1_s00.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map1_s00.txt
   reloc_addrs_path:
     - configs/maps/rel.map1_s00.txt

--- a/configs/maps/map1_s01.yaml
+++ b/configs/maps/map1_s01.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map1_s01.txt
   reloc_addrs_path:
     - configs/maps/rel.map1_s01.txt

--- a/configs/maps/map1_s02.yaml
+++ b/configs/maps/map1_s02.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map1_s02.txt
   reloc_addrs_path:
     - configs/maps/rel.map1_s02.txt

--- a/configs/maps/map1_s03.yaml
+++ b/configs/maps/map1_s03.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map1_s03.txt
   reloc_addrs_path:
     - configs/maps/rel.map1_s03.txt

--- a/configs/maps/map1_s04.yaml
+++ b/configs/maps/map1_s04.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map1_s04.txt
   reloc_addrs_path:
     - configs/maps/rel.map1_s04.txt

--- a/configs/maps/map1_s05.yaml
+++ b/configs/maps/map1_s05.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map1_s05.txt
   reloc_addrs_path:
     - configs/maps/rel.map1_s05.txt

--- a/configs/maps/map1_s06.yaml
+++ b/configs/maps/map1_s06.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map1_s06.txt
   reloc_addrs_path:
     - configs/maps/rel.map1_s06.txt

--- a/configs/maps/map2_s00.yaml
+++ b/configs/maps/map2_s00.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map2_s00.txt
   reloc_addrs_path:
     - configs/maps/rel.map2_s00.txt

--- a/configs/maps/map2_s01.yaml
+++ b/configs/maps/map2_s01.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map2_s01.txt
   reloc_addrs_path:
     - configs/maps/rel.map2_s01.txt

--- a/configs/maps/map2_s02.yaml
+++ b/configs/maps/map2_s02.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map2_s02.txt
   reloc_addrs_path:
     - configs/maps/rel.map2_s02.txt

--- a/configs/maps/map2_s03.yaml
+++ b/configs/maps/map2_s03.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map2_s03.txt
   reloc_addrs_path:
     - configs/maps/rel.map2_s03.txt

--- a/configs/maps/map2_s04.yaml
+++ b/configs/maps/map2_s04.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map2_s04.txt
   reloc_addrs_path:
     - configs/maps/rel.map2_s04.txt

--- a/configs/maps/map3_s00.yaml
+++ b/configs/maps/map3_s00.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map3_s00.txt
   reloc_addrs_path:
     - configs/maps/rel.map3_s00.txt

--- a/configs/maps/map3_s01.yaml
+++ b/configs/maps/map3_s01.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map3_s01.txt
   reloc_addrs_path:
     - configs/maps/rel.map3_s01.txt

--- a/configs/maps/map3_s02.yaml
+++ b/configs/maps/map3_s02.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map3_s02.txt
   reloc_addrs_path:
     - configs/maps/rel.map3_s02.txt

--- a/configs/maps/map3_s03.yaml
+++ b/configs/maps/map3_s03.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map3_s03.txt
   reloc_addrs_path:
     - configs/maps/rel.map3_s03.txt

--- a/configs/maps/map3_s04.yaml
+++ b/configs/maps/map3_s04.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map3_s04.txt
   reloc_addrs_path:
     - configs/maps/rel.map3_s04.txt

--- a/configs/maps/map3_s05.yaml
+++ b/configs/maps/map3_s05.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map3_s05.txt
   reloc_addrs_path:
     - configs/maps/rel.map3_s05.txt

--- a/configs/maps/map3_s06.yaml
+++ b/configs/maps/map3_s06.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map3_s06.txt
   reloc_addrs_path:
     - configs/maps/rel.map3_s06.txt

--- a/configs/maps/map4_s00.yaml
+++ b/configs/maps/map4_s00.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map4_s00.txt
   reloc_addrs_path:
     - configs/maps/rel.map4_s00.txt

--- a/configs/maps/map4_s01.yaml
+++ b/configs/maps/map4_s01.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map4_s01.txt
   reloc_addrs_path:
     - configs/maps/rel.map4_s01.txt

--- a/configs/maps/map4_s02.yaml
+++ b/configs/maps/map4_s02.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map4_s02.txt
   reloc_addrs_path:
     - configs/maps/rel.map4_s02.txt

--- a/configs/maps/map4_s03.yaml
+++ b/configs/maps/map4_s03.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map4_s03.txt
   reloc_addrs_path:
     - configs/maps/rel.map4_s03.txt

--- a/configs/maps/map4_s04.yaml
+++ b/configs/maps/map4_s04.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map4_s04.txt
   reloc_addrs_path:
     - configs/maps/rel.map4_s04.txt

--- a/configs/maps/map4_s05.yaml
+++ b/configs/maps/map4_s05.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map4_s05.txt
   reloc_addrs_path:
     - configs/maps/rel.map4_s05.txt

--- a/configs/maps/map4_s06.yaml
+++ b/configs/maps/map4_s06.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map4_s06.txt
   reloc_addrs_path:
     - configs/maps/rel.map4_s06.txt

--- a/configs/maps/map5_s00.yaml
+++ b/configs/maps/map5_s00.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map5_s00.txt
   reloc_addrs_path:
     - configs/maps/rel.map5_s00.txt

--- a/configs/maps/map5_s01.yaml
+++ b/configs/maps/map5_s01.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map5_s01.txt
   reloc_addrs_path:
     - configs/maps/rel.map5_s01.txt

--- a/configs/maps/map5_s02.yaml
+++ b/configs/maps/map5_s02.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map5_s02.txt
   reloc_addrs_path:
     - configs/maps/rel.map5_s02.txt

--- a/configs/maps/map5_s03.yaml
+++ b/configs/maps/map5_s03.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map5_s03.txt
   reloc_addrs_path:
     - configs/maps/rel.map5_s03.txt

--- a/configs/maps/map6_s00.yaml
+++ b/configs/maps/map6_s00.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map6_s00.txt
   reloc_addrs_path:
     - configs/maps/rel.map6_s00.txt

--- a/configs/maps/map6_s01.yaml
+++ b/configs/maps/map6_s01.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map6_s01.txt
   reloc_addrs_path:
     - configs/maps/rel.map6_s01.txt

--- a/configs/maps/map6_s02.yaml
+++ b/configs/maps/map6_s02.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map6_s02.txt
   reloc_addrs_path:
     - configs/maps/rel.map6_s02.txt

--- a/configs/maps/map6_s03.yaml
+++ b/configs/maps/map6_s03.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map6_s03.txt
   reloc_addrs_path:
     - configs/maps/rel.map6_s03.txt

--- a/configs/maps/map6_s04.yaml
+++ b/configs/maps/map6_s04.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map6_s04.txt
   reloc_addrs_path:
     - configs/maps/rel.map6_s04.txt

--- a/configs/maps/map6_s05.yaml
+++ b/configs/maps/map6_s05.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map6_s05.txt
   reloc_addrs_path:
     - configs/maps/rel.map6_s05.txt

--- a/configs/maps/map7_s00.yaml
+++ b/configs/maps/map7_s00.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map7_s00.txt
   reloc_addrs_path:
     - configs/maps/rel.map7_s00.txt

--- a/configs/maps/map7_s01.yaml
+++ b/configs/maps/map7_s01.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map7_s01.txt
   reloc_addrs_path:
     - configs/maps/rel.map7_s01.txt

--- a/configs/maps/map7_s02.yaml
+++ b/configs/maps/map7_s02.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map7_s02.txt
   reloc_addrs_path:
     - configs/maps/rel.map7_s02.txt

--- a/configs/maps/map7_s03.yaml
+++ b/configs/maps/map7_s03.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,7 @@ options:
 
   symbol_addrs_path:
     - configs/sym.main.txt
+    - configs/sym.bodyprog.txt
     - configs/maps/sym.map7_s03.txt
   reloc_addrs_path:
     - configs/maps/rel.map7_s03.txt

--- a/configs/screens/b_konami.yaml
+++ b/configs/screens/b_konami.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/screens/credits.yaml
+++ b/configs/screens/credits.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/screens/options.yaml
+++ b/configs/screens/options.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/screens/saveload.yaml
+++ b/configs/screens/saveload.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/screens/stream.yaml
+++ b/configs/screens/stream.yaml
@@ -15,6 +15,7 @@ options:
 
   find_file_boundaries: False
   gp_value: 0x80022BB0
+  global_vram_start: 0x80010000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/include/screens/options/options.h
+++ b/include/screens/options/options.h
@@ -3,10 +3,6 @@
 
 #include "common.h"
 
-extern u8 D_800BC747;
-
-extern u8 D_800BC748;
-
 void func_801E3F68(void);
 
 void func_801E3F90(void);

--- a/include/screens/saveload/saveload.h
+++ b/include/screens/saveload/saveload.h
@@ -13,7 +13,6 @@ typedef struct
 extern s_FsImageDesc D_800A902C;
 extern u8            D_800A97D4[];
 extern s8            D_800A97D8;
-extern s32           D_800B9FE0[];
 extern u32           D_800BCD34;
 extern s8            D_800BCD39;
 extern s8            D_800BCD40;

--- a/src/screens/options/options.c
+++ b/src/screens/options/options.c
@@ -10,12 +10,12 @@ INCLUDE_ASM("asm/screens/options/nonmatchings/options", func_801E3770);
 
 void func_801E3F68(void)
 {
-    func_801E3FB8(0, D_800BC747);
+    func_801E3FB8(0, g_GameWork.optVolumeBgm_1F);
 }
 
 void func_801E3F90(void)
 {
-    func_801E3FB8(1, D_800BC748);
+    func_801E3FB8(1, g_GameWork.optVolumeSe_20);
 }
 
 INCLUDE_ASM("asm/screens/options/nonmatchings/options", func_801E3FB8);

--- a/src/screens/saveload/saveload.c
+++ b/src/screens/saveload/saveload.c
@@ -85,7 +85,7 @@ void func_801E63C0(void)
 
     func_801E2D8C();
     
-    D_800B9FE0[0] = 0;
+    g_SysWork.field_20 = 0;
     g_GameWork.gameStateStep_598[0]++;
     g_GameWork.gameStateStep_598[1] = 0;
     g_GameWork.gameStateStep_598[2] = 0;


### PR DESCRIPTION
Fixes issues with symbols being placed inside known ones in the disassembly, eg. `D_800BA134` refs will now become `g_SysWork+0x174`

Seems this only affected overlays since they didn't have any vram region for bodyprog etc setup, which is why we saw things like https://decomp.me/scratch/oOieA using `D_800B9FDC` instead of `g_SysWork+0x1c` in STREAM.BIN, or https://decomp.me/scratch/PXNW1 & https://decomp.me/scratch/6ugPF using `D_800BA134` instead of `g_SysWork+0x174` in the map bins.
(the map overlays were also missing sym.bodyprog.txt include too, oops)

It only affected disassembly though, using either `D_800BA134` or `g_SysWork+0x174` would both assembled to same opcodes & made matching code, but since disassembly is what we use to work on decomp it was easy to accidentally use the alias instead of the actual var :/

Should make m2c decomp a bit more accurate too hopefully, some scratches might need to be redone after this though (not sure if the asm for them can be replaced?)