### PR TITLE
symbols: add names for GameState/SysState update funcs, match `SysState_Fmv_Update`

### DIFF
--- a/configs/screens/sym.b_konami.txt
+++ b/configs/screens/sym.b_konami.txt
@@ -1,0 +1,2 @@
+GameState_KonamiLogo_Update = 0x800C95AC; // type:func
+GameState_KcetLogo_Update = 0x800C99A4; // type:func

--- a/configs/screens/sym.credits.txt
+++ b/configs/screens/sym.credits.txt
@@ -1,0 +1,1 @@
+GameState_Unk15_Update = 0x801E3094; // type:func

--- a/configs/screens/sym.options.txt
+++ b/configs/screens/sym.options.txt
@@ -1,4 +1,4 @@
-
+GameState_OptionScreen_Update = 0x801E2D44; // type:func
 Settings_ExtraScreen = 0x801E318C; // type:func
 Settings_MainScreen = 0x801E3770; // type:func
 Gfx_BgmBarDraw = 0x801E3F68; // type:func

--- a/configs/screens/sym.saveload.txt
+++ b/configs/screens/sym.saveload.txt
@@ -1,0 +1,2 @@
+GameState_Unk4_Update = 0x801E72FC; // type:func
+GameState_Unk8_Update = 0x801E6320; // type:func

--- a/configs/screens/sym.stream.txt
+++ b/configs/screens/sym.stream.txt
@@ -1,3 +1,11 @@
+// Handlers for movie-related GameStates
+GameState_StartMovieIntro_Update = 0x801E2654; // type:func
+GameState_MovieIntro_Update = 0x801E279C; // type:func
+GameState_MovieOpening_Update = 0x801E2838; // type:func
+GameState_ExitMovie_Update = 0x801E28B0; // type:func
+GameState_DebugMoviePlayer_Update = 0x801E2908; // type:func
+GameState_MovieIntroAlternate_Update = 0x801E2A24; // type:func
+
 // beatmania MOVIESYS names, which seems based on PSX SDK sample code
 // (SH1 seems closer to MOVIESYS than the SDK code)
 open_main = 0x801e2aa4; // type:func

--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -151,6 +151,30 @@ g_Demo_ControllerPacket = 0x800C4890;
 g_Demo_DemoStep = 0x800C4894;
 g_Demo_VideoPresentInterval = 0x800C4898;
 
+GameState_Unk0_Update = 0x80032D1C; // type:func
+GameState_MainMenu_Update = 0x8003AB28; // type:func
+GameState_LoadScreen_Update = 0x800348E8; // type:func
+GameState_InGame_Update = 0x80038BD4; // type:func
+GameState_MapEvent_Update = 0x8003AA4C; // type:func
+GameState_StatusScreen_Update = 0x8004C9B0; // type:func
+GameState_MapScreen_Update = 0x80066EB0; // type:func
+GameState_LoadStatusScreen_Update = 0x800395C0; // type:func
+GameState_LoadMapScreen_Update = 0x8003991C; // type:func
+
+SysState_Gameplay_Update = 0x80038F6C; // type:func
+SysState_OptionsMenu_Update = 0x80039344; // type:func
+SysState_StatusMenu_Update = 0x80039568; // type:func
+SysState_Unk3_Update = 0x800396D4; // type:func
+SysState_Fmv_Update = 0x80039A58; // type:func
+SysState_LoadArea_Update = 0x80039C40; // type:func
+SysState_ReadMessage_Update = 0x80039FB8; // type:func
+SysState_SaveMenu_Update = 0x8003A230; // type:func
+SysState_Unk10_Update = 0x8003A3C8; // type:func
+SysState_Unk11_Update = 0x8003A460; // type:func
+SysState_Unk12_Update = 0x8003A4B4; // type:func
+SysState_GameOver_Update = 0x8003A52C; // type:func
+SysState_GamePaused_Update = 0x800391E8; // type:func
+
 SaveGame_CopyWithChecksum = 0x8002FCCC; // type:func
 SaveGame_ChecksumUpdate = 0x8002FF30; // type:func
 SaveGame_ChecksumValidate = 0x8002FF74; // type:func

--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -15,6 +15,7 @@ g_DeltaTime0 = 0x800B5CC0; // type:s32 - Q20.12 fixed point, usually 0x44 (0.016
 g_DeltaTime1 = 0x800A8FEC; // type:s32
 g_DeltaTime2 = 0x800B9CC8; // type:s32
 g_MapEventIdx = 0x800A9A14; // type:u32
+g_MapEventParam = 0x800BCDD8; // type:u32 - pointer to s_ShEventParam
 
 g_IntervalVBlanks = 0x800A8FF0; // type:s32
 g_PrevVBlanks = 0x800A9770; // type:s32

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -503,9 +503,13 @@ extern s8 D_800A99CC[];
 
 extern s_FsImageDesc D_800A9A04;
 
+extern s32 D_800A9A0C; // old IDB name FS_AllFilesLoaded, though FS code doesn't set it
+
 extern s32 D_800A9A1C;
 
 extern s32 D_800A9A68;
+
+extern RECT D_800A9A6C; // RECT <320, 256, 160, 240>, only used in SysState_Fmv_Update?
 
 extern s_FsImageDesc D_800A9EB4;
 
@@ -841,6 +845,11 @@ s32 func_80033548();
 
 /** Unknown bodyprog func. Called by `Fs_QueuePostLoadAnm`. */
 void func_80035560(s32 arg0, s32 arg1, void* arg2, s32 arg3);
+
+/** SysState_Fmv update function.
+ * Movie to play is decided by `2072 - g_MapEventIdx`
+ * After playback, savegame gets `D_800BCDD8->eventFlagNum_2` event flag set. */
+void SysState_Fmv_Update();
 
 /** Unknown bodyprog func. Called by `Fs_QueueDoThingWhenEmpty`. */
 s32 func_8003c850();

--- a/include/game.h
+++ b/include/game.h
@@ -306,7 +306,18 @@ typedef struct _ShSaveGameContainer
     s_ShSaveGameFooter footer_27C;
 } s_ShSaveGameContainer;
 STATIC_ASSERT_SIZEOF(s_ShSaveGameContainer, 0x280);
-    
+
+typedef struct _ShEventParam
+{
+    u8  unk_0[2];
+    s16 eventFlagNum_2;
+    u8  unk_4[1];
+    u8  field_5;
+    u8  unk_6[2];
+    u32 flags_8;
+} s_ShEventParam;
+STATIC_ASSERT_SIZEOF(s_ShEventParam, 0xC);
+
 typedef struct _GameWork
 {
     s_ControllerBindings controllerBinds_0;
@@ -510,6 +521,7 @@ extern s32 g_DeltaTime0;
 extern s32 g_DeltaTime1;
 extern s32 g_DeltaTime2;
 extern u32 g_MapEventIdx;
+extern s_ShEventParam* g_MapEventParam;
 
 extern s32 g_IntervalVBlanks;
 extern s32 g_PrevVBlanks;
@@ -571,6 +583,15 @@ static inline void Game_StateSetPrevious()
     g_GameWork.gameState_594        = g_GameWork.gameStatePrev_590;
     g_GameWork.gameStatePrev_590    = prevState;
     g_GameWork.gameStateStep_598[0] = 0;
+}
+
+/** Sets the given flag ID inside the savegame event flags array. */
+static inline void SaveGame_EventFlagSet(u32 flagNum)
+{
+    s16 flagIdx = flagNum / 32;
+    s16 flagBit = flagNum % 32;
+
+    g_SaveGamePtr->eventFlags_168[flagIdx] |= (1 << flagBit);
 }
 
 #endif

--- a/include/game.h
+++ b/include/game.h
@@ -73,7 +73,7 @@ typedef enum _GameState
     GameState_LoadScreen          = 10,
     GameState_InGame              = 11,
     GameState_MapEvent            = 12,
-    GameState_ReturnToGameplay    = 13,
+    GameState_ExitMovie           = 13,
     GameState_StatusScreen        = 14,
     GameState_MapScreen           = 15,
     GameState_Unk10               = 16,

--- a/include/screens/b_konami/b_konami.h
+++ b/include/screens/b_konami/b_konami.h
@@ -33,11 +33,11 @@ extern u8* D_800CA50C;
 extern s32 D_800CA510;
 
 /** Display Konami logo and start loading base hero animations. */
-void func_800C95AC();
+void GameState_KonamiLogo_Update();
 
 s32 func_800C9874();
 
-void func_800C99A4();
+void GameState_KcetLogo_Update();
 
 void func_800C9E6C(s_FsImageDesc* image, s32 otz, s32 vramX, s32 vramY, s32 w, s32 h, s32 x, s32 y);
 

--- a/include/screens/stream/stream.h
+++ b/include/screens/stream/stream.h
@@ -63,6 +63,15 @@ extern DISPENV	  disp;
 extern s32 		  max_frame;
 #endif
 
+// Handlers for movie-related GameStates
+void GameState_StartMovieIntro_Update();
+void GameState_MovieIntro_Update();
+void GameState_MovieOpening_Update();
+void GameState_ExitMovie_Update();
+void GameState_DebugMoviePlayer_Update(); /** Unused debug movie player, movie to play decided by LStickLeft/LStickRight */
+void GameState_MovieIntroAlternate_Update();
+
+// MOVIESYS code
 void    open_main(s32 file_idx, s16 num_frames);
 void    movie_main(char* file_name, s32 f_size, s32 sector);
 void    strSetDefDecEnv(DECENV* dec, s32 x0, s32 y0, s32 x1, s32 y1);

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -1295,7 +1295,59 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk3_Update);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_LoadMapScreen_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Fmv_Update);
+void SysState_Fmv_Update() // 0x80039A58
+{
+    switch (g_SysWork.sysStateStep_C)
+    {
+        case 0:
+            D_800BCD0C               = 3;
+            D_800A9A0C               = 0;
+            g_SysWork.sysStateStep_C = 1;
+        case 1:
+            if (func_8003c850() != 0)
+            {
+                GameFs_StreamBinLoad();
+                g_SysWork.sysStateStep_C++;
+            }
+            break;
+    }
+
+    if (D_800A9A0C == 0)
+    {
+        return;
+    }
+
+    // Copy framebuffer into `IMAGE_BUFFER_0` before movie playback
+    DrawSync(0);
+    StoreImage(&D_800A9A6C, (u32*)IMAGE_BUFFER_0);
+    DrawSync(0);
+
+    func_800892A4(0);
+    func_80089128();
+
+    // Start playing movie, file to play is based on file ID `2072 - g_MapEventIdx`
+    // Blocks until movie has finished playback (or user has skipped it)
+    open_main(2072 - g_MapEventIdx, g_FileTable[2072 - g_MapEventIdx].blockCount);
+
+    func_800892A4(1);
+
+    // Restore copied framebuffer from `IMAGE_BUFFER_0`
+    GsSwapDispBuff();
+    LoadImage(&D_800A9A6C, (u32*)IMAGE_BUFFER_0);
+    DrawSync(0);
+
+    // Set savegame flag based on `D_800BCDD8->eventFlagNum_2` flag ID
+    SaveGame_EventFlagSet(g_MapEventParam->eventFlagNum_2);
+
+    // Return to game
+    Game_StateSetNext(GameState_InGame);
+
+    // If flag is set, returns us to GameState_InGame with gameStateStep[0] = 1
+    if ((g_MapEventParam->flags_8 >> 0xD) & 2) // flags_8 & 0x4000? does shift imply bitfield?
+    {
+        g_GameWork.gameStateStep_598[0] = 1;
+    }
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_LoadArea_Update);
 

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -561,7 +561,7 @@ void func_80032CE8()
     Gfx_StringDraw(&D_8002510C, 100);
 }
 
-void func_80032D1C()
+void GameState_Unk0_Update() // 0x80032D1C
 {
     s32 gameStateStep0;
     s32 gameState;
@@ -963,7 +963,7 @@ void func_800348C0()
     bzero(&D_800A9944, 0x48);
 }
 
-void func_800348E8()
+void GameState_LoadScreen_Update() // 0x800348E8
 {
     u8 temp;
 
@@ -1241,11 +1241,11 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80038A6C);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80038B44);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80038BD4);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_InGame_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80038F6C);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Gameplay_Update);
 
-void func_800391E8() // 0x800391E8
+void SysState_GamePaused_Update() // 0x800391E8
 {
     D_800A9A68 += g_DeltaTime1;
     if (((D_800A9A68 >> 11) & 1) == 0)
@@ -1283,21 +1283,21 @@ void func_800391E8() // 0x800391E8
     }
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80039344);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_OptionsMenu_Update);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003943C);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80039568);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_StatusMenu_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_800395C0);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_LoadStatusScreen_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_800396D4);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk3_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003991C);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_LoadMapScreen_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80039A58);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Fmv_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80039C40);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_LoadArea_Update);
 
 void AreaLoad_UpdatePlayerPosition() // 0x80039F30
 {
@@ -1308,7 +1308,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80039F54);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80039F90);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80039FB8);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_ReadMessage_Update);
 
 void SysWork_SaveGameUpdatePlayer() // 0x8003A120
 {
@@ -1341,19 +1341,19 @@ void SysWork_SaveGameReadPlayer() // 0x8003A1F4
     g_SysWork.player_4C.chara_0.health_B0      = g_SaveGamePtr->playerHealth_240;
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003A230);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_SaveMenu_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003A3C8);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk10_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003A460);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk11_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003A4B4);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk12_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003A52C);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_GameOver_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003AA4C);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_MapEvent_Update);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003AB28);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_MainMenu_Update);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003B550);
 

--- a/src/bodyprog/bodyprog_8004A87C.c
+++ b/src/bodyprog/bodyprog_8004A87C.c
@@ -166,7 +166,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8004C564);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8004C8DC);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8004C9B0);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", GameState_StatusScreen_Update);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_8004D1A0);
 
@@ -636,7 +636,7 @@ void func_80066E7C() // 0x80066E7C
     DrawSync(0);
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_80066EB0);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", GameState_MapScreen_Update);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_8004A87C", func_80067914);
 

--- a/src/screens/b_konami/b_konami.c
+++ b/src/screens/b_konami/b_konami.c
@@ -27,7 +27,7 @@ s32 D_800CA508 = 0;
 u8* D_800CA50C = 0;
 s32 D_800CA510 = 0;
 
-void func_800C95AC() // 0x800C95AC
+void GameState_KonamiLogo_Update() // 0x800C95AC
 {
     s32 idx;
 
@@ -144,7 +144,7 @@ s32 func_800C9874() // 0x800C9874
     return 4;
 }
 
-void func_800C99A4() // 0x800C99A4
+void GameState_KcetLogo_Update() // 0x800C99A4
 {
     s_GameWork* ptr;
 

--- a/src/screens/credits/credits.c
+++ b/src/screens/credits/credits.c
@@ -60,7 +60,7 @@ INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2ED8);
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2FC0);
 
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E3094);
+INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", GameState_Unk15_Update); // 0x801E3094
 
 s32 func_801E3124() // 0x801E3124
 {

--- a/src/screens/options/options.c
+++ b/src/screens/options/options.c
@@ -8,7 +8,7 @@
 // GENERAL, MAIN, AND EXTRA OPTION SCREENS
 // ========================================
 
-INCLUDE_ASM("asm/screens/options/nonmatchings/options", func_801E2D44);
+INCLUDE_ASM("asm/screens/options/nonmatchings/options", GameState_OptionScreen_Update); // 0x801E2D44
 
 INCLUDE_ASM("asm/screens/options/nonmatchings/options", Settings_ExtraScreen); // 0x801E318C
 

--- a/src/screens/saveload/saveload.c
+++ b/src/screens/saveload/saveload.c
@@ -72,7 +72,7 @@ INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E5898);
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E5E18);
 
-INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E6320);
+INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", GameState_Unk8_Update); // 0x801E6320
 
 void func_801E63C0() // 0x801E63C0
 {
@@ -152,6 +152,6 @@ void func_801E72DC() // 0x801E72DC
     func_801E3C44();
 }
 
-INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E72FC);
+INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", GameState_Unk4_Update); // 0x801E72FC
 
 INCLUDE_ASM("asm/screens/saveload/nonmatchings/saveload", func_801E737C);

--- a/src/screens/stream/stream.c
+++ b/src/screens/stream/stream.c
@@ -8,8 +8,7 @@
 #include "main/fileinfo.h"
 #include "screens/stream/stream.h"
 
-// Old IDB name: MainLoopState3_StartMovieIntro_801E2654
-void func_801E2654()
+void GameState_StartMovieIntro_Update() // 0x801E2654
 {
     switch (g_GameWork.gameStateStep_598[0])
     {
@@ -40,8 +39,7 @@ void func_801E2654()
     func_800314EC(D_800A900C);
 }
 
-// Old IDB name: MainLoopState6_Movie_PlayIntro_801E279C
-void func_801E279C()
+void GameState_MovieIntro_Update() // 0x801E279C
 {
     s32 fileIdx = FILE_XA_C1_20670;
 
@@ -56,22 +54,18 @@ void func_801E279C()
     D_800B5C30 = 0x1000;
 }
 
-// Old IDB name: MainLoopState9_Movie_PlayOpening_801E2838
-void func_801E2838()
+void GameState_MovieOpening_Update() // 0x801E2838
 {
     open_main(FILE_XA_M1_03500, 0);
     Game_StateSetNext(GameState_LoadScreen);
 }
 
-// Old IDB name: MainLoopStateD_ReturnToGame_801E28B0
-void func_801E28B0()
+void GameState_ExitMovie_Update() // 0x801E28B0
 {
     Game_StateSetNext(GameState_InGame);
 }
 
-// Old IDB name: MainLoopState11_Movie_PlayEnding_801E2908
-// Movie to play seems decided by LStickLeft/LStickRight, possibly debug movie player?
-void func_801E2908()
+void GameState_DebugMoviePlayer_Update() // 0x801E2908
 {
     extern s32 g_Debug_MoviePlayerIdx; // Only used in this func, maybe a static.
 
@@ -110,8 +104,7 @@ void func_801E2908()
     }
 }
 
-// Old IDB name: MainLoopState5_Movie_PlayIntroAlternate_801E2A24
-void func_801E2A24(void)
+void GameState_MovieIntroAlternate_Update() // 0x801E2A24
 {
     open_main(FILE_XA_C1_20670, 2060); // Second param looks like file ID for FILE_XA_M6_02112, but is actually frame count?
     Game_StateSetNext(GameState_MainMenu);


### PR DESCRIPTION
Named each of the GameState/SysState update funcs, eg. `GameState_MainMenu_Update`, this makes the func tables look a lot nicer in .data.s file:

```
dlabel D_800A9A2C
    /* 84ECC 800A9A2C 6C8F0380 */ .word SysState_Gameplay_Update
    /* 84ED0 800A9A30 44930380 */ .word SysState_OptionsMenu_Update
    /* 84ED4 800A9A34 68950380 */ .word SysState_StatusMenu_Update
    /* 84ED8 800A9A38 D4960380 */ .word SysState_Unk3_Update
    /* 84EDC 800A9A3C 589A0380 */ .word SysState_Fmv_Update
    /* 84EE0 800A9A40 409C0380 */ .word SysState_LoadArea_Update
    /* 84EE4 800A9A44 409C0380 */ .word SysState_LoadArea_Update
    /* 84EE8 800A9A48 B89F0380 */ .word SysState_ReadMessage_Update
    /* 84EEC 800A9A4C 30A20380 */ .word SysState_SaveMenu_Update
    /* 84EF0 800A9A50 30A20380 */ .word SysState_SaveMenu_Update
    /* 84EF4 800A9A54 C8A30380 */ .word SysState_Unk10_Update
    /* 84EF8 800A9A58 60A40380 */ .word SysState_Unk11_Update
    /* 84EFC 800A9A5C B4A40380 */ .word SysState_Unk12_Update
    /* 84F00 800A9A60 2CA50380 */ .word SysState_GameOver_Update
    /* 84F04 800A9A64 E8910380 */ .word SysState_GamePaused_Update
.size D_800A9A2C, . - D_800A9A2C
```

and now allows the GameState funcs inside `stream`/`saveload`/etc to get included into the func table (previously these used raw 0x80XXXXXX numbers instead of symbols)

```
dlabel D_800A977C
    /* 84C1C 800A977C 1C2D0380 */ .word GameState_Unk0_Update
    /* 84C20 800A9780 AC950C80 */ .word GameState_KonamiLogo_Update
    /* 84C24 800A9784 A4990C80 */ .word GameState_KcetLogo_Update
    /* 84C28 800A9788 54261E80 */ .word GameState_StartMovieIntro_Update
    /* 84C2C 800A978C FC721E80 */ .word GameState_Unk4_Update
    /* 84C30 800A9790 242A1E80 */ .word GameState_MovieIntroAlternate_Update
    /* 84C34 800A9794 9C271E80 */ .word GameState_MovieIntro_Update
    /* 84C38 800A9798 28AB0380 */ .word GameState_MainMenu_Update
    /* 84C3C 800A979C 20631E80 */ .word GameState_Unk8_Update
    /* 84C40 800A97A0 38281E80 */ .word GameState_MovieOpening_Update
    /* 84C44 800A97A4 E8480380 */ .word GameState_LoadScreen_Update
    /* 84C48 800A97A8 D48B0380 */ .word GameState_InGame_Update
    /* 84C4C 800A97AC 4CAA0380 */ .word GameState_MapEvent_Update
    /* 84C50 800A97B0 B0281E80 */ .word GameState_ExitMovie_Update
    /* 84C54 800A97B4 B0C90480 */ .word GameState_StatusScreen_Update
    /* 84C58 800A97B8 B06E0680 */ .word GameState_MapScreen_Update
    /* 84C5C 800A97BC 20631E80 */ .word GameState_Unk8_Update
    /* 84C60 800A97C0 08291E80 */ .word GameState_DebugMoviePlayer_Update
    /* 84C64 800A97C4 442D1E80 */ .word GameState_OptionScreen_Update
    /* 84C68 800A97C8 C0950380 */ .word GameState_LoadStatusScreen_Update
    /* 84C6C 800A97CC 1C990380 */ .word GameState_LoadMapScreen_Update
    /* 84C70 800A97D0 94301E80 */ .word GameState_Unk15_Update
.size D_800A977C, . - D_800A977C
```