### PR TITLE
splat: add `global_vram_end` to configs, add overlay syms to bodyprog

### DIFF
--- a/configs/bodyprog.yaml
+++ b/configs/bodyprog.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -17,6 +17,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False
@@ -27,6 +28,11 @@ options:
 
   section_order: [".rodata", ".text", ".data", ".sdata", ".sbss", ".bss"]
   symbol_addrs_path:
+    - configs/screens/sym.b_konami.txt
+    - configs/screens/sym.stream.txt
+    - configs/screens/sym.saveload.txt
+    - configs/screens/sym.options.txt
+    - configs/screens/sym.credits.txt
     - configs/sym.bodyprog.txt
     - configs/sym.main.txt
   reloc_addrs_path:

--- a/configs/maps/map0_s00.yaml
+++ b/configs/maps/map0_s00.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map0_s01.yaml
+++ b/configs/maps/map0_s01.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map0_s02.yaml
+++ b/configs/maps/map0_s02.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map1_s00.yaml
+++ b/configs/maps/map1_s00.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map1_s01.yaml
+++ b/configs/maps/map1_s01.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map1_s02.yaml
+++ b/configs/maps/map1_s02.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map1_s03.yaml
+++ b/configs/maps/map1_s03.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map1_s04.yaml
+++ b/configs/maps/map1_s04.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map1_s05.yaml
+++ b/configs/maps/map1_s05.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map1_s06.yaml
+++ b/configs/maps/map1_s06.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map2_s00.yaml
+++ b/configs/maps/map2_s00.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map2_s01.yaml
+++ b/configs/maps/map2_s01.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map2_s02.yaml
+++ b/configs/maps/map2_s02.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map2_s03.yaml
+++ b/configs/maps/map2_s03.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map2_s04.yaml
+++ b/configs/maps/map2_s04.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map3_s00.yaml
+++ b/configs/maps/map3_s00.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map3_s01.yaml
+++ b/configs/maps/map3_s01.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map3_s02.yaml
+++ b/configs/maps/map3_s02.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map3_s03.yaml
+++ b/configs/maps/map3_s03.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map3_s04.yaml
+++ b/configs/maps/map3_s04.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map3_s05.yaml
+++ b/configs/maps/map3_s05.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map3_s06.yaml
+++ b/configs/maps/map3_s06.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map4_s00.yaml
+++ b/configs/maps/map4_s00.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map4_s01.yaml
+++ b/configs/maps/map4_s01.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map4_s02.yaml
+++ b/configs/maps/map4_s02.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map4_s03.yaml
+++ b/configs/maps/map4_s03.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map4_s04.yaml
+++ b/configs/maps/map4_s04.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map4_s05.yaml
+++ b/configs/maps/map4_s05.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map4_s06.yaml
+++ b/configs/maps/map4_s06.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map5_s00.yaml
+++ b/configs/maps/map5_s00.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map5_s01.yaml
+++ b/configs/maps/map5_s01.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map5_s02.yaml
+++ b/configs/maps/map5_s02.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map5_s03.yaml
+++ b/configs/maps/map5_s03.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map6_s00.yaml
+++ b/configs/maps/map6_s00.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map6_s01.yaml
+++ b/configs/maps/map6_s01.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map6_s02.yaml
+++ b/configs/maps/map6_s02.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map6_s03.yaml
+++ b/configs/maps/map6_s03.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map6_s04.yaml
+++ b/configs/maps/map6_s04.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map6_s05.yaml
+++ b/configs/maps/map6_s05.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map7_s00.yaml
+++ b/configs/maps/map7_s00.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map7_s01.yaml
+++ b/configs/maps/map7_s01.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map7_s02.yaml
+++ b/configs/maps/map7_s02.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/maps/map7_s03.yaml
+++ b/configs/maps/map7_s03.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/screens/b_konami.yaml
+++ b/configs/screens/b_konami.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/screens/credits.yaml
+++ b/configs/screens/credits.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/screens/options.yaml
+++ b/configs/screens/options.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/screens/saveload.yaml
+++ b/configs/screens/saveload.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False

--- a/configs/screens/stream.yaml
+++ b/configs/screens/stream.yaml
@@ -16,6 +16,7 @@ options:
   find_file_boundaries: False
   gp_value: 0x80022BB0
   global_vram_start: 0x80010000
+  global_vram_end: 0x80200000
 
   o_as_suffix: False
   use_legacy_include_asm: False


### PR DESCRIPTION
Fixes #66, now bodyprog can make calls into overlay symbols like `open_main` fine.

Still doesn't symbolize undefined funcs that we haven't added symbols for though, so the func table in that issue is still mostly raw addrs, but I guess unnamed/undefined funcs probably aren't a huge deal anyway (funcs can always be fixed if needed by just adding them to sym.xxx.txt file, which we'll eventually do anyway...)