### PR TITLE
permute.sh: use -G0 for overlays, allow specify num threads with -j

### DIFF
--- a/permute.sh
+++ b/permute.sh
@@ -2,24 +2,46 @@
 
 # Function to display usage
 usage() {
-    echo "Usage: $0 [--clean] [--run] FUNCTION_NAME ASM_FUNCTION C_FUNCTION"
-    echo "ASM_FUNCTION is the .s file from asm/../nonmatching folder"
-    echo "C_FUNCTION file should contain just the function and related includes"
+    echo "Usage: $0 [--clean] [--run] [-j THREADS] FUNCTION_NAME ASM_FUNCTION C_FUNCTION"
+    echo "  --clean       : Clean the output directory before processing"
+    echo "  --run         : Run the permuter after setup"
+    echo "  -j THREADS    : Number of threads to use for the permuter (default: 4)"
+    echo "  FUNCTION_NAME : Name of the function to permute"
+    echo "  ASM_FUNCTION  : Path to the .s file from asm/../nonmatching folder"
+    echo "  C_FUNCTION    : Path to the C file containing just the function and related includes"
     exit 1
 }
 
 # Initialize flags
 CLEAN=false
 RUN=false
+THREADS=4
 
 # Parse flags
-while [[ "$1" == "--clean" || "$1" == "--run" ]]; do
-    if [ "$1" == "--clean" ]; then
-        CLEAN=true
-    elif [ "$1" == "--run" ]; then
-        RUN=true
-    fi
-    shift
+while [[ "$1" == --* || "$1" == -j ]]; do
+    case "$1" in
+        --clean)
+            CLEAN=true
+            shift
+            ;;
+        --run)
+            RUN=true
+            shift
+            ;;
+        -j)
+            if [[ -n "$2" && "$2" =~ ^[0-9]+$ ]]; then
+                THREADS="$2"
+                shift 2
+            else
+                echo "Error: -j requires a numeric argument"
+                usage
+            fi
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
 done
 
 # Get the parameters
@@ -50,6 +72,13 @@ echo "Creating settings.toml file"
     cat permute_defaults.toml
 } > permuter/$FUNCTION_NAME/settings.toml
 
+# Main executable uses -G8 while overlays use -G0.
+if [[ "$ASM_FUNCTION" == *"asm/main/"* ]]; then
+    G_OPTION="-G8"
+else
+    G_OPTION="-G0"
+fi
+
 echo "Creating compile.sh file"
 {
     echo '#!/usr/bin/env bash'
@@ -63,8 +92,8 @@ echo "Creating compile.sh file"
     echo "cd $SCRIPT_DIR"
     echo ''
     echo 'mips-linux-gnu-cpp -P -MMD -MP -MT "$INPUT_I" -MF "$INPUT_D" -Iinclude -Iinclude/psyq -I build -D_LANGUAGE_C -DUSE_INCLUDE_ASM -P -MMD -MP -undef -Wall -lang-c -nostdinc -o "$INPUT_I" "$INPUT"'
-    echo 'tools/gcc-2.8.1-psx/cc1 -O2 -mips1 -mcpu=3000 -w -funsigned-char -fpeephole -ffunction-cse -fpcc-struct-return -fcommon -fverbose-asm -msoft-float -mgas -fgnu-linker -quiet -G4 -o "$INPUT_S" "$INPUT_I"'
-    echo 'python3 tools/maspsx/maspsx.py --aspsx-version=2.77 --run-assembler -EL -Iinclude -Iinclude/psyq -I build -O2 -G4 -march=r3000 -mtune=r3000 -no-pad-sections -o "$OUTPUT" "$INPUT_S"'
+    echo "tools/gcc-2.8.1-psx/cc1 -O2 $G_OPTION -mips1 -mcpu=3000 -w -funsigned-char -fpeephole -ffunction-cse -fpcc-struct-return -fcommon -fverbose-asm -msoft-float -mgas -fgnu-linker -quiet -o \"\$INPUT_S\" \"\$INPUT_I\""
+    echo "python3 tools/maspsx/maspsx.py --aspsx-version=2.77 --run-assembler -EL -Iinclude -Iinclude/psyq -I build -O2 $G_OPTION -march=r3000 -mtune=r3000 -no-pad-sections -o \"\$OUTPUT\" \"\$INPUT_S\""
 } > permuter/$FUNCTION_NAME/compile.sh
 
 chmod +x permuter/$FUNCTION_NAME/compile.sh
@@ -81,10 +110,10 @@ echo "Preprocessing the C function $C_FUNCTION and saving to permuter/$FUNCTION_
 gcc -E -P -Iinclude -Iinclude/psyq -DPERMUTER $C_FUNCTION > permuter/$FUNCTION_NAME/base.c
 
 echo "Assembling the ASM function permuter/$FUNCTION_NAME/target.o"
-mips-linux-gnu-as -EL -Iinclude -Iinclude/psyq -I build -O2 -march=r3000 -mtune=r3000 -no-pad-sections -G4 -o permuter/$FUNCTION_NAME/target.o permuter/$FUNCTION_NAME/target.s
+mips-linux-gnu-as -EL -Iinclude -Iinclude/psyq -I build -O2 -march=r3000 -mtune=r3000 -no-pad-sections $G_OPTION -o permuter/$FUNCTION_NAME/target.o permuter/$FUNCTION_NAME/target.s
 
 # Run decomp-permuter if the --run flag is set
 if [ "$RUN" = true ]; then
     echo "Running decomp-permuter"
-    python3 tools/decomp-permuter/permuter.py -j2 --algorithm levenshtein permuter/$FUNCTION_NAME/
+    python3 tools/decomp-permuter/permuter.py -j$THREADS --algorithm levenshtein permuter/$FUNCTION_NAME/
 fi


### PR DESCRIPTION
Allows permute score to match closer to decomp.me score (eg. would give 3500+ score for movie_main, now gives 140)

Also added `-j X` param to specify number of threads for permuter to use

example
```
tools/m2ctx.py src/screens/stream/stream.c
vi ctx.c # add movie_main to end of file
./permute.sh -j 20 --run movie_main asm/screens/stream/nonmatchings/stream/movie_main.s ctx.c
```