### PR TITLE
splat: add overlay syms to bodyprog instead of main

### DIFF
--- a/configs/bodyprog.yaml
+++ b/configs/bodyprog.yaml
@@ -28,6 +28,11 @@ options:
   section_order: [".rodata", ".text", ".data", ".bss"]
 
   symbol_addrs_path:
+    - configs/screens/sym.b_konami.txt
+    - configs/screens/sym.stream.txt
+    - configs/screens/sym.saveload.txt
+    - configs/screens/sym.options.txt
+    - configs/screens/sym.credits.txt
     - configs/sym.bodyprog.txt
     - configs/sym.main.txt
   reloc_addrs_path:

--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -28,11 +28,6 @@ options:
 
   section_order: [".rodata", ".text", ".data", ".sdata", ".sbss", ".bss"]
   symbol_addrs_path:
-    - configs/screens/sym.b_konami.txt
-    - configs/screens/sym.stream.txt
-    - configs/screens/sym.saveload.txt
-    - configs/screens/sym.options.txt
-    - configs/screens/sym.credits.txt
     - configs/sym.bodyprog.txt
     - configs/sym.main.txt
   reloc_addrs_path:


### PR DESCRIPTION
Oops, #67 added to wrong yaml by mistake, this should let bodyprog see overlay syms properly now.