### PR TITLE
docs: add file_formats/sh1_dms.bt, rename DMS struct fields

### DIFF
--- a/docs/file_formats/sh1_dms.bt
+++ b/docs/file_formats/sh1_dms.bt
@@ -1,0 +1,88 @@
+//------------------------------------------------
+//--- 010 Editor v14.0.1 Binary Template
+//
+//      File: sh1_dms.bt
+//   Authors: emoose
+//   Version: 1.0
+//   Purpose: Parser for SH1 DMS cutscene files
+//------------------------------------------------
+
+DisplayFormatHex();
+
+struct VECTOR3
+{
+    int vx<format=decimal>;
+    int vy<format=decimal>;
+    int vz<format=decimal>;
+};
+
+struct SVECTOR3
+{
+    short vx<format=decimal>;
+    short vy<format=decimal>;
+    short vz<format=decimal>;
+};
+
+struct DVECTOR
+{
+    short vx<format=decimal>;
+    short vy<format=decimal>;
+};
+
+struct CameraFrame
+{
+    short field_0[8]; // Used to calculate cam_tgt_pos & watch_tgt_pos.
+};
+
+struct CharacterFrame
+{
+    SVECTOR3 position_0;
+    SVECTOR3 rotation_6;
+};
+
+struct DMSEntry(int isCharacter)
+{    
+    int16 keyframeCount_0; // TODO: Are these actually keyframes?
+    byte svectorCount_2;
+    byte field_3; // Usually 0, but sometimes filled in, possibly junk data left in padding byte.
+    char name[4];
+    int svectorOffset_8;
+    int keyframeOffset_C;
+    
+    local long end = FTell();
+    
+    FSeek(svectorOffset_8);
+    SVECTOR3 svector[svectorCount_2]<optimize=false>;
+    
+    FSeek(keyframeOffset_C);
+    
+    if (isCharacter == 1)
+        CharacterFrame keyframes[keyframeCount_0]<optimize=false>;
+    else
+        CameraFrame keyframes[keyframeCount_0]<optimize=false>;
+        
+    FSeek(end);
+};
+
+struct DMSHeader
+{
+    byte isLoaded_0;
+    byte characterCount_1;
+    byte dvectorCount_2;
+    byte field_3; // Usually 0, but sometimes filled in.
+    uint32 field_4; // Unknown, correlates to file size?
+    uint32 dvectorOffset_8;
+    VECTOR3 field_C;
+    uint32 charactersOffset;
+    DMSEntry camera(0);
+};
+
+DMSHeader header;
+
+// DVECTORs sometimes have contiguous values (0, 20), (20, 42), (42, 56)
+// but sometimes have gaps, or decreasing values like (176, 78)
+FSeek(header.dvectorOffset_8);
+DVECTOR dvectors[header.dvectorCount_2];
+    
+FSeek(header.charactersOffset);
+DMSEntry characters(1)[header.characterCount_1]<optimize=false>;

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -272,12 +272,12 @@ STATIC_ASSERT_SIZEOF(s_Skeleton, 28);
 
 typedef struct
 {
-    s16      count_0;
-    u8       ptr_8_count_2;
-    char     unk_3[1];
+    s16       keyframeCount_0;
+    u8        svectorCount_2;
+    u8        field_3;   // Usually 0, but sometimes filled in, possibly junk data left in padding byte.
     char     name_4[4]; // First 4 chars of name, eg. game code checks for "DAHLIA" but in file it's "DAHL"
     SVECTOR3* svectorPtr_8;   // Pointer to SVECTOR3s, unknown purpose.
-    u16*      unkStructPtr_C; // Pointer to struct of u16s, possibly MATRIX?
+    u16*      keyframePtr_C;  // Points to 6x u16 for characters, or 8x u16 for camera
 } s_DMSEntry;
 STATIC_ASSERT_SIZEOF(s_DMSEntry, 0x10);
 
@@ -285,9 +285,10 @@ typedef struct
 {
     u8          isLoaded_0;
     u8          characterCount_1;
-    u8          length_2;
-    s8          unk_3[5];
-    s16*        field_8;
+    u8          dvectorCount_2;
+    u8          field_3; // Usually 0, but sometimes filled in.
+    u32         field_4; // Unknown, correlates with DMS file size.
+    DVECTOR*    dvectorPtr_8;
     VECTOR3     field_C;
     s_DMSEntry* characters_18;
     s_DMSEntry  camera_1C;

--- a/src/bodyprog/bodyprog_80085D78.c
+++ b/src/bodyprog/bodyprog_80085D78.c
@@ -1241,7 +1241,7 @@ void DMSHeader_FixOffsets(s_DMSHeader* header) // 0x8008C9A0
     header->isLoaded_0 = 1;
 
     // Add memory addr of DMS header to the offsets in header
-    header->field_8       = (u8*)header->field_8 + (u32)header;
+    header->dvectorPtr_8  = (u8*)header->dvectorPtr_8 + (u32)header;
     header->characters_18 = (u8*)header->characters_18 + (u32)header;
 
     DMSEntry_FixOffsets(&header->camera_1C, header);
@@ -1256,8 +1256,8 @@ void DMSHeader_FixOffsets(s_DMSHeader* header) // 0x8008C9A0
 
 void DMSEntry_FixOffsets(s_DMSEntry* entry, s_DMSHeader* header) // 0x8008CA44
 {
-    entry->unkStructPtr_C = (u32)entry->unkStructPtr_C + (u32)header;
-    entry->svectorPtr_8   = (u32)entry->svectorPtr_8 + (u32)header;
+    entry->keyframePtr_C = (u32)entry->keyframePtr_C + (u32)header;
+    entry->svectorPtr_8  = (u32)entry->svectorPtr_8 + (u32)header;
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80085D78", func_8008CA60);
@@ -1320,7 +1320,7 @@ s32 DMS_CameraGetTargetPos(VECTOR3* cam_tgt_pos, VECTOR3* watch_tgt_pos, u16* ar
     camera = &header->camera_1C;
 
     func_8008D1D0(&sp28, &sp2C, &sp30, time, camera, header);
-    camProjValue = func_8008CFEC(&sp18, &camera->unkStructPtr_C[sp28 * 8], &camera->unkStructPtr_C[sp2C * 8], sp30);
+    camProjValue = func_8008CFEC(&sp18, &camera->keyframePtr_C[sp28 * 8], &camera->keyframePtr_C[sp2C * 8], sp30);
 
     cam_tgt_pos->vx = FP_TO(sp18[0] + header->field_C.vx, Q4_SHIFT);
     cam_tgt_pos->vy = FP_TO(sp18[1] + header->field_C.vy, Q4_SHIFT);


### PR DESCRIPTION
Adds `file_formats` folder inside `docs`, and added a .DMS parser for 010 editor inside it.

Might be worth documenting the file separately instead of only having a parser though, maybe could try making a SH page on http://wiki.decomp.dev, like how some other games have one there (https://wiki.decomp.dev/en/projects/nintendo-64/dinosaur-planet), so that anyone could contribute to it without needing to make PRs to have repo access.