### PR TITLE
maps: add `g_MapOverlayHeader`, skip overlapping garbage bodyprog data, small fixups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ endif
 
 # Utils
 
+# Function to find matching .bin files for a target name.
+find_bin_files = $(shell find $(ASM_DIR)/$(strip $1) -type f -path "*.bin" 2> /dev/null)
+
 # Function to find matching .s files for a target name.
 find_s_files = $(shell find $(ASM_DIR)/$(strip $1) -type f -path "*.s" -not -path "asm/*matchings*" 2> /dev/null)
 
@@ -88,7 +91,8 @@ find_c_files = $(shell find $(C_DIR)/$(strip $1) -type f -path "*.c" 2> /dev/nul
 # Function to generate matching .o files for target name in build directory.
 gen_o_files = $(addprefix $(BUILD_DIR)/, \
 							$(patsubst %.s, %.s.o, $(call find_s_files, $1)) \
-							$(patsubst %.c, %.c.o, $(call find_c_files, $1)))
+							$(patsubst %.c, %.c.o, $(call find_c_files, $1)) \
+							$(patsubst %.bin, %.bin.o, $(call find_bin_files, $1)))
 
 # Function to get path to .yaml file for given target.
 get_yaml_path = $(addsuffix .yaml,$(addprefix $(CONFIG_DIR)/,$1))
@@ -272,7 +276,7 @@ $(BUILD_DIR)/%.s.o: %.s
 
 $(BUILD_DIR)/%.bin.o: %.bin
 	@mkdir -p $(dir $@)
-	$(LD) -r -b binary -o $@ $<
+	$(LD) $(LD_FLAGS) -r -b binary -o $@ $<
 
 # Split .yaml.
 $(LINKER_DIR)/%.ld: $(CONFIG_DIR)/%.yaml

--- a/configs/bodyprog.yaml
+++ b/configs/bodyprog.yaml
@@ -9,6 +9,7 @@ options:
 
   asm_path: asm/bodyprog
   src_path: src/bodyprog
+  asset_path: asm/bodyprog
   build_path: build/
 
   ld_script_path: linkers/bodyprog.ld
@@ -28,7 +29,7 @@ options:
   section_order: [".rodata", ".text", ".data", ".bss"]
 
   symbol_addrs_path:
-    - configs/screens/sym.b_konami.txt
+   # - configs/screens/sym.b_konami.txt - Can't currently be included as function addrs overlap with map overlay data addrs
     - configs/screens/sym.stream.txt
     - configs/screens/sym.saveload.txt
     - configs/screens/sym.options.txt
@@ -253,4 +254,11 @@ segments:
       - [0x821b8, c, libsd/sdmidi2]
 
       - [0x84238, data, bodyprog]
+
+  # Random garbage data at end of bodyprog, overlaps into other overlays causing symbol size issues.
+  # Define as bin file to make splat mostly ignore it.
+  - name: footer_data
+    type: bin
+    start: 0xA4A18
+
   - [0xA4B00]

--- a/configs/screens/b_konami.yaml
+++ b/configs/screens/b_konami.yaml
@@ -9,6 +9,7 @@ options:
 
   asm_path: asm/screens/b_konami
   src_path: src/screens/b_konami
+  asset_path: asm/screens/b_konami
   build_path: build
 
   ld_script_path: linkers/screens/b_konami.ld
@@ -60,5 +61,8 @@ segments:
       - [0x34, c, b_konami]
 
       - [0xF78, .data, b_konami]
-      - [0xF9C, data] # Probably gibberish data.
+  # Random garbage data at end, define as bin file to make splat mostly ignore it.
+  - name: footer_data
+    type: bin
+    start: 0xF9C
   - [0x1000]

--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -27,6 +27,10 @@ g_MaybePlayerAnims = 0x800AF228; // type:MaybeCharacterAnim
 g_Gfx_DebugStringPosition0 = 0x800B5C20; // type:DVECTOR size:4
 g_Gfx_DebugStringPosition1 = 0x800B5C24; // type:DVECTOR size:4
 
+// TODO: g_MapOverlayHeader is part of the overlay bin file, maybe should be moved to sym.maps_shared.txt or similar.
+// Including here for now since all map configs include this sym file, and bodyprog also reads from this header.
+g_MapOverlayHeader = 0x800C957C; // type:MapOverlayHeader size:0x16C - size incomplete
+
 // sh "view" / "vw" / "vc" / "vb" code
 // Most names from SH2, functions seem to match pretty close between it and SH1 besides a few missing/extra funcs.
 hack_vcSetWatchTgtXzPos_fix = 0x8002B2B4; // type:s32 - Some 0x80083500 value which coincidentally points to code inside vcSetWatchTgtXzPos, probably unrelated flags or something. A jtbl is right before this which spimdisasm tries to include, breaking vcSetWatchTgtXzPos build.

--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -29,7 +29,7 @@ g_Gfx_DebugStringPosition1 = 0x800B5C24; // type:DVECTOR size:4
 
 // TODO: g_MapOverlayHeader is part of the overlay bin file, maybe should be moved to sym.maps_shared.txt or similar.
 // Including here for now since all map configs include this sym file, and bodyprog also reads from this header.
-g_MapOverlayHeader = 0x800C957C; // type:MapOverlayHeader size:0x16C - size incomplete
+g_MapOverlayHeader = 0x800C957C; // type:MapOverlayHeader size:0x84C - size incomplete
 
 // sh "view" / "vw" / "vc" / "vb" code
 // Most names from SH2, functions seem to match pretty close between it and SH1 besides a few missing/extra funcs.
@@ -137,11 +137,12 @@ cam_mv_prm_user = 0x800AFCD0; // type:VC_CAM_MV_PARAM size:0x10
 excl_r_ary = 0x800AFCE0; // int[9]
 vcWork = 0x800B9CD0; // type:VC_WORK size:0x2E8
 vcRefPosSt = 0x800BCDF8; // type:VECTOR3 size:0xC
-vcCameraInternalInfo = 0x800BE9F4; // type:VC_CAMERA_INTINFO size:8
 vwViewPointInfo = 0x800C37E0; // type:VW_VIEW_WORK size:0x84
 VbWvsMatrix = 0x800C3888; // type:MATRIX size:0x20
 vcWatchMvPrmSt = 0x800C4630; // type:VC_WATCH_MV_PARAM size:0xC
 vcSelfViewTimer = 0x800C463C; // type:s32
+
+D_800BCE18 = 0x800BCE18; // type:u8 size:0x2BEC - size incomplete, contains vcCameraInternalInfo and others
 
 g_Sd_VolumeSe = 0x800C1684;
 g_Sd_VolumeBgm = 0x800C1685;

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -1367,6 +1367,8 @@ void func_8003C3AC();
 
 void func_8003C878(s32);
 
+void func_8003CB3C(s_800BCE18* arg0);
+
 void func_8003D938();
 
 void func_8003DA9C(s32, GsCOORDINATE2*, s32, s16, s32);

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -3,6 +3,7 @@
 
 #include "game.h"
 #include "main/fsqueue.h"
+#include "bodyprog/vw_system.h"
 
 #define TEMP_MEMORY_ADDR (s8*)0x801A2600
 
@@ -188,6 +189,20 @@ typedef struct
     s8 field_3;
 } s_800BCDA8;
 STATIC_ASSERT_SIZEOF(s_800BCDA8, 4);
+
+typedef struct _s_800BCE18
+{
+    s8                unk_0[4];
+    s8                field_4;
+    u8                unk_5[3];
+    u8                unk_8[0x1644];
+    s32               field_164C;
+    u8                unk_1650[0x58C];
+    VC_CAMERA_INTINFO vcCameraInternalInfo_1BDC; // Debug camera info.
+    s_800BE9FC        field_1BE4;
+    s32               field_2BE8;
+} s_800BCE18;
+STATIC_ASSERT_SIZEOF(s_800BCE18, 0x2BEC); // TODO: likely even larger, func_8003CB44 accesses some 16 byte fields at 0x2BEC.
 
 typedef struct
 {
@@ -596,11 +611,7 @@ extern u8 D_800BCDD4;
 
 extern u16 D_800BCE14;
 
-extern s8 D_800BCE1C;
-
-extern s32 D_800BE464;
-
-extern s_800BE9FC D_800BE9FC;
+extern s_800BCE18 D_800BCE18;
 
 extern s_800C1020 D_800C1020;
 
@@ -799,6 +810,9 @@ typedef struct _MapOverlayHeader
     s32 (*func_13C)(s32, s32, void*, s16, s32); // 0x800C96B8
     u8 unk_140[40];
     void (*func_168)(void*, void*, void*);
+    u8           unk_16C[4];
+    u8           unk_170[0x25C];
+    VC_ROAD_DATA roadDataList_3CC[48]; // Ends at 0x84C
     // TODO: a lot more in here.
 } s_MapOverlayHeader;
 

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -114,14 +114,6 @@ typedef struct
 
 typedef struct
 {
-    s8  unk_8[62];
-    u16 field_3E;
-    s8  unk_40[4];
-    u16 field_44;
-} s_8008A384;
-
-typedef struct
-{
     u8  field_0;
     s8  unk_1;
     s16 field_2;
@@ -1174,11 +1166,11 @@ void func_80089500();
 
 s32 func_8008A35C(s_8008A35C* arg0, s32 arg1);
 
-void func_8008A384(s_8008A384* arg0);
+void func_8008A384(s_SubCharacter* chara);
 
-void func_8008A398(s_8008A384* arg0);
+void func_8008A398(s_SubCharacter* chara);
 
-void func_8008A3AC(s_8008A384* arg0);
+void func_8008A3AC(s_SubCharacter* chara);
 
 s32 func_8008D850();
 

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -497,7 +497,11 @@ extern s_FsImageDesc D_800A9A04;
 
 extern s32 D_800A9A0C; // old IDB name FS_AllFilesLoaded, though FS code doesn't set it
 
+extern s32 D_800A9A10;
+
 extern s32 D_800A9A1C;
+
+extern void (*D_800A9A2C[])(); // SysState func table
 
 extern s32 D_800A9A68;
 
@@ -559,6 +563,8 @@ extern DVECTOR g_Gfx_DebugStringPosition0;
 
 extern DVECTOR g_Gfx_DebugStringPosition1;
 
+extern s32 D_800B5C30;
+
 extern s_800B5C40 D_800B5C40[];
 
 extern s32 D_800B5C7C; // Type assumed.
@@ -579,6 +585,8 @@ extern u8 D_800BCD3F;
 extern s8 D_800BCD40;
 
 extern s8 D_800BCD78;
+
+extern s32 D_800BCD84;
 
 extern s_800BCDA8 D_800BCDA8[];
 
@@ -640,12 +648,6 @@ extern s_800C38B0 D_800C38B0;
 extern s32 D_800C38B4;
 
 extern s32 D_800C4710[];
-
-extern void (*D_800C9644)();
-
-extern void (*D_800C9648)(s32);
-
-extern s32 (*D_800C9668)();
 
 extern u8 D_800C37C8;
 
@@ -757,10 +759,6 @@ extern s_800C4818 D_800C4818;
 /** Unknown bodyprog var. Set in `Fs_QueueDoThingWhenEmpty`. */
 extern s32 D_800C489C;
 
-extern s8 D_800C9584;
-
-extern s8 D_800C9590;
-
 // TODO: Order these by address.
 
 extern s32 g_MainLoop_FrameCount; // 0x800B9CCC
@@ -779,10 +777,32 @@ extern s_FsImageDesc g_MainImg0; // 0x80022C74
 
 extern s_800AD4C8 D_800AD4C8[];
 
-/** TODO: 800C964C and 800C96B8 are part of map overlay header? maybe should be moved to maps/s00.h or dynamic/dynamic.h */
-extern s32 (*D_800C964C)(s32, void*, s16, s32);
+/** TODO: `g_MapOverlayHeader` is part of the overlay bin files, maybe should be moved to `maps/s00.h` or `dynamic/dynamic.h`. */
+typedef struct _MapOverlayHeader
+{
+    u8 unk_0[8];
+    s8 field_8;
+    u8 unk_9[3];
+    u8 unk_C[8];
+    s8 field_14;
+    u8 unk_15[3];
+    u8 unk_18[40];
+    void (*func_40)();
+    void (*func_44)();
+    u8 unk_48[128];
+    void (*func_C8)();
+    void (*func_CC)(s32);
+    s32 (*func_D0)(s32, void*, s16, s32); // 0x800C964C
+    u8 unk_D4[24];
+    s32 (*func_EC)();
+    u8 unk_F0[76];
+    s32 (*func_13C)(s32, s32, void*, s16, s32); // 0x800C96B8
+    u8 unk_140[40];
+    void (*func_168)(void*, void*, void*);
+    // TODO: a lot more in here.
+} s_MapOverlayHeader;
 
-extern s32 (*D_800C96B8)(s32, s32, void*, s16, s32);
+extern s_MapOverlayHeader g_MapOverlayHeader; // 0x800C957C
 
 /** Initializer for something before the game loop. */
 void func_8002E630();
@@ -828,6 +848,11 @@ char* Math_IntegerToString(s32 widthMin, s32 value);
 
 void func_8003260C(); // Return type assumed.
 
+void func_80032904();
+
+/** Draws some string in display space. */
+void func_80032CE8();
+
 void func_80032D1C();
 
 /** Bodyprog entrypoint. Called by `main`. */
@@ -851,6 +876,8 @@ void func_8003D160();
 
 /** Param types assumed. */
 void func_8003DD80(s32, s32);
+
+void func_80040014();
 
 /** Some kind of queue entry load status getter. */
 s32 func_80041ADC(s32 queueIdx);
@@ -1032,6 +1059,8 @@ void func_80054928();
 void func_80054A04(s8 arg0);
 
 void func_8005E0DC(s32 arg0); // Types assumed.
+
+void func_8005E89C();
 
 /** Unknown bodyprog func. Called by `Fs_QueueWaitForEmpty`. */
 void func_80089128();
@@ -1228,9 +1257,6 @@ void func_80066E7C();
 
 s32 func_8006A3B4(s32 arg0, s32 arg1, s32 arg2);
 
-/** Draws some string in display space. */
-void func_80032CE8();
-
 void Gfx_ClearRectInterlaced(s16 x, s16 y, s16 w, s16 h, u8 r, u8 g, u8 b);
 
 void Gfx_VSyncCallback();
@@ -1277,11 +1303,15 @@ void GameFs_MapLoad(s32 mapIdx);
 
 s32 func_8003528C(s32 idx0, s32 idx1);
 
+void func_80035DB4(s32);
+
 void AreaLoad_UpdatePlayerPosition();
 
 void func_800363D0();
 
 void func_8003640C(s32 arg0);
+
+void func_80036420();
 
 s32 func_8003647C();
 
@@ -1293,8 +1323,11 @@ void func_80037124();
 
 void func_80037154();
 
-/** SysState_GamePaused handler. */
-void func_800391E8();
+void func_800373CC(s32);
+
+void func_80037F24(s32);
+
+void func_80038354();
 
 void SysWork_SaveGameUpdatePlayer();
 
@@ -1316,7 +1349,13 @@ void func_8003BED0();
 
 void func_8003C3A0();
 
+void func_8003C3AC();
+
+void func_8003C878(s32);
+
 void func_8003D938();
+
+void func_8003DA9C(s32, GsCOORDINATE2*, s32, s16, s32);
 
 /** Loads a flame graphic. */
 void GameFs_FlameGfxLoad();
@@ -1327,11 +1366,17 @@ void func_8003ECE4();
 
 void func_8003ED08();
 
+void func_8003F170();
+
 /** Resets player info in the savegame buffer (inventory, health, playtime). */
 void Game_SaveGameResetPlayer();
 
 /** Loads player animations for a given map. Maybe for cutscenes? */
 void GameFs_PlayerMapAnimLoad(s32 mapIdx);
+
+void func_800717D0(s_SubCharacter*, void*, GsCOORDINATE2*);
+
+void func_8007D970(s_SubCharacter*, GsCOORDINATE2*);
 
 /** Resets several global variables to 0. */
 void func_8007F1CC();

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -797,7 +797,9 @@ typedef struct _MapOverlayHeader
     u8 unk_C[8];
     s8 field_14;
     u8 unk_15[3];
-    u8 unk_18[40];
+    u8 unk_18[8];
+    void (**mapEventFuncs_20)(); // Points to array of event functions.
+    u8 unk_24[0x1C];
     void (*func_40)();
     void (*func_44)();
     u8 unk_48[128];
@@ -854,6 +856,8 @@ void func_800303E4();
  * - 'func_801E709C' in saveload.c */
 void func_800314EC(s_FsImageDesc* image);
 
+void func_80031CCC(s32);
+
 void Gfx_DebugStringPosition(s16 x, s16 y);
 
 void Gfx_DebugStringDraw(char* str);
@@ -876,6 +880,8 @@ s32 func_80033548();
 
 /** Unknown bodyprog func. Called by `Fs_QueuePostLoadAnm`. */
 void func_80035560(s32 arg0, s32 arg1, void* arg2, s32 arg3);
+
+void func_8003943C();
 
 /** SysState_Fmv update function.
  * Movie to play is decided by `2072 - g_MapEventIdx`
@@ -1065,6 +1071,10 @@ s32 func_8004C45C();
  *         0 otherwise.
  */
 s32 func_8004C4F8();
+
+void func_80054024(s8);
+
+void func_800540A4(s8);
 
 void func_800546A8(s32 arg0);
 

--- a/include/bodyprog/vw_system.h
+++ b/include/bodyprog/vw_system.h
@@ -255,6 +255,8 @@ typedef struct _VW_VIEW_WORK
 } VW_VIEW_WORK;
 STATIC_ASSERT_SIZEOF(VW_VIEW_WORK, 132);
 
+struct _MapOverlayHeader; // `bodyprog.h` forward declaration.
+
 extern VC_ROAD_DATA      vcNullRoadArray[2];
 extern VC_NEAR_ROAD_DATA vcNullNearRoad;
 extern VC_WATCH_MV_PARAM deflt_watch_mv_prm;
@@ -263,15 +265,13 @@ extern VC_CAM_MV_PARAM   cam_mv_prm_user;
 extern int               excl_r_ary[9];
 extern VC_WORK           vcWork;
 extern VECTOR3           vcRefPosSt;
-extern VC_CAMERA_INTINFO vcCameraInternalInfo; // Debug camera info.
 extern VW_VIEW_WORK      vwViewPointInfo;
 extern MATRIX            VbWvsMatrix;
 extern VC_WATCH_MV_PARAM vcWatchMvPrmSt;
 extern int               vcSelfViewTimer;
 
 // vc_util.c
-
-void vcInitCamera(void* map_overlay_ptr, VECTOR3* chr_pos);
+void vcInitCamera(struct _MapOverlayHeader* map_overlay_ptr, VECTOR3* chr_pos);
 void vcSetCameraUseWarp(VECTOR3* chr_pos, s16 chr_ang_y);
 int  vcRetCamMvSmoothF();
 void vcSetEvCamRate(s16 ev_cam_rate);

--- a/include/game.h
+++ b/include/game.h
@@ -2,6 +2,7 @@
 #define _GAME_H
 
 #include "gpu.h"
+#include "types.h"
 
 #define SCREEN_WIDTH     320
 #define SCREEN_HEIGHT    240
@@ -408,7 +409,7 @@ typedef struct _SubCharacter
     s32     health_B0; // Bits 3-4 contain `s16` associated with player's rate of heavy breathing, always set to 6. Can't split into `s16`s? Maybe packed data.
     s8      unk_B4[16];
     u16     dead_timer_C4; // Part of `shBattleInfo` struct in SH2, may use something similar here.
-    s8      unk_C6[2];
+    u16     field_C6;
 
     // Fields seen used inside maps (eg. `map0_s00` `func_800D923C`)
 

--- a/include/game.h
+++ b/include/game.h
@@ -400,10 +400,11 @@ typedef struct _SubCharacter
     s32     field_34;
     s32     moveSpeed_38;
     s16     headingAngle_3C;
-    s8      pad_3E[2];
+    s16     field_3E;
     s8      unk_40[4];
-    s32     field_44;
-    s8      unk_45[104];
+    s16     field_44;
+    s8      unk_46[2];
+    s8      unk_48[104];
     s32     health_B0; // Bits 3-4 contain `s16` associated with player's rate of heavy breathing, always set to 6. Can't split into `s16`s? Maybe packed data.
     s8      unk_B4[16];
     u16     dead_timer_C4; // Part of `shBattleInfo` struct in SH2, may use something similar here.

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -1124,7 +1124,7 @@ void func_8003640C(s32 arg0) // 0x8003640C
 {
     if (arg0 != 0)
     {
-        D_800C9590 = arg0;
+        g_MapOverlayHeader.field_14 = arg0;
     }
 }
 
@@ -1132,12 +1132,12 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80036420);
 
 s32 func_8003647C() // 0x8003647C
 {
-    return g_SaveGamePtr->field_A5 > D_800C9584;
+    return g_SaveGamePtr->field_A5 > g_MapOverlayHeader.field_8;
 }
 
 s32 func_80036498() // 80036498
 {
-    return !(g_SaveGamePtr->field_A5 > D_800C9584);
+    return !(g_SaveGamePtr->field_A5 > g_MapOverlayHeader.field_8);
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_800364BC);

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -1242,7 +1242,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80038A6C);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80038B44);
 
-void GameState_InGame_Update()
+void GameState_InGame_Update() // 0x80038BD4
 {
     s_SubCharacter* player;
 
@@ -1300,7 +1300,7 @@ void GameState_InGame_Update()
     }
     Demo_DemoRandSeedRestore();
 
-    D_800A9A0C = ((D_800BCD0C & 7) == 5) && Fs_QueueDoThingWhenEmpty();
+    D_800A9A0C = ((D_800BCD0C & 7) == 5) && Fs_QueueDoThingWhenEmpty() != 0;
 
     if ((g_SysWork.field_22A0 & 1) == 0 && g_MapOverlayHeader.func_40 != NULL)
     {
@@ -1392,17 +1392,74 @@ void SysState_GamePaused_Update() // 0x800391E8
     }
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_OptionsMenu_Update);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_OptionsMenu_Update); // 0x80039344
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003943C);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_StatusMenu_Update);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_StatusMenu_Update); // 0x80039568
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_LoadStatusScreen_Update);
+void GameState_LoadStatusScreen_Update() // 0x800395C0
+{
+    s_ShSaveGame* saveGamePtr;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk3_Update);
+    if (g_GameWork.gameStateStep_598[0] == 0)
+    {
+        DrawSync(0);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_LoadMapScreen_Update);
+        g_IntervalVBlanks = 1;
+
+        D_800BCD0C = 0;
+
+        func_8003943C();
+
+        if (func_80045B28())
+        {
+            SD_EngineCmd(0x13);
+        }
+
+        saveGamePtr = g_SaveGamePtr;
+        func_800540A4(saveGamePtr->mapOverlayIdx_A4);
+        func_80054024(saveGamePtr->mapOverlayIdx_A4);
+
+        g_GameWork.gameStateStep_598[0]++;
+    }
+
+    func_80031CCC(2);
+
+    if (Fs_QueueDoThingWhenEmpty() != 0)
+    {
+        Game_StateSetNext(GameState_StatusScreen);
+    }
+}
+
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk3_Update); // 0x800396D4
+
+void GameState_LoadMapScreen_Update() // 0x8003991C
+{
+    s_ShSaveGame* saveGamePtr;
+
+    if (g_GameWork.gameStateStep_598[0] == 0)
+    {
+        DrawSync(0);
+        g_IntervalVBlanks = 1;
+        func_8003943C();
+        func_80066E40();
+        saveGamePtr = g_SaveGamePtr;
+        if (D_800A99CC[saveGamePtr->mapIdx_A9] != NO_VALUE)
+        {
+            Fs_QueueStartReadTim(FILE_TIM_MR_0TOWN_TIM + D_800A99CC[saveGamePtr->mapIdx_A9], FS_BUFFER_1, &D_800A9024);
+        }
+        Fs_QueueStartReadTim(FILE_TIM_MP_0TOWN_TIM + D_800A99B4[saveGamePtr->mapIdx_A9], FS_BUFFER_2, &D_800A901C);
+        g_GameWork.gameStateStep_598[0]++;
+    }
+
+    func_80031CCC(2);
+
+    if (Fs_QueueDoThingWhenEmpty() != 0)
+    {
+        Game_StateSetNext(GameState_MapScreen);
+    }
+}
 
 void SysState_Fmv_Update() // 0x80039A58
 {
@@ -1512,7 +1569,25 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk12_Update); // 0x8
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_GameOver_Update); // 0x8003A52C
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_MapEvent_Update); // 0x8003AA4C
+void GameState_MapEvent_Update() // 0x8003AA4C
+{
+    if (g_GameWork.gameStateStep_598[0] == 0)
+    {
+        g_IntervalVBlanks = 1;
+
+        D_800BCD0C = 6;
+
+        g_GameWork.gameStateStep_598[0] = 1;
+    }
+
+    D_800A9A0C = ((D_800BCD0C & 7) == 5) && Fs_QueueDoThingWhenEmpty() != 0;
+
+    SaveGame_EventFlagSet(g_MapEventParam->eventFlagNum_2);
+
+    g_MapOverlayHeader.mapEventFuncs_20[g_MapEventIdx]();
+
+    func_800314EC(&D_800A902C);
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_MainMenu_Update); // 0x8003AB28
 

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -1579,20 +1579,22 @@ void GameFs_BgEtcGfxLoad() // 0x8003BE6C
 
 void GameFs_BgItemLoad() // 0x8003BE9C
 {
-    D_800BE9FC.queueIdx_1000 = Fs_QueueStartRead(FILE_BG_BG_ITEM_PLM, &D_800BE9FC);
+    D_800BCE18.field_1BE4.queueIdx_1000 = Fs_QueueStartRead(FILE_BG_BG_ITEM_PLM, &D_800BCE18.field_1BE4);
 }
 
 void func_8003BED0() // 0x8003BED0
 {
-    if (Fs_QueueIsEntryLoaded(D_800BE9FC.queueIdx_1000) == 0 || D_800BE9FC.field_2 != 0)
+    s_800BE9FC* D_800BE9FC = &D_800BCE18.field_1BE4;
+
+    if (Fs_QueueIsEntryLoaded(D_800BE9FC->queueIdx_1000) == 0 || D_800BE9FC->field_2 != 0)
     {
         return;
     }
 
-    func_800560FC(&D_800BE9FC);
-    func_80056504(&D_800BE9FC, &D_80025528, &D_800A9EBC, 1);
-    func_80056504(&D_800BE9FC, &D_80025530, &D_800A9EC4, 1);
-    func_80056954(&D_800BE9FC);
+    func_800560FC(&D_800BCE18.field_1BE4);
+    func_80056504(&D_800BCE18.field_1BE4, &D_80025528, &D_800A9EBC, 1);
+    func_80056504(&D_800BCE18.field_1BE4, &D_80025530, &D_800A9EC4, 1);
+    func_80056954(&D_800BCE18.field_1BE4);
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003BF60);
@@ -1615,7 +1617,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003C368);
 
 void func_8003C3A0() // 0x8003C3A0
 {
-    D_800BCE1C = 0;
+    D_800BCE18.field_4 = 0;
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003C3AC);
@@ -1674,7 +1676,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003D7D4);
 
 void func_8003D938() // 0x8003D938
 {
-    func_8003D9C8(&D_800BE464);
+    func_8003D9C8(&D_800BCE18.field_164C);
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003D95C);

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -1630,7 +1630,10 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003C8F8);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003C92C);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003CB3C);
+void func_8003CB3C(s_800BCE18* arg0)
+{
+    arg0->field_2BE8 = 0;
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003CB44);
 

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -7,6 +7,7 @@
 
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
+#include "bodyprog/vw_system.h"
 #include "main/fsqueue.h"
 
 void func_8002E630() 
@@ -1393,19 +1394,19 @@ void SysWork_SaveGameReadPlayer() // 0x8003A1F4
     g_SysWork.player_4C.chara_0.health_B0      = g_SaveGamePtr->playerHealth_240;
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_SaveMenu_Update);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_SaveMenu_Update); // 0x8003A230
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk10_Update);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk10_Update); // 0x8003A3C8
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk11_Update);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk11_Update); // 0x8003A460
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk12_Update);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk12_Update); // 0x8003A4B4
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_GameOver_Update);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_GameOver_Update); // 0x8003A52C
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_MapEvent_Update);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_MapEvent_Update); // 0x8003AA4C
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_MainMenu_Update);
+INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_MainMenu_Update); // 0x8003AB28
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_8003B550);
 

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -1242,7 +1242,115 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80038A6C);
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80038B44);
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", GameState_InGame_Update);
+void GameState_InGame_Update()
+{
+    s_SubCharacter* player;
+
+    Demo_DemoRandSeedBackup();
+
+    switch (g_GameWork.gameStateStep_598[0])
+    {
+        case 0:
+            D_800BCD0C = 6;
+            D_800B5C30 = 0x3000;
+
+            g_GameWork.gameStateStep_598[0] = 1;
+        case 1:
+            DrawSync(0);
+            func_80037154();
+            func_80036420();
+            func_800892A4(1);
+            g_IntervalVBlanks = 2;
+            g_GameWork.gameStateStep_598[0]++;
+            g_SysWork.field_22A0 |= 0x40;
+            break;
+    }
+
+    if (g_SysWork.sysState_8 != 0 && g_SysWork.player_4C.chara_0.health_B0 <= 0)
+    {
+        SysWork_StateSetNext(SysState_Gameplay);
+    }
+
+    if (g_DeltaTime0 != 0)
+    {
+        D_800BCD84 = g_DeltaTime0;
+    }
+    else
+    {
+        D_800BCD84 = g_DeltaTime1;
+    }
+
+    if (g_SysWork.sysState_8 == SysState_Gameplay)
+    {
+        g_SysWork.field_18 = 0;
+        D_800A9A2C[SysState_Gameplay]();
+    }
+    else
+    {
+        g_DeltaTime0 = 0;
+        D_800A9A2C[g_SysWork.sysState_8]();
+        if (g_SysWork.sysState_8 == 0)
+        {
+            func_800373CC(1);
+            if (D_800A9A10 != 0xF)
+            {
+                SysWork_StateSetNext(D_800A9A10);
+            }
+        }
+    }
+    Demo_DemoRandSeedRestore();
+
+    D_800A9A0C = ((D_800BCD0C & 7) == 5) && Fs_QueueDoThingWhenEmpty();
+
+    if ((g_SysWork.field_22A0 & 1) == 0 && g_MapOverlayHeader.func_40 != NULL)
+    {
+        g_MapOverlayHeader.func_40();
+    }
+
+    func_80032904();
+    func_80035DB4(0);
+    Demo_DemoRandSeedRestore();
+    Demo_DemoRandSeedRestore();
+
+    if ((g_SysWork.field_22A0 & 1) == 0)
+    {
+        func_80040014();
+        vcMoveAndSetCamera(0, 0, 0, 0, 0, 0, 0, 0);
+        if (g_MapOverlayHeader.func_44 != NULL)
+        {
+            g_MapOverlayHeader.func_44();
+        }
+        Demo_DemoRandSeedRestore();
+
+        player = &g_SysWork.player_4C.chara_0;
+        func_800717D0(player, FS_BUFFER_0, g_SysWork.playerBoneCoords_890);
+
+        Demo_DemoRandSeedRestore();
+        func_8003F170();
+
+        if (g_SaveGamePtr->mapOverlayIdx_A4 != 0x2A)
+        {
+            g_MapOverlayHeader.func_168(0, g_SaveGamePtr->mapOverlayIdx_A4, 1);
+        }
+
+        Demo_DemoRandSeedRestore();
+        if (player->model_0.anim_4.flags_2 & 2)
+        {
+            func_8003DA9C(1, g_SysWork.playerBoneCoords_890, 1, g_SysWork.player_4C.chara_0.field_C6, 0);
+            func_8008A384(&g_SysWork.player_4C.chara_0);
+            func_8007D970(&g_SysWork.player_4C, g_SysWork.playerBoneCoords_890);
+            func_8008A3AC(&g_SysWork.player_4C.chara_0);
+        }
+
+        Demo_DemoRandSeedRestore();
+        func_80037F24(1);
+        func_80038354();
+        func_8005E89C();
+        func_8003C3AC();
+        func_8003C878(1);
+        Demo_DemoRandSeedAdvance();
+    }
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Gameplay_Update);
 

--- a/src/bodyprog/bodyprog_80085D78.c
+++ b/src/bodyprog/bodyprog_80085D78.c
@@ -51,8 +51,8 @@ void func_80085DC0(s32 arg0, s32 sysStateStep)
 void func_80085DF0()
 {
     g_SysWork.timer_2C += g_DeltaTime1;
-    
-    if (D_800C9668() != 0 || g_SysWork.timer_2C > 4096)
+
+    if (g_MapOverlayHeader.func_EC() != 0 || g_SysWork.timer_2C > 4096)
     {
         g_SysWork.field_28 = 0;
         g_SysWork.field_10 = 0;
@@ -300,7 +300,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80085D78", func_800865FC);
 
 void func_800866D4(s32 arg0, s32 arg1, s32 arg2) // 0x800866D4
 {
-    if (D_800C964C(arg0, &D_800C4640, D_800C4700, arg1) == 1)
+    if (g_MapOverlayHeader.func_D0(arg0, &D_800C4640, D_800C4700, arg1) == 1)
     {
         func_80085D78(arg2);
     }
@@ -308,7 +308,7 @@ void func_800866D4(s32 arg0, s32 arg1, s32 arg2) // 0x800866D4
 
 void func_80086728(s32 arg0, s32 arg1, s32 arg2, s32 arg3) // 0x80086728
 {
-    if (D_800C96B8(arg0, arg1, &D_800C46A0, D_800C4702, arg2) == 1)
+    if (g_MapOverlayHeader.func_13C(arg0, arg1, &D_800C46A0, D_800C4702, arg2) == 1)
     {
         func_80085D78(arg3);
     }
@@ -316,7 +316,7 @@ void func_80086728(s32 arg0, s32 arg1, s32 arg2, s32 arg3) // 0x80086728
 
 void func_8008677C(s32 arg0, s32 arg1, s32 arg2) // 0x8008677C
 {
-    D_800C96B8(arg0, arg1, &D_800C46A0, D_800C4702, arg2);
+    g_MapOverlayHeader.func_13C(arg0, arg1, &D_800C46A0, D_800C4702, arg2);
 }
 
 void func_800867B4(s32 caseParam, s32 idx) // 0x800867B4
@@ -664,7 +664,7 @@ void func_80086FE8(s32 arg0, s32 arg1, s32 arg2) // 0x80086FE8
     switch (g_SysWork.field_10)
     {
         case 0:
-            D_800C9644();
+            g_MapOverlayHeader.func_C8();
             func_8005DC1C(arg1, arg2, 0x80, 0);
             
             g_SysWork.timer_2C = 0;
@@ -680,7 +680,7 @@ void func_80086FE8(s32 arg0, s32 arg1, s32 arg2) // 0x80086FE8
             break;
 
         default:
-            D_800C9648(0);
+            g_MapOverlayHeader.func_CC(0);
 
             g_SysWork.sysState_8 = 0;
             g_SysWork.timer_24 = 0;
@@ -700,7 +700,7 @@ void func_8008716C(s32 arg0, s32 arg1, s32 arg2) // 0x8008716C
     switch (g_SysWork.field_10)
     {
         case 0:
-            D_800C9644();
+            g_MapOverlayHeader.func_C8();
             func_8008616C(0, 1, 0, arg1, 0);
             g_SysWork.timer_2C = 0;
             g_SysWork.field_14 = 0;
@@ -740,7 +740,7 @@ void func_8008716C(s32 arg0, s32 arg1, s32 arg2) // 0x8008716C
 
         default:
             func_8008616C(0, 0, 0, arg1, 0);
-            D_800C9648(0);
+            g_MapOverlayHeader.func_CC(0);
 
             g_SysWork.sysState_8 = 0;
             g_SysWork.timer_24 = 0;
@@ -760,7 +760,7 @@ void func_80087360(s32 arg0, s32 arg1, s32 arg2, s32 arg3) // 0x80087360
     switch (g_SysWork.field_10)
     {
         case 0:
-            D_800C9644();
+            g_MapOverlayHeader.func_C8();
             func_8008616C(0, 1, 0, arg1, 0);
 
             g_SysWork.timer_2C = 0;
@@ -796,7 +796,7 @@ void func_80087360(s32 arg0, s32 arg1, s32 arg2, s32 arg3) // 0x80087360
 
         default:
             func_8008616C(0, 0, 0, arg1, 0);
-            D_800C9648(0);
+            g_MapOverlayHeader.func_CC(0);
 
             g_SysWork.sysState_8 = 0;
             g_SysWork.timer_24 = 0;
@@ -816,7 +816,7 @@ void func_80087540(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4) // 0x800875
     switch (g_SysWork.field_10)
     {
         case 0:
-            D_800C9644();
+            g_MapOverlayHeader.func_C8();
             func_8008616C(0, 1, 0, arg1, 0);
 
             g_SysWork.timer_2C = 0;
@@ -871,7 +871,7 @@ void func_80087540(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4) // 0x800875
 
         default:
             func_8008616C(0, 0, 0, arg1, 0);
-            D_800C9648(0);
+            g_MapOverlayHeader.func_CC(0);
 
             g_SysWork.sysState_8 = 0;
             g_SysWork.timer_24 = 0;

--- a/src/bodyprog/bodyprog_80085D78.c
+++ b/src/bodyprog/bodyprog_80085D78.c
@@ -1275,21 +1275,21 @@ s32 func_8008A35C(s_8008A35C* arg0, s32 arg1) // 0x8008A35C
     return res;
 }
 
-void func_8008A384(s_8008A384* arg0) // 0x8008A384
+void func_8008A384(s_SubCharacter* chara) // 0x8008A384
 {
-    arg0->field_3E &= ~(1 << 7);
+    chara->field_3E &= ~(1 << 7);
 }
 
-void func_8008A398(s_8008A384* arg0) // 0x8008A398
+void func_8008A398(s_SubCharacter* chara) // 0x8008A398
 {
-    arg0->field_3E |= 1 << 7;
+    chara->field_3E |= 1 << 7;
 }
 
-void func_8008A3AC(s_8008A384* arg0) // 0x8008A3AC
+void func_8008A3AC(s_SubCharacter* chara) // 0x8008A3AC
 {
-    if (!(arg0->field_3E & (1 << 7)))
+    if (!(chara->field_3E & (1 << 7)))
     {
-        arg0->field_44 = 0;
+        chara->field_44 = 0;
         func_8008A3E0();
     }
 }

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -1,11 +1,24 @@
 #include "game.h"
 
 #include "bodyprog/math.h"
-#include "bodyprog/vw_system.h"
+#include "bodyprog/bodyprog.h"
 
 extern s32 g_VBlanks;
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_util", vcInitCamera);
+void vcInitCamera(struct _MapOverlayHeader* map_overlay_ptr, VECTOR3* chr_pos)
+{
+    D_800BCE18.vcCameraInternalInfo_1BDC.mv_smooth   = 0;
+    D_800BCE18.vcCameraInternalInfo_1BDC.ev_cam_rate = 0;
+    D_800BCE18.vcCameraInternalInfo_1BDC.mode        = 0;
+    vcSetCameraUseWarp(chr_pos, g_SysWork.cameraAngleY_237A);
+    SetGeomScreen(g_GameWork.gsScreenHeight_58A);
+    vwInitViewInfo();
+    vcInitVCSystem(map_overlay_ptr->roadDataList_3CC);
+    vcStartCameraSystem();
+    g_SysWork.cameraAngleZ_237C   = 0;
+    g_SysWork.cameraRadiusXz_2380 = 0x3000;
+    g_SysWork.cameraY_2384        = 0;
+}
 
 void vcSetCameraUseWarp(VECTOR3* chr_pos, s16 chr_ang_y) // 0x800400D4
 {
@@ -26,24 +39,24 @@ void vcSetCameraUseWarp(VECTOR3* chr_pos, s16 chr_ang_y) // 0x800400D4
 
 int vcRetCamMvSmoothF() // 0x80040190
 {
-    return vcCameraInternalInfo.mv_smooth;
+    return D_800BCE18.vcCameraInternalInfo_1BDC.mv_smooth;
 }
 
 void func_800401A0(s32 arg0) // 0x800401A0
 {
     if (arg0)
     {
-        vcCameraInternalInfo.ev_cam_rate = 4096; // TODO: If angle, replace magic value with FP_ANGLE(22.5f).
+        D_800BCE18.vcCameraInternalInfo_1BDC.ev_cam_rate = 4096; // TODO: If angle, replace magic value with FP_ANGLE(22.5f).
     }
     else
     {
-        vcCameraInternalInfo.ev_cam_rate = 0;
+        D_800BCE18.vcCameraInternalInfo_1BDC.ev_cam_rate = 0;
     }
 }
 
 void vcSetEvCamRate(s16 ev_cam_rate) // 0x800401C0
 {
-    vcCameraInternalInfo.ev_cam_rate = ev_cam_rate;
+    D_800BCE18.vcCameraInternalInfo_1BDC.ev_cam_rate = ev_cam_rate;
 }
 
 void func_800401CC() // 0x800401CC


### PR DESCRIPTION
- Changed `s_8008A384` usages to `s_SubCharacter`
- Matched 4 `GameState_X_Update` funcs
- Added `s_MapOverlayHeader` / `g_MapOverlayHeader` symbol for map overlay data
- Adjusted splat config to ignore garbage data at end of bodyprog
- Updated makefile to include `.bin` files from asm folder
- Added weird `s_800BCE18` struct, needed for `VC_CAMERA_INTINFO` accesses to match (some funcs like func_8003CB3C / func_8003CB44 also take this as param)
- Matched `vcInitCamera`

Started on the map header struct at the beginning of each map overlay, still a lot missing from it.

Took a while to get it added properly, seems garbage data at the end of bodyprog was overlapping map overlay addr so splat wouldn't recognize symbols for it properly.
Luckily fix itself wasn't too hard, just had to set segment as `bin` which mostly makes it ignore that data, and update makefile to allow using it.

Sadly b_konami has an issue with some funcs overlapping the map overlay header, haven't been able to find a way to fix that yet, so just removed b_konami syms from bodyprog config for now.
AFAIK bodyprog only refs b_konami through the GameState func table so doesn't break anything major, but will need to find some fix eventually.

TODOs for later:
- move MapOverlayHeader defs out of bodyprog.h/sym.bodyprog.txt
- find some fix to allow both b_konami & g_MapOverlayHeader symbols to be loaded into bodyprog splat config