### PR TITLE
bodyprog: match 4 funcs

### DIFF
--- a/configs/bodyprog.yaml
+++ b/configs/bodyprog.yaml
@@ -69,6 +69,9 @@ segments:
       #- [0x11D8, rodata]
       - [0x3938, .rodata, bodyprog_8004A87C] # Jumptable
       - [0x39C4, rodata]
+      - [0x5CF0, .rodata, view/vc_main] # Jumptable: `vcRetFarWatchRate`
+      - [0x5D08, .rodata, view/vc_main] # Jumptable: `vcSetFlagsByCamMvType`
+      - [0x5D1C, rodata]
       - [0x5FBC, .rodata, bodyprog_80085D78] # Jumptables
       - [0x6044, rodata]
       # - [0x64A4, .rodata, bodyprog_80085D78] # Jumptable: `func_8008A2E0`

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -668,6 +668,8 @@ extern s32 D_800AFD9C;
 
 extern u16 D_800AFDBC;
 
+extern void* D_800AFDC0;
+
 extern s32 D_800AFDEC;
 
 extern s_800AFE08 D_800AFE08;
@@ -912,6 +914,8 @@ extern s16 D_800C4700;
 extern s16 D_800C4702;
 
 extern s_800C4818 D_800C4818;
+
+extern s32 g_Demo_FileIndex; // 0x800C4844
 
 /** Unknown bodyprog var. Set in `Fs_QueueDoThingWhenEmpty`. */
 extern s32 D_800C489C;
@@ -1331,6 +1335,8 @@ void func_8008D990(s32, s32, VECTOR3*, s32, s32);
 void func_8008E794(VECTOR3*, s16, s32);
 
 void func_8008EA68(SVECTOR*, VECTOR3*, s32);
+
+void func_8008EF20(s32);
 
 void func_80085D78(s32 arg0);
 

--- a/include/bodyprog/vw_system.h
+++ b/include/bodyprog/vw_system.h
@@ -395,4 +395,14 @@ static inline void vcWork_CurNearRoadSet(VC_WORK* work, VC_NEAR_ROAD_DATA* road)
     memcpy(&work->cur_near_road_2B8, road, sizeof(VC_NEAR_ROAD_DATA));
 }
 
+static inline void vcWork_FlagClear(s32 flag)
+{
+    vcWork.flags_8 &= ~flag;
+}
+
+static inline void vcWork_FlagSet(s32 flag)
+{
+    vcWork.flags_8 |= flag;
+}
+
 #endif /* _VW_SYSTEM_H */

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -443,7 +443,91 @@ s32 vcRetThroughDoorCamEndF(VC_WORK* w_p) // 0x800815F0
     return 0;
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcRetFarWatchRate);
+s32 vcRetFarWatchRate(s32 far_watch_button_prs_f, VC_CAM_MV_TYPE cur_cam_mv_type, VC_WORK* w_p) // 0x800816B0
+{
+    s32 dist;
+    s32 far_watch_rate;
+    s32 abs_ofs_ang_y;
+
+    s32 railDistX;
+    s32 railDistZ;
+    s32 prsFViewFlag;
+
+    if ((vcWork.flags_8 & (VC_USER_WATCH_F | VC_INHIBIT_FAR_WATCH_F)))
+    {
+        far_watch_rate = 0;
+    }
+    else
+    {
+        switch (cur_cam_mv_type)
+        {
+            case VC_MV_CHASE:
+            case VC_MV_SETTLE:
+                far_watch_rate = FP_TO(far_watch_button_prs_f != 0, Q12_SHIFT);
+                break;
+            case VC_MV_THROUGH_DOOR:
+                far_watch_rate = FP_METER(16.f); // FP_ANGLE(22.5f);
+                if (!far_watch_button_prs_f)
+                {
+                    // TODO: unsure if these should use FP_METER or FP_ANGLE
+                    // gets multiplied by `dist` so FP_METER fits
+                    // but then it gets subtracted by `abs_ofs_ang_y`, so FP_ANGLE would also fit?
+
+                    dist           = w_p->through_door_10.rail_sta_to_chara_dist_18;
+                    far_watch_rate = FP_METER(14.4f) - ((dist * FP_METER(14.4f)) / FP_METER(36.8f));
+                    // far_watch_rate = FP_ANGLE(20.25f) - ((dist * FP_ANGLE(20.25f)) / FP_ANGLE(51.75f));
+                    if (far_watch_rate < 0)
+                    {
+                        far_watch_rate = 0;
+                    }
+
+                    if (dist > FP_METER(8.f))
+                    {
+                        railDistX = w_p->chara_pos_114.vx - w_p->through_door_10.rail_sta_pos_C.vx;
+                        railDistZ = w_p->chara_pos_114.vz - w_p->through_door_10.rail_sta_pos_C.vz;
+                        if (((w_p->chara_eye_ang_y_144 - ratan2(railDistX, railDistZ)) << 0x14) < 0)
+                        {
+                            abs_ofs_ang_y = -shAngleRegulate(w_p->chara_eye_ang_y_144 - ratan2(railDistX, railDistZ));
+                        }
+                        else
+                        {
+                            abs_ofs_ang_y = shAngleRegulate(w_p->chara_eye_ang_y_144 - ratan2(railDistX, railDistZ));
+                        }
+                        far_watch_rate = (far_watch_rate * (FP_METER(3.11f) - abs_ofs_ang_y)) / FP_METER(3.11f);
+                        // far_watch_rate = (far_watch_rate * (FP_ANGLE(4.375f) - abs_ofs_ang_y)) / FP_ANGLE(4.375f);
+                        if (far_watch_rate < 0)
+                        {
+                            far_watch_rate = 0;
+                        }
+                    }
+                }
+                break;
+            default:
+            case VC_MV_FIX_ANG:
+            case VC_MV_SELF_VIEW:
+                far_watch_rate = 0;
+                break;
+        }
+    }
+
+    if (g_GameWorkPtr0->optViewMode_29 != 0)
+    {
+        prsFViewFlag = vcWork.flags_8 >> 9; /** VC_PRS_F_VIEW_F */
+        prsFViewFlag = prsFViewFlag & 1;
+
+        if ((g_GameWorkPtr0->optViewCtrl_28 != 0 && (prsFViewFlag ^ 1) != 0) ||
+            (g_GameWorkPtr0->optViewCtrl_28 == 0 && prsFViewFlag != 0))
+        {
+            if (!(w_p->flags_8 & (VC_USER_CAM_F | VC_USER_WATCH_F | VC_INHIBIT_FAR_WATCH_F)) &&
+                func_8008150C(w_p->chara_pos_114.vx, w_p->chara_pos_114.vz))
+            {
+                far_watch_rate = 0;
+            }
+        }
+    }
+
+    return far_watch_rate;
+}
 
 s32 vcRetSelfViewEffectRate(VC_CAM_MV_TYPE cur_cam_mv_type, s32 far_watch_rate, VC_WORK* w_p) // 0x800818D4
 {
@@ -520,7 +604,75 @@ s32 vcRetSelfViewEffectRate(VC_CAM_MV_TYPE cur_cam_mv_type, s32 far_watch_rate, 
     return ret_eff_rate;
 }
 
-INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcSetFlagsByCamMvType);
+void vcSetFlagsByCamMvType(VC_CAM_MV_TYPE cam_mv_type, s32 far_watch_rate, s32 all_warp_f) // 0x80081A0C
+{
+    s32 vcOldPrsFViewFlag;
+    s32 vcPrsFViewFlag;
+
+    if (!far_watch_rate)
+    {
+        switch (cam_mv_type)
+        {
+            case VC_MV_CHASE:
+                vcWork_FlagSet(VC_VISIBLE_CHARA_F);
+                break;
+            case VC_MV_SETTLE:
+                vcWork_FlagSet(VC_VISIBLE_CHARA_F);
+                break;
+            case VC_MV_FIX_ANG:
+                vcWork_FlagClear(VC_VISIBLE_CHARA_F);
+                break;
+            case VC_MV_SELF_VIEW:
+                vcWork_FlagClear(VC_VISIBLE_CHARA_F);
+                break;
+            case VC_MV_THROUGH_DOOR:
+                vcWork_FlagClear(VC_VISIBLE_CHARA_F);
+                break;
+        }
+    }
+    else
+    {
+        vcWork_FlagClear(VC_VISIBLE_CHARA_F);
+    }
+
+    if (cam_mv_type == VC_MV_SELF_VIEW)
+    {
+        vcWork_FlagSet(VC_WARP_CAM_F | VC_WARP_CAM_TGT_F);
+
+        vcPrsFViewFlag = (vcWork.flags_8 >> 9); /** VC_PRS_F_VIEW_F */
+        vcPrsFViewFlag = vcPrsFViewFlag & 1;
+
+        // optViewCtrl != 0 && vcPrsFViewFlag == 0 OR
+        // optViewCtrl == 0 && vcPrsFViewFlag == 1
+        if ((g_GameWorkPtr0->optViewCtrl_28 != 0 && (vcPrsFViewFlag ^ 1) != 0) ||
+            (g_GameWorkPtr0->optViewCtrl_28 == 0 && vcPrsFViewFlag != 0))
+        {
+            vcOldPrsFViewFlag = (vcWork.flags_8 >> 0xA); /** VC_OLD_PRS_F_VIEW_F */
+            vcOldPrsFViewFlag = vcOldPrsFViewFlag & 1;
+
+            // (optViewCtrl != 0 && vcOldPrsFViewFlag == 0) == false AND
+            // (optViewCtrl == 0 && vcOldPrsFViewFlag == 1) == false
+            if (!(g_GameWorkPtr0->optViewCtrl_28 != 0 && (vcOldPrsFViewFlag ^ 1) != 0) &&
+                !(g_GameWorkPtr0->optViewCtrl_28 == 0 && vcOldPrsFViewFlag != 0))
+            {
+                if (g_GameWorkPtr0->optViewMode_29 != 0)
+                {
+                    vcWork_FlagSet(VC_WARP_WATCH_F);
+                }
+            }
+        }
+    }
+
+    if (all_warp_f != 0)
+    {
+        vcWork_FlagSet(VC_WARP_CAM_F | VC_WARP_WATCH_F | VC_WARP_CAM_TGT_F);
+    }
+
+    if (far_watch_rate != 0)
+    {
+        vcWork_FlagSet(VC_WARP_CAM_TGT_F);
+    }
+}
 
 void vcPreSetDataInVC_WORK(VC_WORK* w_p, VC_ROAD_DATA* vc_road_ary_list) // 0x80081B6C
 {


### PR DESCRIPTION
- Demo_DataRead
- Demo_JoyUpdate
- vcRetFarWatchRate
- vcSetFlagsByCamMvType

Not sure about the FP_METER uses in vcRetFarWatchRate, could be FP_ANGLE instead but not really sure how to tell.

Also have Demo_GameGlobalsRestore at https://decomp.me/scratch/ZdDtI, but it'll need sub-struct added to g_GameWork, might try adding it in soon.