### PR TITLE
add and fix nonmatching in credits, add addPrimFast macro

### DIFF
--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -433,50 +433,52 @@ typedef struct
 } s_DmsHeader;
 STATIC_ASSERT_SIZEOF(s_DmsHeader, 44);
 
+// Used for normal credits screen.
 typedef struct
 {
-    s16 field_0;     //prim vertex x
-    s16 field_2;     //prim vertex y
-    s16 field_4;     //width?
-    s8 field_6;      //height? 
-    s8 field_7;      //blend flag
-    s32 field_8;     //rgb24 color + code
-    s16* field_C;    //points to 0x801E5C24, data size 400
-    s32* field_10;   //points to 0x801E5E24, data size 28, rgb24 + code
-    u16 field_14;    //tpage for setDrawTPage, calculated from field_18 with func_801E434C
-    s16 field_16;    //clut xy
-    u32 field_18;    //texture uv
+    s16  field_0;     // Prim vertex x
+    s16  field_2;     // Prim vertex y
+    s16  field_4;     // Width?
+    s8   field_6;     // Height? 
+    s8   field_7;     // Blend flag
+    s32  field_8;     // Rgb24 color + code
+    s16* field_C;     // Points to 0x801E5C24, data size 400
+    s32* field_10;    // Points to 0x801E5E24, data size 28, rgb24 + code
+    u16  field_14;    // Tpage for setDrawTPage, calculated from field_18 with func_801E434C
+    s16  field_16;    // Clut xy
+    u32  field_18;    // Texture uv
 } s_800AFE08; // Size: 28
 
+// Used for UFO ending credits screen.
 typedef struct
 {
-    s16 field_0;     //prim vertex x
-    s16 field_2;     //prim vertex y
-    s16 field_4;     //width?
-    s8 field_6;      //height? 
-    s8 field_7;      //blend flag
-    s32 field_8;     //rgb24 color + code
-    s16* field_C;    //points to 0x801E5C24, data size 400
-    s32* field_10;   //points to 0x801E5E40, data size 28, rgb24 + code
-    u16 field_14;    //tpage for setDrawTPage, calculated from field_18 with func_801E4BD4
-    s16 field_16;    //clut xy
-    u32 field_18;    //texture uv
-    s32 field_1C;
-    s16 field_20;
-    s16 field_22;
-    s32 field_24;
-    s32 field_28;
-    s32 field_2C;
-    s32 field_30;
-    s32 field_34;
-    s32 field_38;
-    s32 field_3C;
-    s32 field_40;
-    s32 field_44;
-    s32 field_48;
-    s32 field_4C;
-    s32 field_50;
-    s32 field_54;
+    s16  field_0;     // Prim vertex x
+    s16  field_2;     // Prim vertex y
+    s16  field_4;     // Width?
+    s8   field_6;     // Height? 
+    s8   field_7;     // Blend flag
+    s32  field_8;     // Rgb24 color + code
+    s16* field_C;     // Points to 0x801E5C24, data size 400
+    s32* field_10;    // Points to 0x801E5E40, data size 28, rgb24 + code
+    u16  field_14;    // Tpage for setDrawTPage, calculated from field_18 with func_801E4BD4
+    s16  field_16;    // Clut xy
+    u32  field_18;    // Texture uv
+    s32  field_1C;
+    s16  field_20;
+    s16  field_22;
+    s32  field_24;
+    s32  field_28;
+    s32  field_2C;
+    s32  field_30;
+    s32  field_34;
+    s32  field_38;
+    s32  field_3C;
+    s32  field_40;
+    s32  field_44;
+    s32  field_48;
+    s32  field_4C;
+    s32  field_50;
+    s32  field_54;
 } s_800AFE24; // Size: 85
 
 extern s8* D_8002510C;

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -433,6 +433,52 @@ typedef struct
 } s_DmsHeader;
 STATIC_ASSERT_SIZEOF(s_DmsHeader, 44);
 
+typedef struct
+{
+    s16 field_0;     //prim vertex x
+    s16 field_2;     //prim vertex y
+    s16 field_4;     //width?
+    s8 field_6;      //height? 
+    s8 field_7;      //blend flag
+    s32 field_8;     //rgb24 color + code
+    s16* field_C;    //points to 0x801E5C24, data size 400
+    s32* field_10;   //points to 0x801E5E24, data size 28, rgb24 + code
+    u16 field_14;    //tpage for setDrawTPage, calculated from field_18 with func_801E434C
+    s16 field_16;    //clut xy
+    u32 field_18;    //texture uv
+} s_800AFE08; // Size: 28
+
+typedef struct
+{
+    s16 field_0;     //prim vertex x
+    s16 field_2;     //prim vertex y
+    s16 field_4;     //width?
+    s8 field_6;      //height? 
+    s8 field_7;      //blend flag
+    s32 field_8;     //rgb24 color + code
+    s16* field_C;    //points to 0x801E5C24, data size 400
+    s32* field_10;   //points to 0x801E5E40, data size 28, rgb24 + code
+    u16 field_14;    //tpage for setDrawTPage, calculated from field_18 with func_801E4BD4
+    s16 field_16;    //clut xy
+    u32 field_18;    //texture uv
+    s32 field_1C;
+    s16 field_20;
+    s16 field_22;
+    s32 field_24;
+    s32 field_28;
+    s32 field_2C;
+    s32 field_30;
+    s32 field_34;
+    s32 field_38;
+    s32 field_3C;
+    s32 field_40;
+    s32 field_44;
+    s32 field_48;
+    s32 field_4C;
+    s32 field_50;
+    s32 field_54;
+} s_800AFE24; // Size: 85
+
 extern s8* D_8002510C;
 
 /** "\x07PAUSED" string */
@@ -556,6 +602,10 @@ extern u16 D_800AFDBC;
 
 extern s32 D_800AFDEC;
 
+extern s_800AFE08 D_800AFE08;
+
+extern s_800AFE24 D_800AFE24;
+
 extern s_800B55E8 D_800B2780[];
 
 extern s_800B55E8 D_800B3680[];
@@ -582,11 +632,15 @@ extern s32 D_800B5C30;
 
 extern s_800B5C40 D_800B5C40[];
 
-extern s32 D_800B5C7C; // Type assumed.
+extern s32 D_800B5C7C;
+
+extern u8 D_800BC74F;
 
 extern u16 D_800BCCB0;
 
 extern u16 D_800BCCB2;
+
+extern s32 D_800B7CC4;
 
 /** Accessed by credits, options, and saveload. */
 extern s32 D_800BCD0C;
@@ -773,6 +827,8 @@ extern s_800C4818 D_800C4818;
 
 /** Unknown bodyprog var. Set in `Fs_QueueDoThingWhenEmpty`. */
 extern s32 D_800C489C;
+
+extern s32 D_800C48F0;
 
 // TODO: Order these by address.
 

--- a/include/gpu.h
+++ b/include/gpu.h
@@ -51,4 +51,7 @@ enum PrimRectFlags
 #define setCodeWord(p, c, rgb24) \
     *(u32*)(((u8*)(p)) + 4) = (((c) << 24) | ((rgb24) & 0xFFFFFF))
 
+/** Combines `addPrim` and `setlen()`. */
+#define addPrimFast(ot,p,_len) (((p)->tag = getaddr(ot) | (_len << 24)), setaddr(ot, p))
+
 #endif

--- a/include/screens/credits/credits.h
+++ b/include/screens/credits/credits.h
@@ -3,21 +3,6 @@
 
 #include "common.h"
 
-typedef struct
-{
-    s16 field_0;
-    s16 field_2;
-    s16 field_4;
-    s8  unk_6;
-    s8  field_7; // bool
-    s32 unk_8;
-    s32 unk_C;
-    s32 unk_10;
-    u16 field_14;
-    s16 unk_16;
-    u32 field_18;
-} s_UnkCredits0;
-
 // Used by `func_801E2E28`.
 typedef struct
 {
@@ -26,20 +11,6 @@ typedef struct
     s16 field_4;
 } s_UnkCredits1;
 STATIC_ASSERT_SIZEOF(s_UnkCredits1, 6);
-
-extern s_UnkCredits0 D_800AFE08;
-
-extern s8 D_800AFE0E;
-
-extern s32 D_800AFE10; // Packed RGB+command color? Command is 0x64.
-
-extern s_UnkCredits0 D_800AFE24;
-
-extern s8 D_800AFE2A;
-
-extern s32 D_800AFE2C; // Packed RGB+command color? Command is 0x2C.
-
-extern s32 D_800C48F0;
 
 extern s_UnkCredits1 D_801E5558[];
 
@@ -52,6 +23,8 @@ extern s32 D_801E5BD0;
 extern s32 D_801E5C20;
 
 extern s32 D_801E5E74;
+
+extern s32 D_801E5E78;
 
 extern s32 D_801E5E7C;
 
@@ -76,6 +49,8 @@ void func_801E3DD0();
 /** Draw some image on the screen. */
 s32 func_801E3124();
 
+s32 func_801E342C();
+
 s32 func_801E3304();
 
 bool func_801E3684();
@@ -84,9 +59,9 @@ s32 func_801E3DF8(s32 arg0);
 
 void func_801E42F8(s32 arg0, s32 arg1);
 
-/** @brief Sets the current RGB+command color for `D_800AFE10`.
+/** @brief Sets the current RGB+command color for `D_800AFE08` struct.
  *
- * This function sets the packed RGB+command color for `D_800AFE10` with
+ * This function sets the packed RGB+command color for `D_800AFE08` with
  * the fourth component hard set to 0x64, possibly a graphics command.
  * 
  * @note RGB order only assumed.

--- a/src/screens/b_konami/b_konami.c
+++ b/src/screens/b_konami/b_konami.c
@@ -346,8 +346,7 @@ void func_800C9E6C(s_FsImageDesc* image, s32 otz, s32 vramX, s32 vramY, s32 w, s
     u32       vramBase = *((u8*)&image->tPage + 1) + (u32)(vramX >> 8) + (((u32)(vramY >> 8)) << 4);
     u32*      addr     = &D_800B5C40[g_ObjectTableIdx].field_0[otz];
 
-    prim->tag = getaddr(addr) | 0x04000000u;
-    setaddr(addr, prim);
+    addPrimFast(addr, prim, 4);
     setCodeWord(prim, PRIM_RECT | RECT_TEXTURE, 0x808080);
     setWH(prim, w, h);
 
@@ -378,11 +377,7 @@ void func_800C9FB8() // 0x800C9FB8
 
     ptr = (g_ObjectTableIdx << 4) + &D_800B5C7C;
 
-    // TODO: Wait on fgsfds's investigations for cleaner match of graphics setup.
-    // addPrim(temp_a1, GsOUT_PACKET_P);
-    ((TILE*)GsOUT_PACKET_P)->tag = (u32)((*ptr & 0xFFFFFF) | 0x03000000);
-    setaddr(ptr, GsOUT_PACKET_P);
-
+    addPrimFast(ptr, (TILE*)GsOUT_PACKET_P, 3);
     setCodeWord((TILE*)GsOUT_PACKET_P, PRIM_RECT, 0xFFFFFF);
     setXY0Fast((TILE*)GsOUT_PACKET_P, -SCREEN_WIDTH, -SCREEN_HEIGHT);
     setWH((TILE*)GsOUT_PACKET_P, SCREEN_WIDTH * 2, SCREEN_HEIGHT * 2);
@@ -399,11 +394,7 @@ void func_800CA120() // 0x800CA120
 
     ptr = (g_ObjectTableIdx << 4) + &D_800B5C7C;
 
-    // TODO: Wait on fgsfds's investigations for cleaner match of graphics setup.
-    // addPrim(temp_a1, GsOUT_PACKET_P);
-    ((TILE*)GsOUT_PACKET_P)->tag = (u32)((*ptr & 0xFFFFFF) | 0x03000000);
-    setaddr(ptr, GsOUT_PACKET_P);
-
+    addPrimFast(ptr, (TILE*)GsOUT_PACKET_P, 3);
     setCodeWord((TILE*)GsOUT_PACKET_P, PRIM_RECT, 0xFFFFFF);
     setXY0Fast((TILE*)GsOUT_PACKET_P, -SCREEN_WIDTH, -SCREEN_HEIGHT);
     setWH((TILE*)GsOUT_PACKET_P, SCREEN_WIDTH * 2, SCREEN_HEIGHT * 2);

--- a/src/screens/credits/credits.c
+++ b/src/screens/credits/credits.c
@@ -60,34 +60,15 @@ s32 func_801E2ED8() // 0x801E2ED8
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2FC0);
 /*s32 func_801E2FC0(void) // 0x801E2FC0
 {
-    s32 state;
-  
-    switch (D_800BCD0C) 
-    {
+    switch (D_800BCD0C) {
         case 4:
         case 5:
         case 12:
         case 13:
-            if (Fs_QueueGetLength() != 0) 
-            {
+            if (Fs_QueueGetLength() != 0) {
                 break;
             }
-            state = g_GameWork.gameState_594;
-            g_GameWork.gameState_594 = 0x15;
-            g_SysWork.timer_1C = 0;
-            g_SysWork.timer_20 = 0;
-            g_GameWork.gameStateStep_598[1] = 0;
-            g_GameWork.gameStateStep_598[2] = 0;
-            g_SysWork.sysState_8 = 0;
-            g_SysWork.timer_24 = 0;
-            g_SysWork.sysStateStep_C = 0;
-            g_SysWork.field_28 = 0;
-            g_SysWork.field_10 = 0;
-            g_SysWork.timer_2C = 0;
-            g_SysWork.field_14 = 0;
-            g_GameWork.gameStateStep_598[0] = state;
-            g_GameWork.gameStatePrev_590 = state;
-            g_GameWork.gameStateStep_598[0] = 0;
+            Game_StateSetNext(GameState_Unk15);
             return 1;
         case 2:
         case 3:

--- a/src/screens/credits/credits.c
+++ b/src/screens/credits/credits.c
@@ -23,9 +23,7 @@ void func_801E2E28(s32 idx) // 0x801E2E28
     D_801E5E80 = 0x10000 / var0;
 }
 
-// TODO: Matched, but checksum fails. --Sezz
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2ED8);
-/*s32 func_801E2ED8() // 0x801E2ED8
+s32 func_801E2ED8() // 0x801E2ED8
 {
     switch (D_801E5E88)
     {
@@ -33,7 +31,7 @@ INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2ED8);
             break;
 
         case 1:
-            SD_EngineCmd(D_801E5558[D_801E5E8C].field_0);
+            SD_EngineCmd((u16)D_801E5558[D_801E5E8C].field_0);
             D_801E5E88++;
             break;
 
@@ -56,11 +54,69 @@ INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2ED8);
     }
 
     return 0;
+}
+
+// TODO: Needs jmptable
+INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2FC0);
+/*s32 func_801E2FC0(void) // 0x801E2FC0
+{
+    s32 state;
+  
+    switch (D_800BCD0C) 
+    {
+        case 4:
+        case 5:
+        case 12:
+        case 13:
+            if (Fs_QueueGetLength() != 0) 
+            {
+                break;
+            }
+            state = g_GameWork.gameState_594;
+            g_GameWork.gameState_594 = 0x15;
+            g_SysWork.timer_1C = 0;
+            g_SysWork.timer_20 = 0;
+            g_GameWork.gameStateStep_598[1] = 0;
+            g_GameWork.gameStateStep_598[2] = 0;
+            g_SysWork.sysState_8 = 0;
+            g_SysWork.timer_24 = 0;
+            g_SysWork.sysStateStep_C = 0;
+            g_SysWork.field_28 = 0;
+            g_SysWork.field_10 = 0;
+            g_SysWork.timer_2C = 0;
+            g_SysWork.field_14 = 0;
+            g_GameWork.gameStateStep_598[0] = state;
+            g_GameWork.gameStatePrev_590 = state;
+            g_GameWork.gameStateStep_598[0] = 0;
+            return 1;
+        case 2:
+        case 3:
+        case 10:
+        case 11:
+            break;
+        default:
+            D_800BCD0C = 10;
+            D_800B5C30 = 0x1000;
+            break;
+    }
+    return 0;
 }*/
 
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E2FC0);
-
+// TODO: Needs rodata
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", GameState_Unk15_Update); // 0x801E3094
+/*void GameState_Unk15_Update(void) // 0x801E3094
+{
+    const s32* (*routines[3])() = { func_801E3124, func_801E342C, func_801E3304 };
+    
+    D_800C48F0 += g_VBlanks;
+    if (routines[g_GameWork.gameStateStep_598[0]]() != 0) 
+    {
+        g_SysWork.timer_20 = 0;
+        g_GameWork.gameStateStep_598[1] = 0;
+        g_GameWork.gameStateStep_598[2] = 0;
+        g_GameWork.gameStateStep_598[0]++;
+    }
+}*/
 
 s32 func_801E3124() // 0x801E3124
 {
@@ -162,7 +218,81 @@ s32 func_801E3304() // 0x801E3304
     return 0;
 }
 
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E342C);
+s32 func_801E342C(void) // 0x801E342C
+{
+    s32 temp_v1;
+    u32* addr;
+    TILE* tile;
+
+    if (((g_GameWork.optExtraOptionsEnabled_27 >> (D_801E5E8C - 1)) & 1) && (g_ControllerPtr0->btns_new_10 & g_GameWorkPtr1->controllerBinds_0.skip))
+    {
+        D_800C48F0 = D_801E5558[D_801E5E8C].field_4 + (D_801E5E84 / 2);
+        SD_EngineCmd(0x13);
+    }
+
+    addr = (g_ObjectTableIdx << 11) + &D_800B7CC4;
+    tile = (TILE*)GsOUT_PACKET_P;
+
+    addPrimFast(addr, tile, 3);
+    setCodeWord(tile, PRIM_RECT, 0);
+    setXY0Fast(tile, -256, -224);
+    setWHFast(tile, 512, 2);
+
+    GsOUT_PACKET_P += sizeof(TILE);
+    temp_v1 = func_801E3684();
+
+    switch(g_GameWork.gameStateStep_598[1])
+    {
+        case 0:
+            switch (D_800BCD0C)
+            {
+                case 13:
+                    D_800BCD0C = 14;
+                    break;
+
+                case 5:
+                    D_800BCD0C = 6;
+                    break;
+            }
+            
+            D_800B5C30 = 0x1000;
+            g_GameWork.gameStateStep_598[1]++;
+            D_801E5E78 = 0xB4;
+            break;
+
+        case 1:
+            if (temp_v1 == 0)
+            {
+                break;
+            }
+            
+            D_801E5E78--;
+            if (!(func_80045B28() & 0xFF))
+            {
+                g_GameWork.gameStateStep_598[1]++;
+            }
+            break;
+
+         case 2:
+            D_801E5E78--;
+            if (D_801E5E78 <= 0)
+            {
+                D_800BCD0C = g_GameWork.gameStateStep_598[1];
+                g_GameWork.gameStateStep_598[1] = 3;
+            }
+            break;
+                
+        case 3:
+            if (D_800BCD0C == 5)
+            {
+                g_GameWork.gameStateStep_598[1] = 4;
+                return 1;
+            }
+            break;
+    }
+    
+    return 0;
+}
 
 bool func_801E3684() // 0x801E3684
 {
@@ -302,12 +432,12 @@ void func_801E42F8(s32 arg0, s32 arg1) // 0x801E42F8
 
 void func_801E4310(s32 r, s32 g, s32 b) // 0x801E4310
 {
-    D_800AFE10 = (r & 0xFF) | ((g & 0xFF) << 8) | ((b & 0xFF) << 16) | (0x64 << 24);
+    D_800AFE08.field_8 = (r & 0xFF) | ((g & 0xFF) << 8) | ((b & 0xFF) << 16) | ((PRIM_RECT | RECT_TEXTURE) << 24);
 }
 
 void func_801E4340(s8 arg0) // 0x801E4340
 {
-    D_800AFE0E = arg0;
+    D_800AFE08.field_6 = arg0;
 }
 
 void func_801E434C(u32 arg0, u32 arg1) // 0x801E434C
@@ -339,16 +469,14 @@ INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4394);
 
 INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E47E0);
 
-// TODO: Matched, but D_800AFE2C is supposed to be HADR0_7 according to sym.bodyprog.txt and I don't know what this is. --Sezz
-INCLUDE_ASM("asm/screens/credits/nonmatchings/credits", func_801E4B98);
-/*void func_801E4B98(s32 r, s32 g, s32 b)
+void func_801E4B98(s32 r, s32 g, s32 b)
 {
-    D_800AFE2C = (r & 0xFF) | ((g & 0xFF) << 8) | ((b & 0xFF) << 16) | (0x2C << 24);
-}*/
+    D_800AFE24.field_8 = (r & 0xFF) | ((g & 0xFF) << 8) | ((b & 0xFF) << 16) | (GPU_COM_TF4 << 24);
+}
 
 void func_801E4BC8(s8 arg0) // 0x801E4BC8
 {
-    D_800AFE2A = arg0;
+    D_800AFE24.field_6 = arg0;
 }
 
 void func_801E4BD4(u32 arg0, u32 arg1) // 0x801E4BD4


### PR DESCRIPTION
- Add `addPrimFast` macro to combine `addPrim` and `setlen`
- Fix non-matching in `credits`
- Add implementation of `func_801E342C`