### PR TITLE
view: add 3 matches, stream.c fixups, update maspsx submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ OBJCOPY_FLAGS       := -O binary
 OBJDUMP_FLAGS       := --disassemble-all --reloc --disassemble-zeroes -Mreg-names=32
 SPLAT_FLAGS         := --disassemble-all
 DUMPSXISO_FLAGS     := -x $(ROM_DIR) -s $(ROM_DIR)/layout.xml $(IMAGE_DIR)/$(GAME_NAME).bin
-MKPSXISO_FLAGS      := -y -q -o $(BUILD_DIR) $(ROM_DIR)/shgame.xml
+MKPSXISO_FLAGS      := -y -q $(ROM_DIR)/shgame.xml
 SILENT_ASSETS_FLAGS := -exe $(ROM_DIR)/SLUS_007.07 -fs $(ROM_DIR)/SILENT. -fh $(ROM_DIR)/HILL. $(ASSETS_DIR)
 INSERT_OVLS_FLAGS   := -exe $(ROM_DIR)/SLUS_007.07 -fs $(ROM_DIR)/SILENT. -ftb $(ASSETS_DIR)/filetable.c.inc -b $(OUT_DIR) -xml $(ROM_DIR)/layout.xml -o $(ROM_DIR)
 

--- a/configs/screens/sym.stream.txt
+++ b/configs/screens/sym.stream.txt
@@ -9,6 +9,9 @@ strKickCD = 0x801e31cc; // type:func
 strNextVlc = 0x801e3298; // type:func
 strNext = 0x801e331c; // type:func
 strSync = 0x801e3438; // type:func
+
+g_Debug_MoviePlayerIndex = 0x801E3F3C; // type:s32
+
 // MOVIESYS globals
 max_frame = 0x801E3F40;
 frame_cnt = 0x801E3F44;

--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -168,6 +168,10 @@ Camera_SetRotation = 0x80086B70; // type:func
 
 Anim_Update = 0x800449F0; // type:func
 
+Gfx_DebugStringPosition = 0x80031EFC; // type:func
+Gfx_DebugStringDraw = 0x80031F40; // type:func
+Math_IntegerToString = 0x80032154; // type:func
+
 Gfx_ClearRectInterlaced = 0x80032358; // type:func
 Gfx_Init = 0x80032428; // type:func
 Settings_ScreenXYSet = 0x800324F4; // type:func

--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -23,6 +23,9 @@ g_UncappedVBlanks = 0x800B5C38; // type:s32
 
 g_MaybePlayerAnims = 0x800AF228; // type:MaybeCharacterAnim
 
+g_Gfx_DebugStringPosition0 = 0x800B5C20; // type:DVECTOR size:4
+g_Gfx_DebugStringPosition1 = 0x800B5C24; // type:DVECTOR size:4
+
 // sh "view" / "vw" / "vc" / "vb" code
 // Most names from SH2, functions seem to match pretty close between it and SH1 besides a few missing/extra funcs.
 hack_vcSetWatchTgtXzPos_fix = 0x8002B2B4; // type:s32 - Some 0x80083500 value which coincidentally points to code inside vcSetWatchTgtXzPos, probably unrelated flags or something. A jtbl is right before this which spimdisasm tries to include, breaking vcSetWatchTgtXzPos build.

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -578,6 +578,12 @@ void func_800303E4();
  * - 'func_801E709C' in saveload.c */
 void func_800314EC(s_FsImageDesc* image);
 
+void Gfx_DebugStringPosition(s32 x, s32 y);
+
+void Gfx_DebugStringDraw(char* str);
+
+char* Math_IntegerToString(s32 numDigits, s32 value);
+
 void func_8003260C(); // Return type assumed.
 
 void func_80032D1C();

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -379,6 +379,10 @@ extern s32 D_800B55FC;
 
 extern s32 D_800B5618;
 
+extern DVECTOR g_Gfx_DebugStringPosition0;
+
+extern DVECTOR g_Gfx_DebugStringPosition1;
+
 extern s8 D_800BCD78;
 
 extern u8 D_800BCDD4;
@@ -578,7 +582,7 @@ void func_800303E4();
  * - 'func_801E709C' in saveload.c */
 void func_800314EC(s_FsImageDesc* image);
 
-void Gfx_DebugStringPosition(s32 x, s32 y);
+void Gfx_DebugStringPosition(s16 x, s16 y);
 
 void Gfx_DebugStringDraw(char* str);
 

--- a/include/bodyprog/math.h
+++ b/include/bodyprog/math.h
@@ -23,6 +23,10 @@
 #define FP_TO(val, shift) \
 	((val) << (shift))
 
+/** Converts a float to a fixed-point Q format. */
+#define FP_FLOAT_TO(val, shift) \
+    ((val) * FP_TO(1, (shift)))
+
 /** Converts an integer from a fixed-point Q format. */
 #define FP_FROM(val, shift) \
 	((val) >> (shift))
@@ -30,6 +34,10 @@
 /** Multiplies two integers in a fixed-point Q format and converts the result from the fixed-point Q format. */
 #define FP_MULTIPLY(val0, val1, shift) \
     (((val0) * (val1)) >> (shift))
+
+/** Multiplies an integer by a float converted to fixed-point Q format, using 64-bit intermediate via Math_MulFixed for higher precision. */
+#define FP_MULTIPLY_PRECISE(val0, val1, shift) \
+    (Math_MulFixed((val0), FP_FLOAT_TO((val1), (shift)), (shift)))
 
 /** Converts a floating-point alpha in the range [0.0f, 1.0f] to a fixed-point alpha in Q3.12 format. */
 #define FP_ALPHA(alpha) \

--- a/include/bodyprog/vw_system.h
+++ b/include/bodyprog/vw_system.h
@@ -351,7 +351,7 @@ void vcMakeFarWatchTgtPos(VECTOR3* watch_tgt_pos, VC_WORK* w_p, VC_AREA_SIZE_TYP
 void vcSetWatchTgtXzPos(VECTOR3* watch_pos, VECTOR3* center_pos, VECTOR3* cam_pos, s32 tgt_chara2watch_cir_dist, s32 tgt_watch_cir_r, s16 watch_cir_ang_y);
 void vcSetWatchTgtYParam(VECTOR3* watch_pos, VC_WORK* w_p, s32 cam_mv_type, s32 watch_y);
 void vcAdjustWatchYLimitHighWhenFarView(VECTOR3* watch_pos, VECTOR3* cam_pos, s16 sy);
-void vcAutoRenewalCamTgtPos(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type, VC_CAM_MV_PARAM* cam_mv_prm_p, VC_ROAD_FLAGS cur_rd_flags, VC_AREA_SIZE_TYPE cur_rd_area_size);
+void vcAutoRenewalCamTgtPos(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type, VC_CAM_MV_PARAM* cam_mv_prm_p, VC_ROAD_FLAGS cur_rd_flags, VC_AREA_SIZE_TYPE cur_rd_area_size, s32 far_watch_rate);
 s32  vcRetMaxTgtMvXzLen(VC_WORK* w_p, VC_CAM_MV_PARAM* cam_mv_prm_p);
 void vcMakeIdealCamPosByHeadPos(VECTOR3* ideal_pos, VC_WORK* w_p, VC_AREA_SIZE_TYPE cur_rd_area_size);
 void vcMakeIdealCamPosForFixAngCam(VECTOR3* ideal_pos, VC_WORK* w_p);
@@ -381,5 +381,10 @@ s32 Math_VectorMagnitude(s32 x, s32 y, s32 z);
 
 s32 vcGetXZSumDistFromLimArea(s32* out_vec_x_p, s32* out_vec_z_p, s32 chk_wld_x, s32 chk_wld_z,
                               s32 lim_min_x, s32 lim_max_x, s32 lim_min_z, s32 lim_max_z, s32 can_ret_minus_dist_f);
+
+static inline void vcWork_CurNearRoadSet(VC_WORK* work, VC_NEAR_ROAD_DATA* road)
+{
+    memcpy(&work->cur_near_road_2B8, road, sizeof(VC_NEAR_ROAD_DATA));
+}
 
 #endif /* _VW_SYSTEM_H */

--- a/include/game.h
+++ b/include/game.h
@@ -67,12 +67,12 @@ typedef enum _GameState
     GameState_StatusScreen        = 14,
     GameState_MapScreen           = 15,
     GameState_Unk10               = 16,
-    GameState_MovieEnding         = 17,
+    GameState_DebugMoviePlayer    = 17,
     GameState_OptionScreen        = 18,
     GameState_LoadStatusScreen    = 19,
     GameState_LoadMapScreen       = 20,
     GameState_Unk15               = 21,
-    GameState_Unk16               = 22
+    GameState_Unk16               = 22 /** Doesn't exist in function array, but DebugMoviePlayer state tries to switch to it, removed debug menu? */
 } e_GameState;
 
 /** State IDs used by GameState_InGame. The values are used as indices into the 0x800A9A2C function array. */

--- a/include/screens/stream/stream.h
+++ b/include/screens/stream/stream.h
@@ -7,7 +7,6 @@
 extern int StCdIntrFlag; // Not included in SDK docs/headers, but movie player sample code (and moviesys) uses it?
 
 extern s32 D_800B5C30;
-extern s32 D_801E3F3C;
 
 extern s32 D_800BCD0C;
 extern u8  D_800A900C[];

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -387,11 +387,11 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80031AAC);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80031CCC);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80031EFC);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", Gfx_DebugStringPosition);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80031F40);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", Gfx_DebugStringDraw);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80032154);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", Math_IntegerToString);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_800321EC);
 

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -387,7 +387,17 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80031AAC);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80031CCC);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", Gfx_DebugStringPosition);
+void Gfx_DebugStringPosition(s16 x, s16 y) // 0x80031EFC
+{
+    if (x != -1)
+    {
+        g_Gfx_DebugStringPosition0.vx = g_Gfx_DebugStringPosition1.vx = x - 160;
+    }
+    if (y != -1)
+    {
+        g_Gfx_DebugStringPosition1.vy = y - 112;
+    }
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", Gfx_DebugStringDraw);
 

--- a/src/bodyprog/bodyprog_8004A87C.c
+++ b/src/bodyprog/bodyprog_8004A87C.c
@@ -384,7 +384,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8005B62C);
 
 void func_8005BF0C(s16 arg0, s16 arg1, s16 arg2) // 0x8005BF0C
 {
-    func_80031EFC(arg1, arg2);
+    Gfx_DebugStringPosition(arg1, arg2);
 }
 
 s16 func_8005BF38(s32 arg0) // 0x8005BF38

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -5,7 +5,26 @@
 
 #define MIN_IN_ROAD_DIST FP_TILE(16.0f) // vcGetMinInRoadDist() in SH2, hardcoded to FP_TILE(16.0f) in SH1.
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcInitVCSystem);
+void vcInitVCSystem(VC_ROAD_DATA* vc_road_ary_list) // 0x80080940
+{
+    vcWork.view_cam_active_f_0 = 0;
+
+    if (vc_road_ary_list == NULL)
+    {
+        vcWork.vc_road_ary_list_4 = vcNullRoadArray;
+    }
+    else
+    {
+        vcWork.vc_road_ary_list_4 = vc_road_ary_list;
+    }
+
+    vcWork_CurNearRoadSet(&vcWork, &vcNullNearRoad);
+
+    vcWork.old_cam_excl_area_r_6C = NO_VALUE;
+    vcWork.watch_tgt_max_y_88     = FP_TILE(480.0f);
+    vcWork.field_D8               = 0;
+    vcWork.field_FC               = 0;
+}
 
 void vcStartCameraSystem() // 0x800809DC
 {
@@ -55,7 +74,7 @@ void vcSetFirstCamWork(VECTOR3* cam_pos, s16 chara_eye_ang_y, s32 use_through_do
 
     vcWork.cam_chara2ideal_ang_y_FE = shAngleRegulate(chara_eye_ang_y + 2048);
 
-    memcpy(&vcWork.cur_near_road_2B8, &vcNullNearRoad, sizeof(VC_NEAR_ROAD_DATA));
+    vcWork_CurNearRoadSet(&vcWork, &vcNullNearRoad);
 
     vcWork.through_door_activate_init_f_C = use_through_door_cam_f;
     vcSetTHROUGH_DOOR_CAM_PARAM_in_VC_WORK(&vcWork, VC_TDSC_END);
@@ -196,7 +215,77 @@ void vcSetSubjChara(VECTOR3* chara_pos, s32 chara_bottom_y, s32 chara_top_y, s32
     vcWork.chara_watch_xz_r_148 = chara_watch_xz_r;
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcExecCamera);
+s32 vcExecCamera() // 0x80080FBC
+{
+    VECTOR3            sv_old_cam_pos;
+    SVECTOR            sv_old_cam_mat_ang;
+    VC_WATCH_MV_PARAM* watch_mv_prm_p;
+    VC_CAM_MV_PARAM*   cam_mv_prm_p;
+    VC_AREA_SIZE_TYPE  cur_rd_area_size;
+    VC_CAM_MV_TYPE     cur_cam_mv_type;
+    s32                self_view_eff_rate;
+    s32                warp_f;
+    s32                far_watch_rate;
+    VC_ROAD_FLAGS      cur_rd_flags;
+
+    sv_old_cam_pos     = vcWork.cam_pos_50;
+    sv_old_cam_mat_ang = vcWork.cam_mat_ang_8E;
+
+    if (vcWork.view_cam_active_f_0 == 0)
+    {
+        return 0;
+    }
+
+    vcSetAllNpcDeadTimer();
+    SetGeomScreen(vcWork.geom_screen_dist_30);
+    vcPreSetDataInVC_WORK(&vcWork, vcWork.vc_road_ary_list_4);
+
+    warp_f           = vcSetCurNearRoadInVC_WORK(&vcWork);
+    cur_rd_flags     = vcWork.cur_near_road_2B8.road_p_0->flags_10;
+    cur_rd_area_size = vcWork.cur_near_road_2B8.road_p_0->area_size_type_11;
+    cur_cam_mv_type  = vcRetCurCamMvType(&vcWork);
+
+    // TODO: This checks for VC_PRS_F_VIEW_F flag in a weird way.
+    far_watch_rate     = vcRetFarWatchRate(((vcWork.flags_8 >> 9) & 1) ^ (g_GameWorkPtr0->optViewCtrl_28 != 0), cur_cam_mv_type, &vcWork);
+    self_view_eff_rate = vcRetSelfViewEffectRate(cur_cam_mv_type, far_watch_rate, &vcWork);
+
+    if (!(vcWork.flags_8 & (VC_USER_CAM_F | VC_USER_WATCH_F)))
+    {
+        vcSetFlagsByCamMvType(cur_cam_mv_type, far_watch_rate, warp_f);
+    }
+
+    if (vcWork.flags_8 & VC_WARP_CAM_TGT_F)
+    {
+        vcWork.old_cam_excl_area_r_6C = NO_VALUE;
+    }
+
+    vcGetUseWatchAndCamMvParam(&watch_mv_prm_p, &cam_mv_prm_p, self_view_eff_rate, &vcWork);
+
+    if (!(vcWork.flags_8 & VC_USER_CAM_F))
+    {
+        vcAutoRenewalCamTgtPos(&vcWork, cur_cam_mv_type, cam_mv_prm_p, (s32)cur_rd_flags, cur_rd_area_size, far_watch_rate);
+    }
+
+    vcRenewalCamData(&vcWork, cam_mv_prm_p);
+
+    if (!(vcWork.flags_8 & VC_USER_WATCH_F))
+    {
+        vcAutoRenewalWatchTgtPosAndAngZ(&vcWork, cur_cam_mv_type, cur_rd_area_size, far_watch_rate, self_view_eff_rate);
+        if ((vcWork.cur_near_road_2B8.road_p_0->flags_10 & VC_RD_LIM_UP_FAR_VIEW_F) &&
+            (vcWork.cur_near_road_2B8.road_p_0->cam_mv_type_14 == VC_MV_CHASE || cur_cam_mv_type == VC_MV_SELF_VIEW))
+        {
+            vcAdjustWatchYLimitHighWhenFarView(&vcWork.watch_tgt_pos_7C, &vcWork.cam_pos_50, vcWork.geom_screen_dist_30);
+        }
+    }
+
+    vcRenewalCamMatAng(&vcWork, watch_mv_prm_p, cur_cam_mv_type, vcWork.flags_8 & VC_VISIBLE_CHARA_F);
+    vcSetDataToVwSystem(&vcWork, cur_cam_mv_type);
+
+    vcWork.through_door_activate_init_f_C = 0;
+    vcWork.flags_8 &= ~(VC_WARP_CAM_F | VC_WARP_WATCH_F | VC_WARP_CAM_TGT_F);
+
+    return vcRetSmoothCamMvF(&sv_old_cam_pos, &vcWork.cam_pos_50, &sv_old_cam_mat_ang, &vcWork.cam_mat_ang_8E);
+}
 
 void vcSetAllNpcDeadTimer() // 0x8008123C
 {
@@ -619,7 +708,7 @@ void vcAdjustWatchYLimitHighWhenFarView(VECTOR3* watch_pos, VECTOR3* cam_pos, s1
     }
 }
 
-void vcAutoRenewalCamTgtPos(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type, VC_CAM_MV_PARAM* cam_mv_prm_p, VC_ROAD_FLAGS cur_rd_flags, VC_AREA_SIZE_TYPE cur_rd_area_size) // 0x800836E8
+void vcAutoRenewalCamTgtPos(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type, VC_CAM_MV_PARAM* cam_mv_prm_p, VC_ROAD_FLAGS cur_rd_flags, VC_AREA_SIZE_TYPE cur_rd_area_size, s32 far_watch_rate) // 0x800836E8
 {
     VECTOR3 tgt_vec;
     VECTOR3 ideal_pos;

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -1031,7 +1031,7 @@ void vcRenewalCamData(VC_WORK* w_p, VC_CAM_MV_PARAM* cam_mv_prm_p) // 0x80084BD8
     }
 
     dec_spd_per_dist_xz = FP_MULTIPLY_PRECISE(cam_mv_prm_p->accel_xz, 0.4f, Q12_SHIFT);
-    dec_spd_per_dist_y  = FP_MULTIPLY_PRECISE(cam_mv_prm_p->accel_y, 1.0f, Q12_SHIFT); // SH2 removed this multiply and used accel_y directly, maybe 0.4f/1.0f were tunable defines
+    dec_spd_per_dist_y  = FP_MULTIPLY_PRECISE(cam_mv_prm_p->accel_y, 1.0f, Q12_SHIFT); // SH2 removes this multiply and uses accel_y directly, maybe 0.4f/1.0f were tunable defines & compiler removed it.
 
     vwRenewalXZVelocityToTargetPos(&w_p->cam_velo_60.vx, &w_p->cam_velo_60.vz, &w_p->cam_pos_50,
                                    &w_p->cam_tgt_pos_44, 0x199, cam_mv_prm_p->accel_xz,

--- a/src/screens/stream/stream.c
+++ b/src/screens/stream/stream.c
@@ -4,9 +4,14 @@
 #include <libds.h>
 #include <libpress.h>
 
+#include "bodyprog/libsd.h"
+
 #include "bodyprog/bodyprog.h"
 #include "main/fileinfo.h"
 #include "screens/stream/stream.h"
+
+#define SCRN_WIDTH 320
+#define SCRN_HEIGHT 240
 
 // Old IDB name: MainLoopState3_StartMovieIntro_801E2654
 void func_801E2654()
@@ -71,8 +76,11 @@ void func_801E28B0()
 }
 
 // Old IDB name: MainLoopState11_Movie_PlayEnding_801E2908
+// Movie to play seems decided by LStickLeft/LStickRight, possibly debug movie player?
 void func_801E2908()
 {
+    extern s32 g_Debug_MoviePlayerIndex; // Only used in this func, maybe a static.
+
     s_GameWork*       gameWork;
     s_ControllerData* controller;
 
@@ -81,23 +89,30 @@ void func_801E2908()
 
     if (controller->btns_new_10 & gameWork->controllerBinds_0.cancel)
     {
-        Game_StateSetNext(GameState_Unk16);
+        Game_StateSetNext(GameState_Unk16); // Changes to nonexistent state 0x16 (22) and crashes, maybe removed debug menu.
     }
 
-    if (controller->field_18 & (1 << 27))
+    if (controller->field_18 & Pad_LStickLeft)
     {
-        D_801E3F3C--;
+        g_Debug_MoviePlayerIndex--;
     }
 
-    if (controller->field_18 & (1 << 25))
+    if (controller->field_18 & Pad_LStickRight)
     {
-        D_801E3F3C++;
+        g_Debug_MoviePlayerIndex++;
     }
 
-    func_80031EFC(0x28, 0x28);
+    Gfx_DebugStringPosition(40, 40);
+
+#ifdef DEBUG
+    // Recreated code from pre-Jan17 builds which include calls to display these (though DebugStringDraw was nullsub in those builds...)
+    Gfx_DebugStringDraw("MOVIE NO=");
+    Gfx_DebugStringDraw(Math_IntegerToString(2, g_Debug_MoviePlayerIndex));
+#endif
+
     if (controller->btns_new_10 & gameWork->controllerBinds_0.enter)
     {
-        open_main(FILE_XA_ZC_14392 - D_801E3F3C, 0);
+        open_main(FILE_XA_ZC_14392 - g_Debug_MoviePlayerIndex, 0);
     }
 }
 
@@ -140,9 +155,9 @@ void movie_main(char* file_name, s32 f_size, s32 sector)
     max_frame = f_size;
     
     m = (MOVIE_STR*)0x801A2600; // probably some kind of TEMP_MEMORY_ADDR define. Also used by b_konami.
-    m->width = 320;
-    m->height = 240;
-    
+    m->width  = SCRN_WIDTH;
+    m->height = SCRN_HEIGHT;
+
     if (sector == 0)
     {
         search_times = 0;
@@ -185,8 +200,8 @@ void movie_main(char* file_name, s32 f_size, s32 sector)
         // DISPENV *SetDefDispEnv(DISPENV *env, int x, int y, int w, int h);
         // making a static inline setupDispEnv(DISPENV*, MOVIE_STR*, s_GameWork**) func got it very close
         // but still had register differences
-        
-        disp.disp.y = 256 - (m->dec.rectid * 240);
+
+        disp.disp.y   = 256 - (m->dec.rectid * SCRN_HEIGHT);
         disp.screen.x = temp_s2->field_1C;
         disp.screen.y = 8 + ((224 - m->height) / 2) + (temp_s2->field_1D);
 
@@ -238,24 +253,16 @@ INCLUDE_ASM("asm/screens/stream/nonmatchings/stream", movie_main);
 
 void strSetDefDecEnv(DECENV* dec, s32 x0, s32 y0, s32 x1, s32 y1) // 0x801E2F8C
 {
-    dec->rect[0].w = 480;
-    dec->rect[1].w = 480;
-    dec->vlcid     = 0;
-    dec->rectid    = 0;
-    dec->isdone    = 0;
-    dec->rect[0].x = x0;
-    dec->rect[0].y = y0;
-    dec->rect[0].h = 240;
-    dec->rect[1].x = x1;
-    dec->rect[1].h = 240;
-    dec->slice.x   = x0;
-    dec->slice.y   = y0;
-    dec->slice.w   = 16 * PPW;
-    dec->slice.h   = 240;
     dec->vlcbuf[0] = m->vlcbuf0;
     dec->vlcbuf[1] = m->vlcbuf1;
+    dec->vlcid     = 0;
     dec->imgbuf    = m->imgbuf0;
-    dec->rect[1].y = y1;
+    dec->rectid    = 0;
+    dec->isdone    = 0;
+
+    setRECT(&dec->rect[0], x0, y0, SCRN_WIDTH * PPW, SCRN_HEIGHT);
+    setRECT(&dec->rect[1], x1, y1, SCRN_WIDTH * PPW, SCRN_HEIGHT);
+    setRECT(&dec->slice, x0, y0, 16 * PPW, SCRN_HEIGHT);
 }
 
 void strInit(CdlLOC* loc, void (*callback)()) // 0x801E300C

--- a/tools/silentassets/insertovl.py
+++ b/tools/silentassets/insertovl.py
@@ -150,6 +150,8 @@ def main():
     index = 0
         
     for x in fileTable:
+        if x.strip().startswith("//"):  # Skip lines that start with "//"
+            continue
         tableLine = readTableLine(re.findall(r"\{.*?\}", x)[0])
         
         fileTableOrig.append(tableLine)
@@ -271,7 +273,9 @@ def main():
         with open(os.path.dirname(args.xmlFile)+"/shgame.xml", "a+") as newXML:
             newXML.truncate(0)
             for fileLine in XML:
-                if "source=\"SLUS_007.07\"" in fileLine:
+                if "image_name=\"mkpsxiso.bin\"" in fileLine:
+                    newXML.write(fileLine.replace("mkpsxiso", "build/SLUS_007.07"))
+                elif "source=\"SLUS_007.07\"" in fileLine:
                     newXML.write(fileLine.replace("source=\"SLUS_007.07\"", "source=\"new_SLUS_007.07\""))
                 elif "source=\"SILENT.\"" in fileLine:
                     newXML.write(fileLine.replace("source=\"SILENT.\"", "source=\"new_SILENT.\""))


### PR DESCRIPTION
Adds `vcInitVCSystem` `vcExecCamera` `vcAdjCamOfsAngByOfsAngSpd`, named some debug string draw funcs, and slight improvements to stream.c matches.

stream.c seems to have some leftover debug movie player code inside, but comparing with pre-Jan17 builds shows some code was removed from it at some point :(

Added some `#ifdef DEBUG` code to recreate it, but don't know if we can actually build with that yet since I'm not sure if that "MOVIE NO=" string will be inserted into rodata properly...

(commenting the line that draws "MOVIE NO" and just printing movie number does work tho, you can switch to this movie player by changing `BCCBC` to 0x11 when you're on main menu, pressing X will start playing selected movie)