### PR TITLE
bodyprog: fix 3 NON_MATCHINGs

### DIFF
--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -704,6 +704,11 @@ extern s_FsImageDesc g_MainImg0; // 0x80022C74
 
 extern s_800AD4C8 D_800AD4C8[];
 
+/** TODO: 800C964C and 800C96B8 are part of map overlay header? maybe should be moved to maps/s00.h or dynamic/dynamic.h */
+extern s32 (*D_800C964C)(s32, void*, s16, s32);
+
+extern s32 (*D_800C96B8)(s32, s32, void*, s16, s32);
+
 /** Initializer for something before the game loop. */
 void func_8002E630();
 

--- a/src/bodyprog/bodyprog_80085D78.c
+++ b/src/bodyprog/bodyprog_80085D78.c
@@ -298,7 +298,6 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80085D78", func_80086470);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80085D78", func_800865FC);
 
-#ifdef NON_MATCHING
 void func_800866D4(s32 arg0, s32 arg1, s32 arg2) // 0x800866D4
 {
     if (D_800C964C(arg0, &D_800C4640, D_800C4700, arg1) == 1)
@@ -306,11 +305,7 @@ void func_800866D4(s32 arg0, s32 arg1, s32 arg2) // 0x800866D4
         func_80085D78(arg2);
     }
 }
-#else
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80085D78", func_800866D4);
-#endif
 
-#ifdef NON_MATCHING
 void func_80086728(s32 arg0, s32 arg1, s32 arg2, s32 arg3) // 0x80086728
 {
     if (D_800C96B8(arg0, arg1, &D_800C46A0, D_800C4702, arg2) == 1)
@@ -318,18 +313,11 @@ void func_80086728(s32 arg0, s32 arg1, s32 arg2, s32 arg3) // 0x80086728
         func_80085D78(arg3);
     }
 }
-#else
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80085D78", func_80086728);
-#endif
 
-#ifdef NON_MATCHING
 void func_8008677C(s32 arg0, s32 arg1, s32 arg2) // 0x8008677C
 {
     D_800C96B8(arg0, arg1, &D_800C46A0, D_800C4702, arg2);
 }
-#else
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80085D78", func_8008677C);
-#endif
 
 void func_800867B4(s32 caseParam, s32 idx) // 0x800867B4
 {


### PR DESCRIPTION
Allows 3 funcs to match, the extern they call seems to be something in map overlay though, have a tiny part of the overlay header mapped out which I posted on discord a week or so back, but 90% of that was still unknown.