### PR TITLE
bodyprog: match 2 functions

### DIFF
--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -941,6 +941,24 @@ void func_8004B9F8(s32 arg0, u8 arg1); // Types assumed.
 
 void func_8004BCBC(s32 arg0);
 
+/** Used to check if Hyper Blaster can be added to inventory.
+    Return values:
+        -1 if already exists in inventory.
+        1 if konami gun controller connected, or savegame flags set.
+        0 otherwise.
+    Maybe Inventory_HyperBlasterCanAdd is suitable (inventory funcs seem bunched at a different address though?)
+*/
+s32 func_8004C45C();
+
+/** Called by status screen to check if Hyper Blaster can be used?
+    Return values:
+        2 if savegame flag is set.
+        1 if konami gun controller connected.
+        0 otherwise.
+    Maybe Inventory_HyperBlasterCanUse is suitable.
+*/
+s32 func_8004C4F8();
+
 void func_800546A8(s32 arg0);
 
 void func_80054928();

--- a/include/game.h
+++ b/include/game.h
@@ -148,10 +148,24 @@ typedef enum _PlayerProperty
     PlayerProperty_RunTimer1     = 9  // Increments every tick indefinitely.
 } s_PlayerProperty;
 
+// Based on LIBOVR.PDF `Buffer Data Format` section.
+typedef enum _PadTerminalType
+{
+    PadTerminalType_Mouse               = 1,
+    PadTerminalType_16ButtonAnalog      = 2,
+    PadTerminalType_GunControllerKonami = 3,
+    PadTerminalType_16Button            = 4,
+    PadTerminalType_AnalogJoystick      = 5,
+    PadTerminalType_GunControllerNamco  = 6,
+    PadTerminalType_AnalogController    = 7,
+    PadTerminalType_MultitapAdapter     = 8,
+} e_PadTerminalType;
+
 typedef struct _AnalogPadData
 {
     u8  status;
-    u8  data_format;
+    u8  received_bytes : 4; /** Number of bytes received / 2. */
+    u8  terminal_type : 4;  /** e_PadTerminalType */
     u16 digitalButtons;
     u8  right_x;
     u8  right_y;
@@ -244,8 +258,8 @@ typedef struct _ShSaveGame
     s32               playerHealth_240;      /** Q20.12, default: 100 */
     s32               playerPositionX_244;   /** Q20.12 */
     s16               playerRotationY_248;   /** Q4.12, in format that can be multiplied by 180 to get degrees. Default: North */
-    s8                field_24A; 
-    s8                field_24B; 
+    u8                field_24A;
+    u8                field_24B;
     s32               playerPositionZ_24C;   /** Q20.12 */
     s32               gameplayTimer_250;     /** Q20.12 */
     s32               runDistance_254;       /** Q20.12 */

--- a/src/bodyprog/bodyprog_8004A87C.c
+++ b/src/bodyprog/bodyprog_8004A87C.c
@@ -109,9 +109,53 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", Player_AnimUpdate);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8004C328);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8004C45C);
+s32 func_8004C45C()
+{
+    s32 i;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8004C4F8);
+    for (i = 0; i < 40; i++)
+    {
+        if (g_SaveGamePtr->items_0[i].id == 0xA3) // HYPER_BLASTER
+        {
+            return -1; // Already in inventory, can't add new one.
+        }
+    }
+
+    if (g_SaveGamePtr->mapOverlayIdx_A4 > 0)
+    {
+        if (g_GameWork.controllers_38[1].analogPad_0.status == 0 &&
+            g_GameWork.controllers_38[1].analogPad_0.received_bytes == 1 &&
+            g_GameWork.controllers_38[1].analogPad_0.terminal_type == PadTerminalType_GunControllerKonami)
+        {
+            return 1; // Konami Gun Controller connected.
+        }
+
+        if (g_SaveGamePtr->field_24A != 0 && (g_SaveGamePtr->field_24B & 0x10) != 0)
+        {
+            return 1; // Game completed with some condition met?
+        }
+    }
+
+    return 0;
+}
+
+s32 func_8004C4F8()
+{
+    if (g_SaveGamePtr->mapOverlayIdx_A4 > 0)
+    {
+        if ((g_SaveGamePtr->field_24B & 0x10) != 0)
+        {
+            return 2; // Game completed with some condition met?
+        }
+
+        // Returns 1 if controller port 2 has Konami gun controller connected.
+        return g_GameWork.controllers_38[1].analogPad_0.status == 0 &&
+               g_GameWork.controllers_38[1].analogPad_0.received_bytes == 1 &&
+               g_GameWork.controllers_38[1].analogPad_0.terminal_type == PadTerminalType_GunControllerKonami;
+    }
+
+    return 0;
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8004C54C);
 


### PR DESCRIPTION
Matches 2 funcs related to Konami lightgun check, haven't added names yet but `Inventory_HyperBlasterCanAdd` / `Inventory_HyperBlasterCanUse` might fit, most of the inventory funcs seem bunched around a different address though.