### PR TITLE
MainCharacter: struct fix

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -311,10 +311,10 @@ typedef struct _SubCharacter
 } s_SubCharacter;
 STATIC_ASSERT_SIZEOF(s_SubCharacter, 296);
 
-typedef struct _MainCharacter
+typedef struct _MainCharacterExtra
 {
     // SubCharacter has the same 0x2C starting bytes?
-    // Maybe some base model struct which SubCharacter extends, model for torch or something attached to player?
+    // Maybe this is actually just a base model struct, which SubCharacter extends, and the extra data in MainCharacter is some model attached to player?
     u8             field_0;
     u8             field_1;
     u8             field_2;
@@ -328,8 +328,15 @@ typedef struct _MainCharacter
     s32            field_20; // Some kind of anim state.
     s32            field_24; // Some kind of anim state.
     s8             unk_28[4];
+} s_MainCharacterExtra;
+STATIC_ASSERT_SIZEOF(s_MainCharacterExtra, 44);
+
+typedef struct _MainCharacter
+{
+    s_SubCharacter       character;
+    s_MainCharacterExtra extra_128;
 } s_MainCharacter;
-STATIC_ASSERT_SIZEOF(s_MainCharacter, 44);
+STATIC_ASSERT_SIZEOF(s_MainCharacter, 340);
 
 typedef struct _SysWork
 {
@@ -351,8 +358,7 @@ typedef struct _SysWork
     s8              unk_46;
     s8              unk_47;
     char            unk_48[4];
-	s_SubCharacter  character_4C;
-    s_MainCharacter player_174;
+    s_MainCharacter player_4C;
     s_SubCharacter  characters_1A0[NPC_COUNT_MAX];
     GsCOORDINATE2   unk_coord_890[2];
     GsCOORDINATE2   hero_neck_930;

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -866,10 +866,10 @@ void SysWork_SaveGameUpdatePlayer() // 0x8003A120
     s_ShSaveGame* save      = g_SaveGamePtr;
     save->curMapEventNum_A8 = g_MapEventIdx;
 
-    save->playerPosX_244        = g_SysWork.character_4C.position_18.vx;
-    save->playerPosZ_24C        = g_SysWork.character_4C.position_18.vz;
-    save->playerRotationYaw_248 = g_SysWork.character_4C.rotation_24.vy;
-    save->playerHealth_240      = g_SysWork.character_4C.health_B0;
+    save->playerPosX_244        = g_SysWork.player_4C.character.position_18.vx;
+    save->playerPosZ_24C        = g_SysWork.player_4C.character.position_18.vz;
+    save->playerRotationYaw_248 = g_SysWork.player_4C.character.rotation_24.vy;
+    save->playerHealth_240      = g_SysWork.player_4C.character.health_B0;
 }
 
 void func_8003A16C() // 0x8003A16C
@@ -886,10 +886,10 @@ void func_8003A16C() // 0x8003A16C
 
 void SysWork_SaveGameReadPlayer() // 0x8003A1F4
 {
-    g_SysWork.character_4C.position_18.vx = g_SaveGamePtr->playerPosX_244;
-    g_SysWork.character_4C.position_18.vz = g_SaveGamePtr->playerPosZ_24C;
-    g_SysWork.character_4C.rotation_24.vy = g_SaveGamePtr->playerRotationYaw_248;
-    g_SysWork.character_4C.health_B0      = g_SaveGamePtr->playerHealth_240;
+    g_SysWork.player_4C.character.position_18.vx = g_SaveGamePtr->playerPosX_244;
+    g_SysWork.player_4C.character.position_18.vz = g_SaveGamePtr->playerPosZ_24C;
+    g_SysWork.player_4C.character.rotation_24.vy = g_SaveGamePtr->playerRotationYaw_248;
+    g_SysWork.player_4C.character.health_B0      = g_SaveGamePtr->playerHealth_240;
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003A230);

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -370,7 +370,7 @@ void vcAutoRenewalWatchTgtPosAndAngZ(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type, V
     }
 
     vcMixSelfViewEffectToWatchTgtPos(&w_p->watch_tgt_pos_7C, &w_p->watch_tgt_ang_z_8C, self_view_eff_rate,
-                                     w_p, &g_SysWork.hero_neck_930.workm, g_SysWork.character_4C.animIdx_4);
+                                     w_p, &g_SysWork.hero_neck_930.workm, g_SysWork.player_4C.character.animIdx_4);
 
     if (w_p->watch_tgt_pos_7C.vy > w_p->watch_tgt_max_y_88)
     {

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -115,7 +115,7 @@ void vcSetRefPosAndSysRef2CamParam(VECTOR3* ref_pos, s_SysWork* sys_p, s32 for_f
         sys_p->cam_r_xz_2380 = TILE_UNIT(16.0f);
     }
 
-    vcAddOfsToPos(ref_pos, &g_SysWork.character_4C.position_18, TILE_UNIT(8.0f), g_SysWork.character_4C.rotation_24.vy, TILE_UNIT(-16.0f));
+    vcAddOfsToPos(ref_pos, &g_SysWork.player_4C.character.position_18, TILE_UNIT(8.0f), g_SysWork.player_4C.character.rotation_24.vy, TILE_UNIT(-16.0f));
 }
 
 void vcSetRefPosAndCamPosAngByPad(VECTOR3* ref_pos, s_SysWork* sys_p) // 0x800406D4

--- a/src/maps/map0_s00/map0_s00.c
+++ b/src/maps/map0_s00/map0_s00.c
@@ -89,13 +89,12 @@ INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D2244);
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D23EC);
 
-#ifdef NON_MATCHING
 void func_800D2C7C(s32 arg0)
 {
-    s_MainCharacter* extra = &g_SysWork.player_174;
-    s_SubCharacter* subchar = &g_SysWork.character_4C; 
-    g_SysWork.character_4C.field_126 = 0;
-    
+    s_MainCharacterExtra* extra             = &g_SysWork.player_4C.extra_128;
+    s_SubCharacter*       character         = &g_SysWork.player_4C.character;
+    g_SysWork.player_4C.character.field_126 = 0;
+
     D_800C4606 = 0;
     
     switch (arg0)
@@ -117,18 +116,15 @@ void func_800D2C7C(s32 arg0)
         break;
     }
 
-    g_SysWork.player_174.field_1C = arg0;
-    
-    subchar->field_3 = 0;
-    subchar->field_2 = 0;
+    g_SysWork.player_4C.extra_128.field_1C = arg0;
+
+    character->field_3                     = 0;
+    character->field_2                     = 0;
     extra->field_3 = 0;
     extra->field_2 = 0;
-    g_SysWork.player_174.field_20 = 0;
-    g_SysWork.player_174.field_24 = 0;
+    g_SysWork.player_4C.extra_128.field_20 = 0;
+    g_SysWork.player_4C.extra_128.field_24 = 0;
 }
-#else
-INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D2C7C);
-#endif
 
 void func_800D2D2C(void)
 {
@@ -137,21 +133,21 @@ void func_800D2D2C(void)
 
 void func_800D2D44(void)
 {
-    s_MainCharacter* extra = &g_SysWork.player_174;
-    s_SubCharacter* character = &g_SysWork.character_4C; 
+    s_MainCharacterExtra* extra     = &g_SysWork.player_4C.extra_128;
+    s_SubCharacter*       character = &g_SysWork.player_4C.character;
     extra->flags_6 &= 0xFFFE;
     character->flags_6 &= 0xFFFE;
 }
 
 s32 func_800D2D6C(void)
 {
-    return ~(g_SysWork.character_4C.flags_6 & 1);
+    return ~(g_SysWork.player_4C.character.flags_6 & 1);
 }
 
 void func_800D2D84(void)
 {
-    s_MainCharacter* extra = &g_SysWork.player_174;
-    s_SubCharacter* character = &g_SysWork.character_4C; 
+    s_MainCharacterExtra* extra     = &g_SysWork.player_4C.extra_128;
+    s_SubCharacter*       character = &g_SysWork.player_4C.character;
     extra->flags_6 |= 1;
     character->flags_6 |= 1;
 }
@@ -159,11 +155,11 @@ void func_800D2D84(void)
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D2DAC);
 
 s32 func_800D2E50(void) {
-    return g_SysWork.character_4C.field_126 == 0;
+    return g_SysWork.player_4C.character.field_126 == 0;
 }
 
 void func_800D2E60(void) {
-    g_SysWork.character_4C.field_126 = 0;
+    g_SysWork.player_4C.character.field_126 = 0;
 }
 
 void func_800D2E6C() {}
@@ -184,7 +180,7 @@ s32 func_800D2E94()
 void func_800D2E9C() {}
 
 u8 func_800D2EA4(void) {
-    return g_SysWork.character_4C.unk_10D;
+    return g_SysWork.player_4C.character.unk_10D;
 }
 
 void func_800D2EB4(void) {
@@ -340,7 +336,7 @@ void func_800DBE00() {
     g_SysWork.field_10 = 0;
     g_SysWork.field_2C = 0;
     g_SysWork.field_14 = 0;
-    g_SysWork.character_4C.position_18.vy = 0;
+    g_SysWork.player_4C.character.position_18.vy = 0;
 }
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800DBE68);


### PR DESCRIPTION
Not really sure what happened to the structs there, changing MainCharacter to the 0x2C struct didn't seem intended but I could be wrong :P, fixed that, and looks like the NON_MATCHING in map00 matches fine now too so removed that ifdef.

There's a good chance the game didn't have any MainCharacter struct, and SysWork just has a SubCharacter field & some kind of SubModel for the extra part, seems that extra stuff is for something attached to player (gun / torch?)

I'm sure I did see some func that took in a MainCharacter* and accessed both the subchar & extra from it though, but haven't been able to dig that up again yet...