### PR TITLE
math: switch to Q4.12 for angles, make `SpawnInfo.rotationY` unsigned

### DIFF
--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -1079,8 +1079,7 @@ typedef struct _MapOverlayHeader
     u8           unk_16C[4];
     u8           unk_170[36];
     void         (*charaUpdateFuncs_194[Chara_Count])(s_SubCharacter*, void*, s32); /** Guessed params. Funcptrs for each `e_ShCharacterId`, set to 0 for IDs not included in the map overlay. Called by `func_80038354`. */
-    u8           charaGroupIds_248[2]; /** `e_ShCharacterId` values used for charaSpawns with chara_type_4 == 0, first value is used for charaSpawns[0:15], second value for charaSpawns[16:31]. */
-    u8           unk_24A[2];
+    u8           charaGroupIds_248[4]; /** `e_ShCharacterId` values used for charaSpawns with chara_type_4 == 0, [0] is used for charaSpawns[0:15], [1] for charaSpawns[16:31]. */
     s_SpawnInfo  charaSpawns_24C[32]; /** Array of chara type/position/flags, flags_6 == 0 are unused slots?, read by `func_80037F24`. */
     VC_ROAD_DATA roadDataList_3CC[48];
     // TODO: A lot more in here.

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -1031,12 +1031,12 @@ extern s_800AD4C8 D_800AD4C8[];
 
 typedef struct _SpawnInfo
 {
-    s32 posX_0;
+    s32 positionX_0;
     s8  chara_type_4;             /** `e_ShCharacterId` */
-    u8  rot_5;
+    u8  rotationY_5; /** Multiplied by 16 to get `s_SubCharacter.rotation_24.vy` value. */
     s8  flags_6; /** Copied to `isAnimStateUnchanged_3` in `s_Model`. */
     s8  unk_7;
-    s32 posZ_8;
+    s32 positionZ_8;
 } s_SpawnInfo;
 STATIC_ASSERT_SIZEOF(s_SpawnInfo, 12);
 

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -1033,7 +1033,7 @@ typedef struct _SpawnInfo
 {
     s32 posX_0;
     s8  chara_type_4;             /** `e_ShCharacterId` */
-    s8  rot_5;
+    u8  rot_5;
     s8  flags_6; /** Copied to `isAnimStateUnchanged_3` in `s_Model`. */
     s8  unk_7;
     s32 posZ_8;

--- a/include/bodyprog/math.h
+++ b/include/bodyprog/math.h
@@ -5,7 +5,7 @@
 #define Q8_SHIFT       8         /** Used for: Q8.8 camera AABBs. Q24.8 meters. */
 #define Q12_SHIFT      12        /** Used for: Q3.12 alphas. Q19.12 timers, trigonometry. */
 #define SIN_LUT_SIZE   4096      /** Number of entries in the sine lookup table. */
-#define FP_ANGLE_COUNT (1 << 16) /** Number of fixed-point angles in Q1.15 format. */
+#define FP_ANGLE_COUNT (1 << 12) /** Number of fixed-point angles in Q4.12 format. */
 
 /** @brief Squares a value. */
 #define SQUARE(x) \
@@ -63,7 +63,7 @@
 #define FP_COLOR(val) \
     (u8)((val) * (FP_FLOAT_TO(1.0f, Q8_SHIFT) - 1))
 
-/** @brief Converts floating-point degrees to fixed-point angles in Q1.15 format. */
+/** @brief Converts floating-point degrees to fixed-point angles in Q4.12 format. */
 #define FP_ANGLE(deg) \
     (s16)((deg) * ((FP_ANGLE_COUNT) / 360.0f))
 

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -72,7 +72,7 @@ void vcSetFirstCamWork(VECTOR3* cam_pos, s16 chara_eye_ang_y, s32 use_through_do
     vcWork.cam_mv_ang_y_5C = 0;
     vcWork.cam_tgt_spd_110 = 0;
 
-    vcWork.cam_chara2ideal_ang_y_FE = shAngleRegulate(chara_eye_ang_y + FP_ANGLE(11.25f));
+    vcWork.cam_chara2ideal_ang_y_FE = shAngleRegulate(chara_eye_ang_y + FP_ANGLE(180.0f));
 
     vcWork_CurNearRoadSet(&vcWork, &vcNullNearRoad);
 
@@ -319,8 +319,8 @@ void vcSetAllNpcDeadTimer() // 0x8008123C
 s32 vcRetSmoothCamMvF(VECTOR3* old_pos, VECTOR3* now_pos, SVECTOR* old_ang, SVECTOR* now_ang) // 0x800812CC
 {
     #define MOVEMENT_MAX_METER 0.2f
-    #define ROT_X_MAX_ANGLE 1.25f
-    #define ROT_Y_MAX_ANGLE 1.875f
+    #define ROT_X_MAX_ANGLE 20.0f
+    #define ROT_Y_MAX_ANGLE 30.0f
     #define INTRPT_MIN_TIME 1.0f
     #define INTRPT_MAX_TIME 4.0f
 
@@ -428,7 +428,7 @@ s32 vcRetThroughDoorCamEndF(VC_WORK* w_p) // 0x800815F0
             abs_ofs_ang_y = -abs_ofs_ang_y;
         }
 
-        if (abs_ofs_ang_y > FP_ANGLE(4.375f))
+        if (abs_ofs_ang_y > FP_ANGLE(70.0f))
         {
             return 1;
         }
@@ -461,7 +461,7 @@ s32 vcRetFarWatchRate(s32 far_watch_button_prs_f, VC_CAM_MV_TYPE cur_cam_mv_type
                 break;
 
             case VC_MV_THROUGH_DOOR:
-                far_watch_rate = FP_METER(16.f); // FP_ANGLE(22.5f);
+                far_watch_rate = FP_METER(16.0f); // FP_ANGLE(256.0f);
                 if (!far_watch_button_prs_f)
                 {
                     // TODO: unsure if these should use FP_METER or FP_ANGLE
@@ -470,7 +470,7 @@ s32 vcRetFarWatchRate(s32 far_watch_button_prs_f, VC_CAM_MV_TYPE cur_cam_mv_type
 
                     dist           = w_p->through_door_10.rail_sta_to_chara_dist_18;
                     far_watch_rate = FP_METER(14.4f) - ((dist * FP_METER(14.4f)) / FP_METER(36.8f));
-                    // far_watch_rate = FP_ANGLE(20.25f) - ((dist * FP_ANGLE(20.25f)) / FP_ANGLE(51.75f));
+                    // far_watch_rate = FP_ANGLE(324.0f) - ((dist * FP_ANGLE(324.0f)) / FP_ANGLE(828.0f));
                     if (far_watch_rate < 0)
                     {
                         far_watch_rate = 0;
@@ -490,7 +490,7 @@ s32 vcRetFarWatchRate(s32 far_watch_button_prs_f, VC_CAM_MV_TYPE cur_cam_mv_type
                         }
 
                         far_watch_rate = (far_watch_rate * (FP_METER(3.11f) - abs_ofs_ang_y)) / FP_METER(3.11f);
-                        // far_watch_rate = (far_watch_rate * (FP_ANGLE(4.375f) - abs_ofs_ang_y)) / FP_ANGLE(4.375f);
+                        // far_watch_rate = (far_watch_rate * (FP_ANGLE(70.0f) - abs_ofs_ang_y)) / FP_ANGLE(70.0f);
                         if (far_watch_rate < 0)
                         {
                             far_watch_rate = 0;
@@ -932,9 +932,9 @@ void vcAdjustWatchYLimitHighWhenFarView(VECTOR3* watch_pos, VECTOR3* cam_pos, s1
 {
     s16 max_cam_ang_x = ratan2(cam_pos->vy + FP_METER(80.0f), FP_METER(208.0f)) - ratan2(g_GameWork.gsScreenHeight_58A / 2, sy);
     s32 dist          = Math_VectorMagnitude(watch_pos->vx - cam_pos->vx, 0, watch_pos->vz - cam_pos->vz);
-    s32 cam_ang_x     = ratan2(-watch_pos->vy + cam_pos->vy, dist) * FP_ANGLE_COUNT;
+    s16 cam_ang_x     = ratan2(-watch_pos->vy + cam_pos->vy, dist);
 
-    if ((max_cam_ang_x * FP_ANGLE_COUNT) < cam_ang_x)
+    if (cam_ang_x > max_cam_ang_x)
     {
         s32 ofs_y     = FP_TO(((FP_FROM(dist, Q4_SHIFT)) * shRsin(max_cam_ang_x)) / shRcos(max_cam_ang_x), Q4_SHIFT);
         watch_pos->vy = cam_pos->vy - ofs_y;
@@ -1040,17 +1040,17 @@ void vcMakeIdealCamPosByHeadPos(VECTOR3* ideal_pos, VC_WORK* w_p, VC_AREA_SIZE_T
 
     if (g_GameWorkPtr0->config_0.optViewMode_29)
     {
-        chara2cam_ang_y = w_p->chara_eye_ang_y_144 + FP_ANGLE(8.75f);
+        chara2cam_ang_y = w_p->chara_eye_ang_y_144 + FP_ANGLE(140.0f);
         ideal_pos->vy   = w_p->chara_head_pos_130.vy + FP_METER(1.12f);
     }
     else
     {
-        chara2cam_ang_y = w_p->chara_eye_ang_y_144 + FP_ANGLE(10.625f);
+        chara2cam_ang_y = w_p->chara_eye_ang_y_144 + FP_ANGLE(170.0f);
         ideal_pos->vy   = w_p->chara_head_pos_130.vy + FP_METER(1.6f);
     }
 
-    ideal_pos->vx = w_p->chara_head_pos_130.vx + FP_MULTIPLY(shRsin(chara2cam_ang_y), FP_ANGLE(4.05f), Q12_SHIFT);
-    ideal_pos->vz = w_p->chara_head_pos_130.vz + FP_MULTIPLY(shRcos(chara2cam_ang_y), FP_ANGLE(4.05f), Q12_SHIFT);
+    ideal_pos->vx = w_p->chara_head_pos_130.vx + FP_MULTIPLY(shRsin(chara2cam_ang_y), FP_ANGLE(64.8f), Q12_SHIFT);
+    ideal_pos->vz = w_p->chara_head_pos_130.vz + FP_MULTIPLY(shRcos(chara2cam_ang_y), FP_ANGLE(64.8f), Q12_SHIFT);
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/view/vc_main", vcMakeIdealCamPosForFixAngCam);
@@ -1237,8 +1237,8 @@ void vcGetUseWatchAndCamMvParam(VC_WATCH_MV_PARAM** watch_mv_prm_pp, VC_CAM_MV_P
 
         *watch_mv_prm_pp = &vcWatchMvPrmSt;
 
-        add_ang_accel_y = FP_FROM((s64)w_p->chara_mv_spd_13C * FP_ANGLE(22.5f), Q12_SHIFT);
-        add_ang_accel_y = CLAMP(add_ang_accel_y, 0, FP_ANGLE(45.0f));
+        add_ang_accel_y = FP_FROM((s64)w_p->chara_mv_spd_13C * FP_ANGLE(360.0f), Q12_SHIFT);
+        add_ang_accel_y = CLAMP(add_ang_accel_y, 0, FP_ANGLE(720.0f));
 
         vcWatchMvPrmSt.ang_accel_y += add_ang_accel_y;
     }
@@ -1409,17 +1409,16 @@ void vcAdjCamOfsAngByCharaInScreen(SVECTOR* cam_ang, SVECTOR* ofs_cam2chara_btm_
         var_a1 = watch2chr_top_ofs_ang_x - w_p->scr_half_ang_wy_2C;
     }
 
-    // SH2 uses similar checks with 0.52359879 / 30 degrees.
-    if (var_a1 < FP_ANGLE(-1.875f))
+    if (var_a1 < FP_ANGLE(-30.0f))
     {
-        adj_cam_ang_x = FP_ANGLE(-1.875f);
+        adj_cam_ang_x = FP_ANGLE(-30.0f);
     }
     else
     {
         adj_cam_ang_x = var_a1;
-        if (var_a1 > FP_ANGLE(1.875f))
+        if (var_a1 > FP_ANGLE(30.0f))
         {
-            adj_cam_ang_x = FP_ANGLE(1.875f);
+            adj_cam_ang_x = FP_ANGLE(30.0f);
         }
     }
 
@@ -1475,7 +1474,7 @@ void vcSetDataToVwSystem(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type) // 0x80085884
         w_p->field_D8 = 0;
         vwSetCoordRefAndEntou(&g_SysWork.playerBoneCoords_890[PlayerBone_Head],
                               0, FP_METER(-0.8f), FP_METER(4.8f),
-                              FP_ANGLE(11.25f), FP_ANGLE(0.0f), FP_METER(-3.2f), FP_METER(16.0f));
+                              FP_ANGLE(180.0f), FP_ANGLE(0.0f), FP_METER(-3.2f), FP_METER(16.0f));
     }
     else if (w_p->field_FC != 0)
     {
@@ -1486,17 +1485,17 @@ void vcSetDataToVwSystem(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type) // 0x80085884
     {
         vcSelfViewTimer += g_DeltaTime0;
 
-        noise_ang.vx = vcCamMatNoise(4, FP_ANGLE(31.25f), FP_ANGLE(50.0f), vcSelfViewTimer);
-        noise_ang.vy = vcCamMatNoise(2, FP_ANGLE(25.0f), FP_ANGLE(62.5f), vcSelfViewTimer);
+        noise_ang.vx = vcCamMatNoise(4, FP_ANGLE(500.0f), FP_ANGLE(800.0f), vcSelfViewTimer);
+        noise_ang.vy = vcCamMatNoise(2, FP_ANGLE(400.0f), FP_ANGLE(1000.0f), vcSelfViewTimer);
         noise_ang.vz = 0;
         func_80096C94(&noise_ang, &noise_mat);
 
-        noise_mat.m[0][0] += vcCamMatNoise(12, FP_ANGLE(43.75f), FP_ANGLE(56.25f), vcSelfViewTimer);
-        noise_mat.m[0][1] += vcCamMatNoise(12, FP_ANGLE(37.5f), FP_ANGLE(62.5f), vcSelfViewTimer);
-        noise_mat.m[0][2] += vcCamMatNoise(12, FP_ANGLE(37.5f), FP_ANGLE(50.0f), vcSelfViewTimer);
-        noise_mat.m[1][0] += vcCamMatNoise(12, FP_ANGLE(31.25f), FP_ANGLE(31.25f), vcSelfViewTimer);
-        noise_mat.m[1][1] += vcCamMatNoise(12, FP_ANGLE(56.25f), FP_ANGLE(25.0f), vcSelfViewTimer);
-        noise_mat.m[1][2] += vcCamMatNoise(12, FP_ANGLE(40.625f), FP_ANGLE(59.375f), vcSelfViewTimer);
+        noise_mat.m[0][0] += vcCamMatNoise(12, FP_ANGLE(700.0f), FP_ANGLE(900.0f), vcSelfViewTimer);
+        noise_mat.m[0][1] += vcCamMatNoise(12, FP_ANGLE(600.0f), FP_ANGLE(1000.0f), vcSelfViewTimer);
+        noise_mat.m[0][2] += vcCamMatNoise(12, FP_ANGLE(600.0f), FP_ANGLE(800.0f), vcSelfViewTimer);
+        noise_mat.m[1][0] += vcCamMatNoise(12, FP_ANGLE(500.0f), FP_ANGLE(500.0f), vcSelfViewTimer);
+        noise_mat.m[1][1] += vcCamMatNoise(12, FP_ANGLE(900.0f), FP_ANGLE(400.0f), vcSelfViewTimer);
+        noise_mat.m[1][2] += vcCamMatNoise(12, FP_ANGLE(650.0f), FP_ANGLE(950.0f), vcSelfViewTimer);
         MulMatrix0(&w_p->cam_mat_98, &noise_mat, &noise_cam_mat);
 
         noise_cam_mat.t[0] = w_p->cam_mat_98.t[0];

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -1485,6 +1485,8 @@ void vcSetDataToVwSystem(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type) // 0x80085884
     {
         vcSelfViewTimer += g_DeltaTime0;
 
+        // TODO: in SH2 these FP_ANGLEs are using radian float values, while rest of SH2 used degrees.
+        // Maybe these are meant to be radians encoded as Q4.12 somehow, but haven't found a good way for it yet.
         noise_ang.vx = vcCamMatNoise(4, FP_ANGLE(500.0f), FP_ANGLE(800.0f), vcSelfViewTimer);
         noise_ang.vy = vcCamMatNoise(2, FP_ANGLE(400.0f), FP_ANGLE(1000.0f), vcSelfViewTimer);
         noise_ang.vz = 0;

--- a/src/bodyprog/view/vc_util.c
+++ b/src/bodyprog/view/vc_util.c
@@ -127,7 +127,7 @@ void vcMoveAndSetCamera(s32 in_connect_f, s32 change_debug_mode, s32 for_f, s32 
 
             vcSetSubjChara(&hr_p->position_18, hero_bottom_y, hero_top_y, grnd_y,
                            &hr_head_pos, hr_p->moveSpeed_38, hr_p->headingAngle_3C, hr_p->rotationSpeed_2C.vy, hr_p->rotation_24.vy,
-                           FP_ANGLE(7.5f), FP_METER(176.0f));
+                           FP_ANGLE(120.0f), FP_METER(176.0f));
 
             D_800BCE18.vcCameraInternalInfo_1BDC.mv_smooth = vcExecCamera();
             break;
@@ -147,7 +147,7 @@ void vcMoveAndSetCamera(s32 in_connect_f, s32 change_debug_mode, s32 for_f, s32 
             vcSetRefPosAndSysRef2CamParam(&vcRefPosSt, &g_SysWork, for_f, back_f, right_f, left_f, up_f, down_f);
             vwSetCoordRefAndEntou(&g_SysWork.playerBoneCoords_890[PlayerBone_Head],
                                   FP_METER(0.0f), FP_METER(-2.4f), FP_METER(16.0f),
-                                  FP_ANGLE(10.315f), FP_ANGLE(0.0f), FP_METER(-3.2f), FP_METER(16.0f));
+                                  FP_ANGLE(165.0f), FP_ANGLE(0.0f), FP_METER(-3.2f), FP_METER(16.0f));
             break;
     }
 
@@ -312,7 +312,7 @@ void vcSetRefPosAndCamPosAngByPad(VECTOR3* ref_pos, s_SysWork* sys_p) // 0x80040
                 var0 = -0x1A;
             }
 
-            var1 = var0 * shRsin(cam_ang.vy + FP_ANGLE(5.625f));
+            var1 = var0 * shRsin(cam_ang.vy + FP_ANGLE(90.0f));
             if (var1 < 0)
             {
                 var1 += 0xFFF;
@@ -320,7 +320,7 @@ void vcSetRefPosAndCamPosAngByPad(VECTOR3* ref_pos, s_SysWork* sys_p) // 0x80040
 
             vec0.vx += FP_FROM(var1, Q12_SHIFT);
 
-            var2 = var0 * shRcos(cam_ang.vy + FP_ANGLE(5.625f));
+            var2 = var0 * shRcos(cam_ang.vy + FP_ANGLE(90.0f));
             if (var2 < 0)
             {
                 var2 += 0xFFF;
@@ -346,7 +346,7 @@ void vcSetRefPosAndCamPosAngByPad(VECTOR3* ref_pos, s_SysWork* sys_p) // 0x80040
         ref_pos->vy = FP_TO(vec0.vy + vec1.vy, Q4_SHIFT);
         ref_pos->vz = FP_TO(vec0.vz + vec1.vz, Q4_SHIFT);
 
-        sys_p->cameraAngleY_237A   = shAngleRegulate(cam_ang.vy + FP_ANGLE(11.25f));
+        sys_p->cameraAngleY_237A   = shAngleRegulate(cam_ang.vy + FP_ANGLE(180.0f));
         sys_p->cameraY_2384        = FP_TO(-vec1.vy, Q4_SHIFT);
         sys_p->cameraRadiusXz_2380 = FP_TO(SquareRoot0(SQUARE(vec1.vx) + SQUARE(vec1.vz)), Q4_SHIFT);
     }

--- a/src/bodyprog/view/vw_calc.c
+++ b/src/bodyprog/view/vw_calc.c
@@ -103,12 +103,12 @@ void vwMatrixToAngleYXZ(SVECTOR* ang, MATRIX* mat) // 0x800495D4
     s32 r_xz = SquareRoot0((mat->m[0][2] * mat->m[0][2]) + (mat->m[2][2] * mat->m[2][2]));
     ang->vx  = ratan2(-mat->m[1][2], r_xz);
 
-    if (ang->vx == FP_ANGLE(5.625f))
+    if (ang->vx == FP_ANGLE(90.0f))
     {
         ang->vz = 0;
         ang->vy = ratan2(mat->m[0][1], mat->m[2][1]);
     }
-    else if (ang->vx == FP_ANGLE(-5.625f))
+    else if (ang->vx == FP_ANGLE(-90.0f))
     {
         ang->vz = 0;
         ang->vy = ratan2(-mat->m[0][1], -mat->m[2][1]);

--- a/src/bodyprog/view/vw_main.c
+++ b/src/bodyprog/view/vw_main.c
@@ -67,7 +67,7 @@ void vwSetCoordRefAndEntou(GsCOORDINATE2* parent_p, s32 ref_x, s32 ref_y, s32 re
     view_ang.vy = cam_ang_y;
     view_ang.vz = cam_ang_z;
     view_ang.vx = -ratan2(-cam_y, cam_xz_r);
-    view_ang.vy = (view_ang.vy + FP_ANGLE(11.25f)) & 0xFFF;
+    view_ang.vy = (view_ang.vy + FP_ANGLE(180.0f)) & 0xFFF;
 
     func_80096E78(&view_ang, view_mtx);
 

--- a/tools/maptool.py
+++ b/tools/maptool.py
@@ -449,7 +449,7 @@ def MapHeader_Read(filepath: str) -> MapHeader:
         chara_spawns = []
         for i in range(32):
             data = f.read(12)
-            posX, chara_type, rot, anim_flag, unk, posZ = struct.unpack("<i4bi", data)
+            posX, chara_type, rot, anim_flag, unk, posZ = struct.unpack("<ibBbbi", data)
                          
             # When chara_type is 0 chara ID is taken from the group section, group[0] if current spawn id is 15 or below, group[1] if 16 or above
             if chara_type == 0:

--- a/tools/maptool.py
+++ b/tools/maptool.py
@@ -410,10 +410,10 @@ MapBasePath = "assets/VIN/"
 
 @dataclass
 class CharaSpawn:
-    posX: float
-    posZ: float
+    positionX: float
+    positionZ: float
     chara_type: int
-    rot: int
+    rotationY: int
     anim_unchanged_flag: int
     unk: int
 
@@ -449,14 +449,14 @@ def MapHeader_Read(filepath: str) -> MapHeader:
         chara_spawns = []
         for i in range(32):
             data = f.read(12)
-            posX, chara_type, rot, anim_flag, unk, posZ = struct.unpack("<ibBbbi", data)
+            positionX, chara_type, rotationY, anim_flag, unk, positionZ = struct.unpack("<ibBbbi", data)
                          
             # When chara_type is 0 chara ID is taken from the group section, group[0] if current spawn id is 15 or below, group[1] if 16 or above
             if chara_type == 0:
                 chara_type = group[1] if i >= 16 else group[0]
             
             chara_spawns.append(
-                CharaSpawn(q20_12(posX), q20_12(posZ), chara_type, q4_12(16 * rot), anim_flag, unk)
+                CharaSpawn(q20_12(positionX), q20_12(positionZ), chara_type, q4_12(16 * rotationY), anim_flag, unk)
             )
 
         return MapHeader(update_funcs=update_funcs, group_charas=group, chara_spawns=chara_spawns)
@@ -489,12 +489,12 @@ def MapHeader_Print(map_header: MapHeader):
     if map_header.chara_spawns:
         print("charaSpawns_24C:")
         for index, spawn in enumerate(map_header.chara_spawns):
-            if spawn.anim_unchanged_flag != 0 or spawn.posX != 0 or spawn.posZ != 0 or spawn.rot != 0:
+            if spawn.anim_unchanged_flag != 0 or spawn.positionX != 0 or spawn.positionZ != 0 or spawn.rotationY != 0:
 
                 # func_80037F24 only seems to count as valid if anim_unchanged_flag != 0   
                 unused_text = "" if spawn.anim_unchanged_flag != 0 else " (flag == 0, slot unused?)"
                 print(f"  [{index:>2}] {charaName(spawn.chara_type)} = "
-                      f"({spawn.posX},{spawn.posZ}) rot {spawn.rot} "
+                      f"({spawn.positionX},{spawn.positionZ}) rotY {spawn.rotationY} "
                       f"flag 0x{spawn.anim_unchanged_flag:X} unk 0x{spawn.unk:X}{unused_text}")
                       
 def MapHeader_SearchForChara(charaId: int):

--- a/tools/maptool.py
+++ b/tools/maptool.py
@@ -442,7 +442,7 @@ def MapHeader_Read(filepath: str) -> MapHeader:
             update_funcs.append(value)
 
         f.seek(OFFSET_mapOverlayHeader + OFFSET_charaGroupIds)
-        data = f.read(2)
+        data = f.read(4)
         group = list(data)
 
         f.seek(OFFSET_mapOverlayHeader + OFFSET_charaSpawns)
@@ -472,7 +472,17 @@ def MapHeader_Print(map_header: MapHeader):
     if map_header.group_charas:
         print("charaGroupIds_248:")
         for index, charaId in enumerate(map_header.group_charas):
-            group_str = " 0 - 15: " if index == 0 else "16 - 31: "
+            if index == 0:
+                group_str = "  0 - 15: "
+            elif index == 1:
+                group_str = " 16 - 31: "
+            else:
+                if charaId == 0:
+                    continue # Skip empty extra entries
+                if index == 2:
+                    group_str = "Extra[2]: "
+                else:
+                    group_str = "Extra[3]: "
             print(f"  {group_str}{charaName(charaId)}")
         print()
 
@@ -494,7 +504,7 @@ def MapHeader_SearchForChara(charaId: int):
         if filename.lower().startswith("map") and filename.lower().endswith(".bin"):  # Only process .bin files
             map_header = MapHeader_Read(filename)
             if map_header is None:
-                continue
+                continue # Skip empty map files (mapT/mapX)
                 
             # Check if any spawns/updatefuncs/group are setup for this chara ID
             foundIn = ""


### PR DESCRIPTION
- Changes angles to Q4.12 used in @Sparagas SH1 templates, makes most of the angle values easier to understand (eg `1.875f` -> `30.0f`, also matched float value that SH2 used)

- Small fixup to maptool/SpawnInfo to use unsigned `rotationY`, fixes wrong angle being shown.