### PR TITLE
bodyprog: fix 1 NON_MATCHING, add missing fn decls

### DIFF
--- a/docs/Game Information.md
+++ b/docs/Game Information.md
@@ -38,14 +38,14 @@ Several pre-release demos and versions were released during development, a table
 |  | **Prototypes** |  |  |
 | 98-11-24 | Silent Hill Preview (U) | SLUS-45678 | WKS. container, includes `FILEINFO.H`, volume dated 98-10-24? |
 | 99-01-07 | Silent Hill Review (U) | SLUS-00707 | WKS. container. |
-| 99-01-17 | Silent Hill Trade Demo (U) | SLUS-80707 | - |
+| 99-01-17 | Silent Hill Trade Demo (U) | SLUS-80707 | Redump mentions "anti-modchip"? |
 | 99-01-22 | Silent Hill Beta (U) | SLUS-00707 | "Russian Bootleg", possibly scene pre-release. |
 |  | **Final Versions** |  |  |
 | 99-01-26 | Silent Hill (J) | SLPM-86192 | Rev 0 |
 | 99-02-10 | Silent Hill (U) | SLUS-00707 | v1.1 |
 | 99-06-02 | Silent Hill (J) | SLPM-86192 | Rev 1, fixed Larval Stalker / Aglaophotis glitch. |
 | 99-06-07 | Silent Hill (E) | SLES-01514 | - |
-| 99-06-16 | Silent Hill (J) | SLPM-86192 | Rev 2, `Konami the Best` release. |
+| 99-06-16 | Silent Hill (J) | SLPM-86192 | Rev 2 `Konami the Best` release, EXE matches Rev 1 but SILENT contents differ, Redump mentions "anti-modchip"? |
 
 ### Unknown Releases
 

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -327,19 +327,17 @@ typedef struct
 
 typedef struct
 {
-    u8  field_0;
-    u8  field_1;
-    u8  field_2;
-    u8  field_3;
-    s8  unk_4[4];
-    s16 field_8;
-    s16 field_A;
-    s16 field_C;
-    s8  unk_E[6];
-    s32 field_14;
-    s8  unk_18[4];
-    s32 field_1C;
-    s32 field_20;
+    u8      field_0;
+    u8      field_1;
+    u8      field_2;
+    u8      field_3;
+    s8      unk_4[4];
+    s16     field_8;
+    s16     field_A;
+    VECTOR3 field_C;
+    s8      unk_18[4];
+    s32     field_1C;
+    s32     field_20;
 } s_800C4818;
 
 // Contains animation data? Size is rather small, so if it does, it would be indices to
@@ -980,6 +978,8 @@ void func_8003DD80(s32, s32);
 
 void func_80040014();
 
+void func_800410D8(VECTOR3*, s32*, s32*, SVECTOR*, VECTOR3*);
+
 /** Some kind of queue entry load status getter. */
 s32 func_80041ADC(s32 queueIdx);
 
@@ -1151,6 +1151,8 @@ s32 func_8004C45C();
  */
 s32 func_8004C4F8();
 
+void func_8004C8DC();
+
 void func_80054024(s8);
 
 void func_800540A4(s8);
@@ -1209,11 +1211,15 @@ void func_8008D464();
 
 void func_8008D470(s16 arg0, SVECTOR* rot, VECTOR3* pos, s32 arg3);
 
-void func_8008D1D0(s32* arg0, s32* arg1, s32* arg2, s32, s_DmsEntry* entry, s_DmsHeader* header);
+void func_8008D5A0(VECTOR3*, s16);
 
-void func_801E2D8C();
+s32 func_8008D8C0(s16, s32, s32);
 
-void func_8004C8DC();
+void func_8008D990(s32, s32, VECTOR3*, s32, s32);
+
+void func_8008E794(VECTOR3*, s16, s32);
+
+void func_8008EA68(SVECTOR*, VECTOR3*, s32);
 
 void func_80085D78(s32 arg0);
 

--- a/include/screens/saveload/saveload.h
+++ b/include/screens/saveload/saveload.h
@@ -36,6 +36,8 @@ extern s16 D_801E7578[];
 
 extern s8 D_801E76D0;
 
+void func_801E2D8C();
+
 void func_801E2F90(s32 idx);
 
 void func_801E2FCC(s32 arg0, s32 columnId, s32 arg2, s32 arg3);

--- a/src/bodyprog/bodyprog_80085D78.c
+++ b/src/bodyprog/bodyprog_80085D78.c
@@ -1578,8 +1578,6 @@ void func_8008D464() // 0x8008D464
     D_800C4818.field_1 = 0;
 }
 
-// TODO: Check what's wrong.
-#ifdef NON_MATCHING
 void func_8008D470(s16 arg0, SVECTOR* rot, VECTOR3* pos, s32 arg3) // 0x8008D470
 {
     s_8008E51C* ptr;
@@ -1589,10 +1587,10 @@ void func_8008D470(s16 arg0, SVECTOR* rot, VECTOR3* pos, s32 arg3) // 0x8008D470
     {
         func_800410D8(&D_800C4818.field_C, &D_800C4818.field_1C, &D_800C4818.field_20, rot, pos);
 
-        if ((ReadGeomScreen() >> 1) < D_800C4818.field_14)
+        if ((ReadGeomScreen() >> 1) < D_800C4818.field_C.vz)
         {
             D_800C4818.field_2 = 1;
-            D_800C4818.field_8 = func_8008D8C0(arg0, D_800C4818.field_14, D_800C4818.field_20);
+            D_800C4818.field_8 = func_8008D8C0(arg0, D_800C4818.field_C.vz, D_800C4818.field_20);
             func_8008D5A0(&D_800C4818.field_C, D_800C4818.field_20);
         }
         else
@@ -1617,9 +1615,6 @@ void func_8008D470(s16 arg0, SVECTOR* rot, VECTOR3* pos, s32 arg3) // 0x8008D470
         }
     }
 }
-#else
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80085D78", func_8008D470);
-#endif
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80085D78", func_8008D5A0);
 


### PR DESCRIPTION
Probably a lot of other mising fn decls around too, maybe need to get gcc to output warnings for them, would help a lot on decomp.me if we had those decls ready.

Left the param names out of the decls since these funcs aren't decomped yet, seems like a good indicator for those.