### PR TITLE
bodyprog/map0: add 13 matches, fix some NON_MATCHING

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <th colspan=3>Total Progress</th>
         </tr>
         <tr>
-            <td colspan=3 align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&category=all"/></td>
+            <td colspan=3 align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&category=all"/></a></td>
         </tr>
         <tr>
             <th colspan=3>⚙ SLUS-00707 ⚙</th>
@@ -23,7 +23,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Purpose</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&category=main"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?category=main"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&category=main"/></a></td>
             <td colspan=2>Main executable.</td>
         </tr>
         <tr>
@@ -31,7 +31,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Purpose</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&category=sdk"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?category=sdk"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&category=sdk"/></a></td>
             <td colspan=2>Psy-Q libraries.</td>
         </tr>
         <tr>
@@ -52,7 +52,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Purpose</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&category=engine"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?category=engine"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&category=engine"/></a></td>
             <td colspan=2>Main game logic.</td>
         </tr>
         <tr>
@@ -63,7 +63,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Purpose</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=screens/b_konami/b_konami"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=screens/b_konami/b_konami"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=screens/b_konami/b_konami"/></a></td>
             <td colspan=2>Boot screen logic.</td>
         </tr>
         <tr>
@@ -74,7 +74,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Purpose</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=screens/stream/stream&color=rgb(0,200,0)"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=screens/stream/stream"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=screens/stream/stream&color=rgb(0,200,0)"/></a></td>
             <td>Full motion videos stream logic.</td>
         </tr>
         <tr>
@@ -85,7 +85,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Purpose</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=screens/saveload/saveload"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=screens/saveload/saveload"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=screens/saveload/saveload"/></a></td>
             <td colspan=2>Save and load screen logic.</td>
         </tr>
         <tr>
@@ -96,7 +96,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Purpose</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=screens/credits/credits"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=screens/credits/credits"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=screens/credits/credits"/></a></td>
             <td colspan=2>Credits roll logic.</td>
         </tr>
         <tr>
@@ -107,7 +107,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Purpose</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=screens/options/options"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=screens/options/options"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=screens/options/options"/></a></td>
             <td colspan=2>Options screen logic.</td>
         </tr>
       </tbody>
@@ -132,7 +132,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map0_s00/map0_s00"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map0_s00/map0_s00"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map0_s00/map0_s00"/></a></td>
             <td colspan=2>Old Silent Hill.</td>
         </tr>
         <tr>
@@ -143,7 +143,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map0_s01/map0_s01"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map0_s01/map0_s01"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map0_s01/map0_s01"/></a></td>
             <td colspan=2>Cafe in Old Silent Hill.</td>
         </tr>
         <tr>
@@ -154,7 +154,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map0_s02/map0_s02"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map0_s02/map0_s02"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map0_s02/map0_s02"/></a></td>
             <td colspan=2>Bonus unlockable areas in Old Silent Hill.</td>
         </tr>
         <tr>
@@ -165,7 +165,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s00/map1_s00"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map1_s00/map1_s00"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s00/map1_s00"/></a></td>
             <td colspan=2>School first floor, courtyard, and basement.</td>
         </tr>
         <tr>
@@ -176,7 +176,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s01/map1_s01"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map1_s01/map1_s01"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s01/map1_s01"/></a></td>
             <td colspan=2>School second floor.</td>
         </tr>
         <tr>
@@ -187,7 +187,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s02/map1_s02"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map1_s02/map1_s02"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s02/map1_s02"/></a></td>
             <td colspan=2>School first floor and courtyard in Otherworld.</td>
         </tr>
         <tr>
@@ -198,7 +198,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s03/map1_s03"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map1_s03/map1_s03"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s03/map1_s03"/></a></td>
             <td colspan=2>School second floor and school roof in Otherworld.</td>
         </tr>
         <tr>
@@ -209,7 +209,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td>Note</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s04/map1_s05"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map1_s04/map1_s05"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s04/map1_s05"/></a></td>
             <td>Unknown</td>
             <td>School location, likely in Otherworld.</td>
         </tr>
@@ -220,7 +220,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td>Note</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s05/map1_s05"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map1_s05/map1_s05"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s05/map1_s05"/></a></td>
             <td>Unknown</td>
             <td>School location, likely in Otherworld.</td>
         </tr>
@@ -231,7 +231,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s06/map1_s06"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map1_s06/map1_s06"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map1_s06/map1_s06"/></a></td>
             <td colspan=2>School first floor and basement after the boss fight.</td>
         </tr>
         <tr>
@@ -242,7 +242,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map2_s00/map2_s00"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map2_s00/map2_s00"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map2_s00/map2_s00"/></a></td>
             <td colspan=2>Old Silent Hill after finishing the school.</td>
         </tr>
         <tr>
@@ -253,7 +253,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map2_s01/map2_s01"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map2_s01/map2_s01"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map2_s01/map2_s01"/></a></td>
             <td colspan=2>Church</td>
         </tr>
         <tr>
@@ -264,7 +264,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map2_s02/map2_s02"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map2_s02/map2_s02"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map2_s02/map2_s02"/></a></td>
             <td colspan=2>Central Silent Hill</td>
         </tr>
         <tr>
@@ -276,7 +276,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td>Note</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map2_s03/map2_s03"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map2_s03/map2_s03"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map2_s03/map2_s03"/></a></td>
             <td>Unknown</td>
             <td>Location related to Central Silent Hill.</td>
         </tr>
@@ -288,7 +288,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map2_s04/map2_s04"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map2_s04/map2_s04"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map2_s04/map2_s04"/></a></td>
             <td colspan=2>Police station in Central Silent Hill.</td>
         </tr>
         <tr>
@@ -300,7 +300,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td>Note</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s00/map3_s00"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map3_s00/map3_s00"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s00/map3_s00"/></a></td>
             <td>Unknown</td>
             <td>Hospital, possibly only the reception<br/>and examination rooms but none of<br/>the rooms around them.</td>
         </tr>
@@ -313,7 +313,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td>Note</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s01/map3_s01"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map3_s01/map3_s01"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s01/map3_s01"/></a></td>
             <td>Unknown</td>
             <td>Hospital, possibly the rest of the first floor<br/>not covered by <code>MAP3_S00.BIN</code><br/>and the basement.</td>
         </tr>
@@ -326,7 +326,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td>Note</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s02/map3_s02"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map3_s02/map3_s02"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s02/map3_s02"/></a></td>
             <td>Unknown</td>
             <td>Hospital, the part when Harry goes<br/>in the elevator and it goes dark.</td>
         </tr>
@@ -338,7 +338,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s03/map3_s03"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map3_s03/map3_s03"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s03/map3_s03"/></a></td>
             <td colspan=2>Hospital third and second floor in Otherworld.</td>
         </tr>
         <tr>
@@ -349,7 +349,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s04/map3_s04"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map3_s04/map3_s04"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s04/map3_s04"/></a></td>
             <td colspan=2>Hospital first floor in Otherworld.</td>
         </tr>
         <tr>
@@ -360,7 +360,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s05/map3_s05"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map3_s05/map3_s05"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s05/map3_s05"/></a></td>
             <td colspan=2>Hospital basement in Otherworld.</td>
         </tr>
         <tr>
@@ -371,7 +371,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s06/map3_s06"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map3_s06/map3_s06"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map3_s06/map3_s06"/></a></td>
             <td colspan=2>Hospital first floor after the Otherworld section.</td>
         </tr>
         <tr>
@@ -382,7 +382,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s00/map4_s00"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map4_s00/map4_s00"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s00/map4_s00"/></a></td>
             <td colspan=2>Unknown</td>
         </tr>
         <tr>
@@ -393,7 +393,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s01/map4_s01"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map4_s01/map4_s01"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s01/map4_s01"/></a></td>
             <td colspan=2>Green Lion Antique Shop in Old Silent Hill and Otherworld.</td>
         </tr>
         <tr>
@@ -405,7 +405,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td>Note</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s02/map4_s02"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map4_s02/map4_s02"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s02/map4_s02"/></a></td>
             <td>Unknown</td>
             <td>Possibly one of the two parts where<br/>Harry goes through Central Silent Hill<br/>in Otherworld.</td>
         </tr>
@@ -417,7 +417,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s03/map4_s03"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map4_s03/map4_s03"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s03/map4_s03"/></a></td>
             <td colspan=2>Mall and boss fight.</td>
         </tr>
         <tr>
@@ -429,7 +429,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td>Note</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s04/map4_s04"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map4_s04/map4_s04"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s04/map4_s04"/></a></td>
             <td>Hospital First Floor</td>
             <td>Cutscene with Lisa after finding the<br/>altar in the Green Lion Antique Shop and<br/>meeting Lisa again after the mall boss fight.</td>
         </tr>
@@ -442,7 +442,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td>Note</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s05/map4_s05"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map4_s05/map4_s05"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s05/map4_s05"/></a></td>
             <td>Unknown</td>
             <td>Possibly one of the two parts when<br/>Harry goes through Central Silent Hill<br/>in Otherworld.</td>
         </tr>
@@ -454,7 +454,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s06/map4_s06"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map4_s06/map4_s06"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map4_s06/map4_s06"/></a></td>
             <td colspan=2>Unknown</td>
         </tr>
         <tr>
@@ -465,7 +465,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map5_s00/map5_s00"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map5_s00/map5_s00"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map5_s00/map5_s00"/></a></td>
             <td colspan=2>Sewers lower and upper levels.</td>
         </tr>
         <tr>
@@ -476,7 +476,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map5_s01/map5_s01"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map5_s01/map5_s01"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map5_s01/map5_s01"/></a></td>
             <td colspan=2>Silent Hill Resort Area.</td>
         </tr>
         <tr>
@@ -487,7 +487,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Locations</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map5_s02/map5_s02"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map5_s02/map5_s02"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map5_s02/map5_s02"/></a></td>
             <td colspan=2>Annie's Bar and Indian Runner in Resort Area.</td>
         </tr>
         <tr>
@@ -498,7 +498,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map5_s03/map5_s03"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map5_s03/map5_s03"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map5_s03/map5_s03"/></a></td>
             <td colspan=2>Norman's Motel in Resort Area.</td>
         </tr>
         <tr>
@@ -509,7 +509,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map6_s00/map6_s00"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map6_s00/map6_s00"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map6_s00/map6_s00"/></a></td>
             <td colspan=2>Silent Hill Resort Area in Otherworld.</td>
         </tr>
         <tr>
@@ -520,7 +520,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map6_s01/map6_s01"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map6_s01/map6_s01"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map6_s01/map6_s01"/></a></td>
             <td colspan=2>Boat at Lakeside Pier.</td>
         </tr>
         <tr>
@@ -531,7 +531,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map6_s02/map6_s02"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map6_s02/map6_s02"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map6_s02/map6_s02"/></a></td>
             <td colspan=2>Lakeside Pier</td>
         </tr>
         <tr>
@@ -542,7 +542,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map6_s03/map6_s03"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map6_s03/map6_s03"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map6_s03/map6_s03"/></a></td>
             <td colspan=2>Sewer connecting to Lakeside Amusement Park.</td>
         </tr>
         <tr>
@@ -553,7 +553,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map6_s04/map6_s04"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map6_s04/map6_s04"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map6_s04/map6_s04"/></a></td>
             <td colspan=2>Cybil boss fight and cutscene of Dahlia kidnapping Alessa.</td>
         </tr>
         <tr>
@@ -564,7 +564,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map6_s05/map6_s05"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map6_s05/map6_s05"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map6_s05/map6_s05"/></a></td>
             <td colspan=2>Unknown</td>
         </tr>
         <tr>
@@ -576,7 +576,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td>Note</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map7_s00/map7_s00"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map7_s00/map7_s00"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map7_s00/map7_s00"/></a></td>
             <td colspan=2>Hospital first floor in Nowhere.</td>
         </tr>
         <tr>
@@ -588,7 +588,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td>Note</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map7_s01/map7_s01"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map7_s01/map7_s01"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map7_s01/map7_s01"/></a></td>
             <td>Unknown</td>
             <td>Nowever related.</td>
         </tr>
@@ -601,7 +601,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td>Note</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map7_s02/map7_s02"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map7_s02/map7_s02"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map7_s02/map7_s02"/></a></td>
             <td>Unknown</td>
             <td>Unknown parts of Nowhere and parts of the<br/>cutscene when Alessa struggles against<br/>Dahlia.</td>
         </tr>
@@ -613,7 +613,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Location</td>
         </tr>
         <tr>
-            <td align=center><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map7_s03/map7_s03"/></td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?unit=maps/map7_s03/map7_s03"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=code&unit=maps/map7_s03/map7_s03"/></a></td>
             <td colspan=2>Final boss fight.</td>
         </tr>
       </tbody>

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -525,6 +525,8 @@ void func_80041FF0();
 
 void func_800420C0();
 
+u32 func_80041B1C(void* arg0);
+
 s32 func_80042C04(s32 idx);
 
 s32 func_80043B70(s_80043B70* arg0);
@@ -564,11 +566,11 @@ u8 func_80045B28();
 
 void func_8004690C(s32);
 
-void Sd_SetVolBgm(s16 arg0, s16 arg1);
+void Sd_SetVolBgm(s16 volLeft, s16 volRight);
 
-void Sd_SetVolXa(s16 arg0, s16 arg1);
+void Sd_SetVolXa(s16 volLeft, s16 volRight);
 
-s32 Sd_GetVolSe(s16 arg0);
+s16 Sd_GetVolSe(s16 arg0);
 
 void Sd_SetReverbDepth(s8 depth);
 

--- a/include/bodyprog/vw_system.h
+++ b/include/bodyprog/vw_system.h
@@ -281,6 +281,7 @@ void           vwInitViewInfo();
 GsCOORDINATE2* vwGetViewCoord();
 void           vwGetViewPosition(VECTOR3* pos);
 void           vwGetViewAngle(SVECTOR* ang);
+void           func_80048AF4(VECTOR3* arg0, VECTOR3* arg1);
 void           vwSetCoordRefAndEntou(GsCOORDINATE2* parent_p, s32 ref_x, s32 ref_y, s32 ref_z, s16 cam_ang_y, s16 cam_ang_z, s32 cam_y, s32 cam_xz_r);
 void           vwSetViewInfoDirectMatrix(GsCOORDINATE2* pcoord, MATRIX* cammat);
 void           vwSetViewInfo();
@@ -294,8 +295,13 @@ void vwDecreaseSideOfVector(s32* vec_x, s32* vec_z, s32 dec_val, s32 max_side_ve
 s32  vwRetNewVelocityToTargetVal(s32 now_spd, s32 mv_pos, s32 tgt_pos, s32 accel, s32 total_max_spd, s32 dec_val_lim_spd);
 s32  vwRetNewAngSpdToTargetAng(s32 now_ang_spd, s16 now_ang, s16 tgt_ang, s32 accel_spd, s32 total_max_ang_spd, s32 dec_val_lim_spd);
 void vwMatrixToAngleYXZ(SVECTOR* ang, MATRIX* mat);
+void func_800496AC(MATRIX*, MATRIX*, SVECTOR*);
 void vbSetWorldScreenMatrix(GsCOORDINATE2* coord);
 void vbSetRefView(VbRVIEW* rview);
+void func_80049984(GsCOORDINATE2*, MATRIX*);
+void func_80049AF8(GsCOORDINATE2* coord, SVECTOR* vec);
+void func_80049B6C(GsCOORDINATE2* coord, MATRIX* mat, SVECTOR* vec);
+void func_80049C2C(MATRIX* mat, s32 x, s32 y, s32 z);
 void vwAngleToVector(SVECTOR* vec, SVECTOR* ang, s32 r);
 s32  vwVectorToAngle(SVECTOR* ang, SVECTOR* vec);
 

--- a/include/game.h
+++ b/include/game.h
@@ -287,7 +287,7 @@ typedef struct _ModelAnimData
 
     u8  animIdx_0;
     u8  maybeSomeState_1; // State says if animTime_4 is anim time or a func ptr? That field could be a union.  -- emoose
-    s16 flags_2;          /** e_AnimFlags */ // Bit 1: movement unlockled(?), bit 2: visible.
+    u16 flags_2;          /** e_AnimFlags */ // Bit 1: movement unlockled(?), bit 2: visible.
     s32 time_4;           /** Fixed-point time along keyframe timeline. */ 
     s16 keyframeIdx0_8;
     s16 keyframeIdx1_A;
@@ -324,7 +324,21 @@ typedef struct _SubCharacter
     s8      unk_B4[16];
     u16     dead_timer_C4; // Part of shBattleInfo struct in SH2, may use something similar here.
     s8      unk_C6[2];
-    s8      unk_C8[32];
+
+    // Fields seen used inside maps (eg. map0_s00 func_800D923C)
+    s16 field_C8;
+    s16 field_CA;
+    s8  unk_CC[2];
+    s16 field_CE;
+    s8  unk_D0[4];
+    s16 field_D4;
+    s16 field_D6;
+    s16 field_D8;
+    s16 field_DA;
+    s16 field_DC;
+    s16 field_DE;
+    s32 flags_E0;
+    s8  unk_E4[4];
 
     // Fields in the following block may be part of a multi-purpose array of `s32` elements used to store unique property data for each character type.
     // Start of this section is unclear, bytes above may be part of it.
@@ -341,10 +355,10 @@ typedef struct _SubCharacter
     s32 field_108; // Player run counter. Increments every tick indefinitely. Purpose for other characters unknown.
 
     s8  unk_10C;
-	u8  field_10D;
-	s8  unk_10E[5];
+    u8  field_10D;
+    s8  unk_10E[5];
     s32 field_112;
-	s8  unk_116[14];
+    s8  unk_116[14];
     s16 field_126;
 } s_SubCharacter;
 STATIC_ASSERT_SIZEOF(s_SubCharacter, 296);

--- a/include/maps/map0/s00.h
+++ b/include/maps/map0/s00.h
@@ -60,18 +60,28 @@ void func_800D4924();
 
 void func_800D654C();
 
-void func_800D8888();
+void func_800D8888(s_SubCharacter* chara);
 
 void func_800D88AC(s_SubCharacter* chara);
 
 /** Among other things, sets the character's anim to anim 3. */
 void func_800D88C0(s_SubCharacter* chara, s32 arg1);
 
-/**
- * Seems to call for a specific struct, however `func_800D8888` it indicates
- * that it doesn't have arguments
- */
-void func_800D923C();
+void func_800D8904(s_SubCharacter* chara, s32 arg1);
+
+void func_800D891C(s_SubCharacter* chara);
+
+void func_800D8928(s_SubCharacter* chara);
+
+s32 func_800D893C(s_SubCharacter* chara);
+
+void func_800D8950(s_SubCharacter* chara);
+
+void func_800D9064(s_SubCharacter* chara);
+
+void func_800D9078(s_SubCharacter* chara);
+
+void func_800D923C(s_SubCharacter* chara);
 
 s32 func_800D929C();
 

--- a/src/bodyprog/bodyprog_80040A64.c
+++ b/src/bodyprog/bodyprog_80040A64.c
@@ -3,6 +3,7 @@
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/fsqueue.h"
+#include "bodyprog/libsd.h"
 
 // Known contents:
 // - Animation funcs
@@ -117,15 +118,10 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80040A64", func_800426E4);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80040A64", func_8004287C);
 
-// TODO: Matched, but checksum fails.
-#ifdef NON_MATCHING
 s32 func_80042C04(s32 idx) // 0x80042C04
 {
     return (func_80041B1C(&D_800C117C[idx]) < 3) ^ 1;
 }
-#else
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80040A64", func_80042C04);
-#endif
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80040A64", func_80042C3C);
 
@@ -613,27 +609,19 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80040A64", func_80047634);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80040A64", SD_SetVolume);
 
-#ifdef NON_MATCHING
-void Sd_SetVolBgm(s16 arg0, s16 arg1) // 0x80047808
+void Sd_SetVolBgm(s16 volLeft, s16 volRight) // 0x80047808
 {
-    SdSeqSetVol(0, ((arg0 * g_Sd_VolumeBgm) << 9) >> 16, ((arg1 * g_Sd_VolumeBgm) << 9) >> 16);
+    SdSeqSetVol(0, (volLeft * g_Sd_VolumeBgm) >> 7, (volRight * g_Sd_VolumeBgm) >> 7);
 }
-#else
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80040A64", Sd_SetVolBgm);
-#endif
 
-#ifdef NON_MATCHING
-void Sd_SetVolXa(s16 arg0, s16 arg1) // 0x80047860
+void Sd_SetVolXa(s16 volLeft, s16 volRight) // 0x80047860
 {
-    SdSetSerialVol(0, ((arg0 * g_Sd_VolumeXa) << 9) >> 16, ((arg1 * g_Sd_VolumeXa) << 9) >> 16);
+    SdSetSerialVol(0, (volLeft * g_Sd_VolumeXa) >> 7, (volRight * g_Sd_VolumeXa) >> 7);
 }
-#else
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80040A64", Sd_SetVolXa);
-#endif
 
-s32 Sd_GetVolSe(s16 arg0) // 0x800478B8
+s16 Sd_GetVolSe(s16 arg0) // 0x800478B8
 {
-    return ((arg0 * g_Sd_VolumeSe) << 9) >> 16;
+    return (arg0 * g_Sd_VolumeSe) >> 7;
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80040A64", func_800478DC);

--- a/src/bodyprog/bodyprog_80040A64.c
+++ b/src/bodyprog/bodyprog_80040A64.c
@@ -1,9 +1,9 @@
 #include "game.h"
 
 #include "bodyprog/bodyprog.h"
+#include "bodyprog/libsd.h"
 #include "bodyprog/math.h"
 #include "main/fsqueue.h"
-#include "bodyprog/libsd.h"
 
 // Known contents:
 // - Animation funcs

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -227,7 +227,43 @@ void vcSetAllNpcDeadTimer() // 0x8008123C
     }
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRetSmoothCamMvF);
+s32 vcRetSmoothCamMvF(VECTOR3* old_pos, VECTOR3* now_pos, SVECTOR* old_ang, SVECTOR* now_ang) // 0x800812CC
+{
+    s32 intrpt; // interpolate time?
+    s32 mv_vec;
+    s32 rot_x;
+    s32 rot_y;
+
+    intrpt = FP_TO(g_DeltaTime0, Q12_SHIFT) / 0x44; // divide by 0.0166?
+    intrpt = CLAMP(intrpt, 0x1000, 0x4000);         // clamp between 1.0 and 4.0
+
+    mv_vec = Math_VectorMagnitude(
+        FP_FROM(now_pos->vx - old_pos->vx, Q4_SHIFT),
+        FP_FROM(now_pos->vy - old_pos->vy, Q4_SHIFT),
+        FP_FROM(now_pos->vz - old_pos->vz, Q4_SHIFT));
+
+    mv_vec = FP_TO(mv_vec, Q12_SHIFT) / intrpt;
+    if (mv_vec > FP_TILE(0.2f))
+    {
+        return 0;
+    }
+
+    rot_x = FP_TO(now_ang->vx - old_ang->vx >= 0 ? now_ang->vx - old_ang->vx : old_ang->vx - now_ang->vx, Q12_SHIFT) / intrpt;
+    if (rot_x > FP_ANGLE(1.25f))
+    {
+        return 0;
+    }
+
+    rot_y = FP_TO(abs(shAngleRegulate(now_ang->vy - old_ang->vy)), Q12_SHIFT) / intrpt;
+
+    // This (guessed) line is needed for regalloc match, but compiler just optimizes out since rot_x isn't used afterward.
+    // BUG: Maybe the shRcos call below was meant to use the result of this, but was somehow left using now_ang->vx?
+    rot_x = now_ang->vx - old_ang->vx >= 0 ? now_ang->vx : old_ang->vx;
+
+    rot_y = FP_MULTIPLY(rot_y, shRcos(now_ang->vx), Q12_SHIFT);
+
+    return rot_y <= FP_ANGLE(1.875f);
+}
 
 VC_CAM_MV_TYPE vcRetCurCamMvType(VC_WORK* w_p) // 0x80081428
 {

--- a/src/bodyprog/view/vw_calc.c
+++ b/src/bodyprog/view/vw_calc.c
@@ -199,8 +199,6 @@ void func_80049B6C(GsCOORDINATE2* coord, MATRIX* mat, SVECTOR* vec)
 
 void func_80049C2C(MATRIX* mat, s32 x, s32 y, s32 z)
 {
-    extern MATRIX D_800C6FC0;
-
     VECTOR input;
     VECTOR output;
 

--- a/src/bodyprog/view/vw_calc.c
+++ b/src/bodyprog/view/vw_calc.c
@@ -171,11 +171,55 @@ void vbSetRefView(VbRVIEW* rview) // 0x800498D8
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049984);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049AF8);
+void func_80049AF8(GsCOORDINATE2* coord, SVECTOR* vec)
+{
+    MATRIX mat;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049B6C);
+    func_80049984(coord, &mat);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049C2C);
+    mat.t[0] -= D_800C3868.t[0];
+    mat.t[1] -= D_800C3868.t[1];
+    mat.t[2] -= D_800C3868.t[2];
+
+    func_800496AC(&VbWvsMatrix, &mat, vec);
+}
+
+void func_80049B6C(GsCOORDINATE2* coord, MATRIX* mat, SVECTOR* vec)
+{
+    func_80049984(coord, mat);
+    mat->t[0] -= D_800C3868.t[0];
+    mat->t[1] -= D_800C3868.t[1];
+    mat->t[2] -= D_800C3868.t[2];
+
+    func_800496AC(&VbWvsMatrix, mat, vec);
+    mat->t[0] += D_800C3868.t[0];
+    mat->t[1] += D_800C3868.t[1];
+    mat->t[2] += D_800C3868.t[2];
+}
+
+void func_80049C2C(MATRIX* mat, s32 x, s32 y, s32 z)
+{
+    extern MATRIX D_800C6FC0;
+
+    VECTOR input;
+    VECTOR output;
+
+    input.vx = FP_FROM(x, Q4_SHIFT);
+    input.vy = FP_FROM(y, Q4_SHIFT);
+    input.vz = FP_FROM(z, Q4_SHIFT);
+    ApplyMatrixLV(&D_800C6FC0, &input, &output);
+
+    // Copies matrix fields as 32-bit words, maybe an inlined CopyMatrix func?
+    *(u32*)&mat->m[0][0] = *(u32*)&D_800C6FC0.m[0][0];
+    *(u32*)&mat->m[0][2] = *(u32*)&D_800C6FC0.m[0][2];
+    *(u32*)&mat->m[1][1] = *(u32*)&D_800C6FC0.m[1][1];
+    *(u32*)&mat->m[2][0] = *(u32*)&D_800C6FC0.m[2][0];
+    mat->m[2][2]         = D_800C6FC0.m[2][2];
+
+    mat->t[0] = output.vx + D_800C6FC0.t[0];
+    mat->t[1] = output.vy + D_800C6FC0.t[1];
+    mat->t[2] = output.vz + D_800C6FC0.t[2];
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_calc", func_80049D04);
 

--- a/src/bodyprog/view/vw_main.c
+++ b/src/bodyprog/view/vw_main.c
@@ -32,7 +32,29 @@ void vwGetViewAngle(SVECTOR* ang) // 0x80048AC4
     *ang = vwViewPointInfo.worldang;
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vw_main", func_80048AF4);
+void func_80048AF4(VECTOR3* arg0, VECTOR3* arg1)
+{
+    s32     temp_x;
+    s32     temp_y;
+    s32     temp_z;
+    MATRIX  mat;
+    SVECTOR vec;
+
+    temp_x = FP_FROM(arg1->vx - arg0->vx, Q4_SHIFT);
+    temp_y = FP_FROM(arg1->vy - arg0->vy, Q4_SHIFT);
+    temp_z = FP_FROM(arg1->vz - arg0->vz, Q4_SHIFT);
+
+    vec.vz = 0;
+    vec.vy = ratan2(temp_x, temp_z);
+    vec.vx = ratan2(-temp_y, SquareRoot0((temp_x * temp_x) + (temp_z * temp_z)));
+
+    func_80096C94(&vec, &mat);
+
+    mat.t[0] = FP_FROM(arg0->vx, Q4_SHIFT);
+    mat.t[1] = FP_FROM(arg0->vy, Q4_SHIFT);
+    mat.t[2] = FP_FROM(arg0->vz, Q4_SHIFT);
+    vwSetViewInfoDirectMatrix(NULL, &mat);
+}
 
 void vwSetCoordRefAndEntou(GsCOORDINATE2* parent_p, s32 ref_x, s32 ref_y, s32 ref_z, s16 cam_ang_y, s16 cam_ang_z, s32 cam_y, s32 cam_xz_r) // 0x80048BE0
 {

--- a/src/maps/map0_s00/map0_s00.c
+++ b/src/maps/map0_s00/map0_s00.c
@@ -268,7 +268,7 @@ void func_800D8888(s_SubCharacter* chara)
 }
 
 // The following funcs that take s_SubCharacter* arg are shared with other maps too.
-// Possibly shared .c file or seperate SubCharacter library?
+// Possibly shared .c file or separate SubCharacter library?
 
 void func_800D88AC(s_SubCharacter* chara)
 {
@@ -300,10 +300,11 @@ void func_800D88C0(s_SubCharacter* chara, s32 arg1)
 
 void func_800D8904(s_SubCharacter* chara, s32 arg1)
 {
-    chara->field_126                      = 0;
-    chara->field_F8                       = 0;
-    chara->field_F0                       = 0;
-    chara->field_E8                       = arg1;
+    chara->field_126 = 0;
+    chara->field_F8  = 0;
+    chara->field_F0  = 0;
+    chara->field_E8  = arg1;
+
     chara->model_0.isAnimStateUnchanged_3 = 0;
 }
 

--- a/src/maps/map0_s00/map0_s00.c
+++ b/src/maps/map0_s00/map0_s00.c
@@ -370,7 +370,7 @@ void func_800D923C(s_SubCharacter* chara)
     chara->field_F0 = 0;
     chara->field_F4 = 0;
     chara->flags_E0 = (char_flagsE0 | 0x300);
-    chara->model_0.field_2 += 1;
+    chara->model_0.field_2++;
 }
 
 s32 func_800D929C()

--- a/src/maps/map0_s00/map0_s00.c
+++ b/src/maps/map0_s00/map0_s00.c
@@ -136,8 +136,6 @@ void func_800D2D2C()
     D_800C4606++;
 }
 
-// TODO: Need to update pointers.
-#ifdef NON_MATCHING
 void func_800D2D44()
 {
     s_MainCharacterExtra* playerExtra = &g_SysWork.player_4C.extra_128;
@@ -146,9 +144,6 @@ void func_800D2D44()
     playerExtra->model_0.anim_4.flags_2 &= ~AnimFlag_Unk1;
     chara->model_0.anim_4.flags_2 &= ~AnimFlag_Unk1;
 }
-#else
-INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D2D44);
-#endif
 
 s32 func_800D2D6C()
 {
@@ -266,18 +261,21 @@ INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D8310);
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D8748);
 
-void func_800D8888()
+void func_800D8888(s_SubCharacter* chara)
 {
-    func_800D923C();
+    func_800D923C(chara);
     D_800E3A30 = 0;
 }
 
-void func_800D88AC(s_SubCharacter* arg0)
+// The following funcs that take s_SubCharacter* arg are shared with other maps too.
+// Possibly shared .c file or seperate SubCharacter library?
+
+void func_800D88AC(s_SubCharacter* chara)
 {
-    arg0->field_F4 = 0;
-    arg0->field_F0 = 0;
-    arg0->field_EC = 0;
-    arg0->field_126 = 0;
+    chara->field_F4  = 0;
+    chara->field_F0  = 0;
+    chara->field_EC  = 0;
+    chara->field_126 = 0;
 }
 
 void func_800D88C0(s_SubCharacter* chara, s32 arg1)
@@ -300,23 +298,48 @@ void func_800D88C0(s_SubCharacter* chara, s32 arg1)
     chara->model_0.anim_4.flags_2 |= AnimFlag_Unk1;
 }
 
-INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D8904);
+void func_800D8904(s_SubCharacter* chara, s32 arg1)
+{
+    chara->field_126                      = 0;
+    chara->field_F8                       = 0;
+    chara->field_F0                       = 0;
+    chara->field_E8                       = arg1;
+    chara->model_0.isAnimStateUnchanged_3 = 0;
+}
 
-INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D891C);
+void func_800D891C(s_SubCharacter* chara)
+{
+    chara->field_F8 = 1;
+}
 
-INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D8928);
+void func_800D8928(s_SubCharacter* chara)
+{
+    chara->model_0.anim_4.flags_2 &= ~AnimFlag_Unk1;
+}
 
-INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D893C);
+s32 func_800D893C(s_SubCharacter* chara)
+{
+    return ~(chara->model_0.anim_4.flags_2 & AnimFlag_Unk1);
+}
 
-INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D8950);
+void func_800D8950(s_SubCharacter* chara)
+{
+    chara->model_0.anim_4.flags_2 |= AnimFlag_Unk1;
+}
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D8964);
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D8A00);
 
-INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D9064);
+void func_800D9064(s_SubCharacter* chara)
+{
+    chara->model_0.anim_4.flags_2 |= AnimFlag_Unk2;
+}
 
-INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D9078);
+void func_800D9078(s_SubCharacter* chara)
+{
+    chara->model_0.anim_4.flags_2 &= ~AnimFlag_Unk2;
+}
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D908C);
 
@@ -324,7 +347,30 @@ INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D9188);
 
 INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D921C);
 
-INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D923C);
+void func_800D923C(s_SubCharacter* chara)
+{
+    s32 char_flagsE0 = chara->flags_E0;
+    char_flagsE0     = (char_flagsE0 & ~0xF00);
+
+    chara->model_0.isAnimStateUnchanged_3 = 0;
+
+    chara->field_C8 = 0;
+    chara->field_CA = 0;
+    chara->field_CE = 0;
+    chara->field_D4 = 0;
+    chara->field_D6 = 0;
+    chara->field_DE = 0;
+    chara->field_DC = 0;
+    chara->field_DA = 0;
+    chara->field_D8 = 0;
+    chara->field_EC = 0;
+    chara->field_E8 = 0;
+    chara->field_EC = 0;
+    chara->field_F0 = 0;
+    chara->field_F4 = 0;
+    chara->flags_E0 = (char_flagsE0 | 0x300);
+    chara->model_0.field_2 += 1;
+}
 
 s32 func_800D929C()
 {


### PR DESCRIPTION
Matches some of the map0 funcs which seem shared between different maps, and a couple `view` funcs.

Shared funcs could probably be copied to most of the other map files (though oddly a couple do seem to be missing them), need to look into whether we could share them between them at all too.