### PR TITLE
bodyprog: add SysState_EventXXX funcs, SysState_GameOver_Update

### DIFF
--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -15,6 +15,7 @@ g_DeltaTime0 = 0x800B5CC0; // type:s32 - Q20.12 fixed point, usually 0x44 (0.016
 g_DeltaTime1 = 0x800A8FEC; // type:s32
 g_DeltaTime2 = 0x800B9CC8; // type:s32
 g_MapEventIdx = 0x800A9A14; // type:u32
+g_SysState_GameOver_CurTipIndex = 0x800BCD80; // type:u8
 g_MapEventParam = 0x800BCDD8; // type:u32 - pointer to s_ShEventParam
 
 g_IntervalVBlanks = 0x800A8FF0; // type:s32

--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -180,9 +180,9 @@ SysState_Fmv_Update = 0x80039A58; // type:func
 SysState_LoadArea_Update = 0x80039C40; // type:func
 SysState_ReadMessage_Update = 0x80039FB8; // type:func
 SysState_SaveMenu_Update = 0x8003A230; // type:func
-SysState_Unk10_Update = 0x8003A3C8; // type:func
-SysState_Unk11_Update = 0x8003A460; // type:func
-SysState_Unk12_Update = 0x8003A4B4; // type:func
+SysState_EventCallFunc_Update = 0x8003A3C8; // type:func
+SysState_EventSetFlag_Update = 0x8003A460; // type:func
+SysState_EventPlaySound_Update = 0x8003A4B4; // type:func
 SysState_GameOver_Update = 0x8003A52C; // type:func
 SysState_GamePaused_Update = 0x800391E8; // type:func
 

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -538,6 +538,8 @@ extern s_FsImageDesc D_800A9044;
 
 extern s_FsImageDesc D_800A904C;
 
+extern s_FsImageDesc D_800A9054;
+
 extern s_FsImageDesc D_800A906C;
 
 /** Unknown bodyprog var. Used in `Fs_QueueStartReadAnm`. */
@@ -981,12 +983,16 @@ s32 func_80033548();
 /** Unknown bodyprog func. Called by `Fs_QueuePostLoadAnm`. */
 void func_80035560(s32 arg0, s32 arg1, void* arg2, s32 arg3);
 
+void func_80037188();
+
 void func_8003943C();
 
 /** SysState_Fmv update function.
  * Movie to play is decided by `2072 - g_MapEventIdx`
  * After playback, savegame gets `D_800BCDD8->eventFlagNum_2` event flag set. */
 void SysState_Fmv_Update();
+
+void func_8003B550();
 
 /** Unknown bodyprog func. Called by `Fs_QueueDoThingWhenEmpty`. */
 s32 func_8003c850();

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -1081,7 +1081,8 @@ void func_800453E8(s_Skeleton* skel, s32 cond);
 /** Does something with skeleton bones. `arg0` is a struct pointer. */
 void func_80045468(s_Skeleton* skel, s32* arg1, s32 cond);
 
-void Sd_EngineCmd(s32 cmd);
+/** Passes a command to the sound driver. */
+void Sd_EngineCmd(u32 cmd);
 
 /** Sound func? */
 u8 func_80045B28();
@@ -1096,7 +1097,15 @@ void Sd_DriverInit();
 
 u8 func_80045B28();
 
+void func_80046048(u16, s32, s32);
+
 void func_8004690C(s32);
+
+void func_8004692C(u16);
+
+void func_80046A24(u16);
+
+void func_80046D3C(u16);
 
 void func_8004729C(u16);
 
@@ -1419,9 +1428,6 @@ void Settings_ScreenAndVolUpdate();
 
 void Settings_RestoreDefaults();
 
-/** Passes a command to the sound driver. */
-void Sd_EngineCmd(s32 cmd);
-
 /** Updates the savegame buffer with the current player SysWork info (position, rotation, health, event index). */
 void SysWork_SaveGameUpdatePlayer();
 
@@ -1429,6 +1435,8 @@ void SysWork_SaveGameUpdatePlayer();
 void SysWork_SaveGameReadPlayer();
 
 s32 MainLoop_ShouldWarmReset();
+
+void Game_WarmBoot();
 
 void Joy_Init();
 

--- a/include/game.h
+++ b/include/game.h
@@ -397,7 +397,7 @@ typedef struct _ShSaveGame
     s16               field_276;
     s16               field_278;
     s8                field_27A;
-    s8                continueCount_27B;
+    u8                continueCount_27B;
 } s_ShSaveGame;
 STATIC_ASSERT_SIZEOF(s_ShSaveGame, 636);
 
@@ -451,7 +451,7 @@ typedef struct _GameWork
     u8                   optWalkRunCtrl_2B;         /** Normal: 0, Reverse: 1, default: Normal. */
     u8                   optAutoAiming_2C;          /** On: 0, Off: 1, default: On. */
     s8                   optBulletAdjust_2D;        /** x1-x6: Range [0, 5], default: x1. */
-    s8                   unk_2E[2];                 /** Looks like non-zero values in "Next Fear" mode. */
+    u16                  seenGameOverTips_2E[1];    /** Bitfield tracking seen game-over tips. Each bit corresponds to a tip index (0–15); set bits indicate seen tips. */
     s8                   unk_30[8];
     s_ControllerData     controllers_38[2];
     s_ShSaveGame         saveGame_90; // Backup savegame?
@@ -607,7 +607,9 @@ typedef struct _SysWork
     s8              unk_2388[20];
     s8              field_239C;
     u8              field_239D; // Index?
-    s8              unk_239E[370];
+    s8              unk_239E[318];
+    s32             field_24DC;
+    s8              unk_24E0[48];
     s32             field_2510;
     s32             field_2514[10];
     u8              unk_253C[524];
@@ -654,6 +656,16 @@ static inline void SysWork_StateSetNext(e_SysState sysState)
     g_SysWork.field_10       = 0;
     g_SysWork.timer_2C       = 0;
     g_SysWork.field_14       = 0;
+}
+
+/** @brief Increments the sysStateStep index inside SysWork. */
+static inline void SysWork_StateStepIncrement()
+{
+    g_SysWork.field_28 = 0;
+    g_SysWork.field_10 = 0;
+    g_SysWork.timer_2C = 0;
+    g_SysWork.field_14 = 0;
+    g_SysWork.sysStateStep_C++;
 }
 
 /** @brief Sets the GameState to be used in the next game update.
@@ -706,6 +718,12 @@ static inline void SaveGame_EventFlagSet(u32 flagId)
     s16 flagBit = flagId % 32;
 
     g_SaveGamePtr->eventFlags_168[flagIdx] |= 1 << flagBit;
+}
+
+/** @brief Sets the given flag ID inside an array of 16-bit flag values. */
+static inline int Flags16b_IsSet(u16* array, s32 flagId)
+{
+    return (array[flagId >> 5] >> (flagId & 0x1F)) & 1;
 }
 
 #endif

--- a/include/game.h
+++ b/include/game.h
@@ -107,21 +107,21 @@ typedef enum _GameState
  */
 typedef enum _SysState
 {
-    SysState_Gameplay    = 0,
-    SysState_OptionsMenu = 1,
-    SysState_StatusMenu  = 2,
-    SysState_Unk3        = 3,
-    SysState_Fmv         = 4,
-    SysState_LoadArea0   = 5,
-    SysState_LoadArea1   = 6,
-    SysState_ReadMessage = 7,
-    SysState_SaveMenu0   = 8,
-    SysState_SaveMenu1   = 9,
-    SysState_Unk10       = 10,
-    SysState_Unk11       = 11,
-    SysState_Unk12       = 12,
-    SysState_GameOver    = 13,
-    SysState_GamePaused  = 14
+    SysState_Gameplay       = 0,
+    SysState_OptionsMenu    = 1,
+    SysState_StatusMenu     = 2,
+    SysState_Unk3           = 3,
+    SysState_Fmv            = 4,
+    SysState_LoadArea0      = 5,
+    SysState_LoadArea1      = 6,
+    SysState_ReadMessage    = 7,
+    SysState_SaveMenu0      = 8,
+    SysState_SaveMenu1      = 9,
+    SysState_EventCallFunc  = 10,
+    SysState_EventSetFlag   = 11,
+    SysState_EventPlaySound = 12,
+    SysState_GameOver       = 13,
+    SysState_GamePaused     = 14
 } e_SysState;
 
 /** @brief Inventory command IDs. */

--- a/include/game.h
+++ b/include/game.h
@@ -720,9 +720,11 @@ static inline void SaveGame_EventFlagSet(u32 flagId)
     g_SaveGamePtr->eventFlags_168[flagIdx] |= 1 << flagBit;
 }
 
-/** @brief Sets the given flag ID inside an array of 16-bit flag values. */
+/** @brief Checks if the given flag ID is set inside array of 16-bit flag values. */
 static inline int Flags16b_IsSet(u16* array, s32 flagId)
 {
+    // BUG: `>> 5` divides flagId by 32 to get the index into array, but array is of 16-bit values.
+    // Maybe copy paste from a u32 version of the func.
     return (array[flagId >> 5] >> (flagId & 0x1F)) & 1;
 }
 

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -1600,7 +1600,7 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_GameOver_Update); // 
 /** TODO: Needs jump table.
 void SysState_GameOver_Update() // 0x8003A52C
 {
-    extern u8   g_SysState_GameOver_CurTipIndex; // only used in this func, maybe g_SysState_GameOver_CurTipIndex?
+    extern u8   g_SysState_GameOver_CurTipIndex; // Only used in this func, maybe static.
     extern char D_80025448[];                    // "\aGAME_OVER" - needs rodata migration
 
     u16  seenTipIndexes[1];

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -1568,11 +1568,32 @@ void SysWork_SaveGameReadPlayer() // 0x8003A1F4
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_SaveMenu_Update); // 0x8003A230
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk10_Update); // 0x8003A3C8
+void SysState_EventCallFunc_Update() // 0x8003A3C8
+{
+    if ((g_MapEventParam->flags_8 >> 0xD) & 0x3F)
+    {
+        SaveGame_EventFlagSet(g_MapEventParam->eventFlagId_2);
+    }
+    g_DeltaTime0 = D_800BCD84;
+    g_MapOverlayHeader.mapEventFuncs_20[g_MapEventIdx]();
+}
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk11_Update); // 0x8003A460
+void SysState_EventSetFlag_Update() // 0x8003A460
+{
+    g_DeltaTime0 = D_800BCD84;
+    SaveGame_EventFlagSet(g_MapEventParam->eventFlagId_2);
+    g_SysWork.sysState_8 = 0;
+}
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_Unk12_Update); // 0x8003A4B4
+void SysState_EventPlaySound_Update() // 0x8003A4B4
+{
+    g_DeltaTime0 = D_800BCD84;
+
+    Sd_EngineCmd(((u16)g_MapEventIdx + 0x500) & 0xFFFF);
+
+    SaveGame_EventFlagSet(g_MapEventParam->eventFlagId_2);
+    g_SysWork.sysState_8 = 0;
+}
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", SysState_GameOver_Update); // 0x8003A52C
 

--- a/src/bodyprog/bodyprog_80040A64.c
+++ b/src/bodyprog/bodyprog_80040A64.c
@@ -775,30 +775,27 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80040A64", func_80045534);
 // SOUND
 // ========================================
 
-void Sd_EngineCmd(s32 cmd) // 0x80045A7C
+void Sd_EngineCmd(u32 cmd) // 0x80045A7C
 {
-    u32 maskedCmd;
-
-    maskedCmd = ((u32)cmd >> 8) & 0xFF;
-    switch (maskedCmd)
+    switch ((cmd >> 8) & 0xFF)
     {
         case 0:
-            func_80045BD8(cmd & 0xFFFF);
+            func_80045BD8(cmd);
             return;
 
         case 3:
         case 4:
-            func_80046A24(cmd & 0xFFFF);
+            func_80046A24(cmd);
             return;
 
         case 5:
         case 6:
-            func_80046048(cmd & 0xFFFF, 0, 0);
+            func_80046048(cmd, 0, 0);
             return;
 
         case 7:
         case 8:
-            func_8004692C((cmd - 0x200) & 0xFFFF);
+            func_8004692C((cmd - 0x200));
             return;
 
         case 11:
@@ -813,7 +810,7 @@ void Sd_EngineCmd(s32 cmd) // 0x80045A7C
         case 20:
         case 21:
         case 22:
-            func_80046D3C(cmd & 0xFFFF);
+            func_80046D3C(cmd);
 
         default:
             return;
@@ -1008,12 +1005,12 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog_80040A64", func_800468EC);
 
 void func_8004690C(s32 arg0) // 0x8004690C
 {
-    func_8004692C(arg0 & 0xFFFF);
+    func_8004692C(arg0);
 }
 
-void func_8004692C(s32 arg0) // 0x8004692C
+void func_8004692C(u16 arg0) // 0x8004692C
 {
-    if ((arg0 & 0xFFFF) == 0x500)
+    if (arg0 == 0x500)
     {
         return;
     }


### PR DESCRIPTION
Changes Unk10/11/12 to EventCallFunc / EventSetFlag / EventPlaySound

SysState_GameOver_Update needs jump table, not really sure how we add those though.

Small fixups to Sd_EngineCmd too, that func might be taking u16 param since most callers use & 0xFFFF to it, but couldn't get it to match with that changed, odd.

Contributors: @fmil95, @IWILLCRAFT-M0d 