### PR TITLE
silentassets: Fix XA file extraction

### DIFF
--- a/tools/silentassets/extract.py
+++ b/tools/silentassets/extract.py
@@ -123,11 +123,13 @@ def _extract(entries:Iterable[TableEntry], output: Path, file: BinaryIO, sectorS
         
         file.seek((i.offset - entries[0].offset) * sectorSize)
         size = 0
-        if not i.size == 0:
-            size = i.size
+        if not i.size == 0 and (i.type != FILE_TYPES[15]):
+            size = i.size * FILESIZE_STEP
         elif index+1 < len(entries):
-            size = entries[index + 1].offset - i.offset
-        data = file.read(size * FILESIZE_STEP)
+            size = (entries[index + 1].offset - i.offset) * sectorSize
+        else:
+            size = -1 # read until end of file
+        data = file.read(size)
         if(i.type == FILE_TYPES[2] and regionID != "NTSC Nov 24, 1998"):
             if i.path.startswith("1ST"):
                 logging.info("\tDecrypting Overlay...")
@@ -179,7 +181,7 @@ def main():
     _extract(entriesSilent, args.outputFolder, args.silentFile, 2048, region.id)
     
     if region.id != "NTSC Nov 24, 1998":
-        _extract(entriesHill, args.outputFolder, args.hillFile, 2352, region.id)
+        _extract(entriesHill, args.outputFolder, args.hillFile, 2336, region.id)
 
     with open(os.path.join(args.outputFolder, "filetable.c.inc"), "a+") as f:
         f.truncate(0)


### PR DESCRIPTION
The offsets of the XA files extracted from the `HILL` archive were calculated incorrectly, using 2352 as the sector size instead of 2336, but dumpsxiso apparently strips the extra bytes from each sector when extracting the file.  
In addition,  the `blockCount` field in the filetable for XA files apparently has a different meaning (for example for videos it's the number of frames), so we can't use it to get the size of the file. Instead I made it calculate the size using the next entry's offset.  
The filenames of the XA files actually contain the size of the file: for example, `XA\C1_20670` is 20670 sectors (2336 bytes each) in size, so we can use those to get the size as an alternative.

Checked the files with jPSXdec, they seem to be correct now.