### PR TITLE
Q notations and renames

### DIFF
--- a/configs/sym.bodyprog.txt
+++ b/configs/sym.bodyprog.txt
@@ -11,7 +11,7 @@ g_GameWorkPtr1 = 0x80024D54; // type:u32 same as g_GameWorkPtr0?
 g_ObjectTable0 = 0x800A8F74; // type:s8
 g_ObjectTable1 = 0x800A8FC4; // type:s8
 
-g_DeltaTime0 = 0x800B5CC0; // type:s32 - Q20.12 fixed point, usually 0x44 (0.0166..) or 0x88 (0.033..).
+g_DeltaTime0 = 0x800B5CC0; // type:s32 - Q19.12 fixed point, usually 0x44 (0.0166..) or 0x88 (0.033..).
 g_DeltaTime1 = 0x800A8FEC; // type:s32
 g_DeltaTime2 = 0x800B9CC8; // type:s32
 g_MapEventIdx = 0x800A9A14; // type:u32

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -1038,12 +1038,12 @@ extern s_800AD4C8 D_800AD4C8[];
 
 typedef struct _SpawnInfo
 {
-    s32 positionX_0;
-    s8  chara_type_4;             /** `e_ShCharacterId` */
-    u8  rotationY_5; /** Multiplied by 16 to get `s_SubCharacter.rotation_24.vy` value. */
-    s8  flags_6; /** Copied to `isAnimStateUnchanged_3` in `s_Model`. */
-    s8  unk_7;
-    s32 positionZ_8;
+    q19_12 positionX_0;
+    s8     charaId_4;             /** `e_ShCharacterId` */
+    u8     rotationY_5; /** Multiplied by 16 to get `s_SubCharacter.rotation_24.vy` value. */
+    s8     flags_6; /** Copied to `isAnimStateUnchanged_3` in `s_Model`. */
+    s8     unk_7;
+    q19_12 positionZ_8;
 } s_SpawnInfo;
 STATIC_ASSERT_SIZEOF(s_SpawnInfo, 12);
 
@@ -1086,8 +1086,9 @@ typedef struct _MapOverlayHeader
     u8           unk_16C[4];
     u8           unk_170[36];
     void         (*charaUpdateFuncs_194[Chara_Count])(s_SubCharacter*, void*, s32); /** Guessed params. Funcptrs for each `e_ShCharacterId`, set to 0 for IDs not included in the map overlay. Called by `func_80038354`. */
-    u8           charaGroupIds_248[4]; /** `e_ShCharacterId` values used for charaSpawns with chara_type_4 == 0, [0] is used for charaSpawns[0:15], [1] for charaSpawns[16:31]. */
-    s_SpawnInfo  charaSpawns_24C[32]; /** Array of chara type/position/flags, flags_6 == 0 are unused slots?, read by `func_80037F24`. */
+    u8           charaGroupIds_248[4]; /** `e_ShCharacterId` values where if `s_SpawnInfo.charaId_4` == 0, `charaGroupIds_248[0]` is used for `charaSpawnsA_24C` and `charaGroupIds_248[1]` for `charaSpawnsB_30C`. */
+    s_SpawnInfo  charaSpawnsA_24C[16]; /** Array of chara type/position/flags, flags_6 == 0 are unused slots?, read by `func_80037F24`. */
+    s_SpawnInfo  charaSpawnsB_30C[16]; /** Array of chara type/position/flags, flags_6 == 0 are unused slots?, read by `func_80037F24`. */
     VC_ROAD_DATA roadDataList_3CC[48];
     // TODO: A lot more in here.
 } s_MapOverlayHeader;

--- a/include/bodyprog/math.h
+++ b/include/bodyprog/math.h
@@ -1,11 +1,9 @@
 #ifndef _BODYPROG_MATH_H
 #define _BODYPROG_MATH_H
 
-#define Q4_SHIFT       4         /** Used for: Q27.4 positions. */
-#define Q8_SHIFT       8         /** Used for: Q8.8 camera AABBs. Q24.8 meters. */
-#define Q12_SHIFT      12        /** Used for: Q3.12 alphas. Q19.12 timers, trigonometry. */
-#define SIN_LUT_SIZE   4096      /** Number of entries in the sine lookup table. */
-#define FP_ANGLE_COUNT (1 << 12) /** Number of fixed-point angles in Q4.12 format. */
+#define Q4_SHIFT  4  /** Used for: Q27.4 positions. */
+#define Q8_SHIFT  8  /** Used for: Q7.8 camera AABBs. Q23.8 meters. */
+#define Q12_SHIFT 12 /** Used for: Q3.12 alphas and angles, Q19.12 timers and trigonometry, number of entries in the sine lookup table.*/
 
 /** @brief Squares a value. */
 #define SQUARE(x) \
@@ -63,11 +61,11 @@
 #define FP_COLOR(val) \
     (u8)((val) * (FP_FLOAT_TO(1.0f, Q8_SHIFT) - 1))
 
-/** @brief Converts floating-point degrees to fixed-point angles in Q4.12 format. */
+/** @brief Converts floating-point degrees to fixed-point angles in Q3.12 format. */
 #define FP_ANGLE(deg) \
-    (s16)((deg) * ((FP_ANGLE_COUNT) / 360.0f))
+    (s16)((deg) * ((FP_TO(1, Q12_SHIFT)) / 360.0f))
 
-/** @brief Converts floating-point meters to fixed-point meters in Q24.8 format. */
+/** @brief Converts floating-point meters to fixed-point meters in Q23.8 format. */
 #define FP_METER(met) \
     FP_FLOAT_TO(met, Q8_SHIFT)
 

--- a/include/bodyprog/vw_system.h
+++ b/include/bodyprog/vw_system.h
@@ -91,7 +91,7 @@ typedef enum _THROUGH_DOOR_SET_CMD_TYPE
 } THROUGH_DOOR_SET_CMD_TYPE;
 STATIC_ASSERT_SIZEOF(THROUGH_DOOR_SET_CMD_TYPE, 4);
 
-/** @brief 2D camera-specific axis-aligned bounding box (AABB), with values in Q8.8 format.
+/** @brief 2D camera-specific axis-aligned bounding box (AABB), with values in Q7.8 format.
  * 
  * Constrains the camera position to a limited area on the XZ plane.
  */

--- a/include/game.h
+++ b/include/game.h
@@ -130,7 +130,7 @@ typedef enum _SysState
 /** @brief Inventory command IDs. */
 typedef enum _InventoryCommandId
 {
-    InventoryCommandId_UseHealth     = 0,
+    InventoryCommandId_UseHealth     = 0,  /** Text is "Use", but this one is used explusively on health items. */
     InventoryCommandId_Use           = 1,
     InventoryCommandId_Equip         = 2,
     InventoryCommandId_Unequip       = 3,
@@ -288,9 +288,9 @@ enum e_ShCharacterId
     Chara_Splithead           = 14,
     Chara_Floatstinger        = 15,
     Chara_PuppetNurse         = 16,
-    Chara_DummyA              = 17, /** Uses dummy anim file without model/texture, but uses same update funcptr as `Chara_PuppetNurse`. */
+    Chara_DummyNurse          = 17, /** Uses dummy anim file without model/texture, but uses same update funcptr as `Chara_PuppetNurse`. */
     Chara_PuppetDoctor        = 18,
-    Chara_DummyB              = 19, /** Uses dummy anim file without model/texture, but uses same update funcptr as `Chara_PuppetDoctor`. */
+    Chara_DummyDoctor         = 19, /** Uses dummy anim file without model/texture, but uses same update funcptr as `Chara_PuppetDoctor`. */
     Chara_Twinfeeler          = 20,
     Chara_Bloodsucker         = 21,
     Chara_Incubus             = 22,
@@ -314,7 +314,7 @@ enum e_ShCharacterId
     Chara_Flauros             = 40,
     Chara_LittleIncubus       = 41,
     Chara_GhostDoctor         = 42,
-    Chara_IntensiveCareUnit   = 43,
+    Chara_Parasite            = 43,
     Chara_Null                = 44,
 
     Chara_Count
@@ -405,47 +405,47 @@ typedef struct _ShSaveGame
     s_ShInventoryItem items_0[INVENTORY_ITEM_COUNT_MAX];
     s8                field_A0;
     s8                field_A1[3];
-    s8                mapOverlayIdx_A4;
-    s8                field_A5;
+    s8                mapOverlayIdx_A4;         /** Index to overlay `*.BIN` files. */
+    s8                mapRoomIdx_A5;            /** Index to local map geometry `*.IPD` files. */
     s16               saveGameCount_A6;
     s8                mapEventIdx_A8;          // See Sparagas' `SaveTitle` enum for details of every value.
-    u8                mapIdx_A9; 
-    s8                equippedWeapon_AA;       /** `InventoryItemId` */
+    u8                mapIdx_A9;                /** Index to global map geometry `*.PLM` files. */
+    s8                equippedWeapon_AA;        /** `InventoryItemId` */
     u8                field_AB;
     u32               flags_AC;
     s32               field_B0[45];
-    s32               hasMapsFlags_164;        // See Sparagas' `HasMapsFlags` struct for details of every bit.
-    s32               eventFlags_168[6];       //----------------------------------------
-    s32               field_180[2];            //
-    s32               field_188;               //
-    s32               field_18C;               // Only tested a few, but it seems all are related to events and pick-up flags, grouped by location and not item types.
-    s32               field_190[4];            //
-    s32               field_1A0;               //
-    s32               field_1A4[12];           //----------------------------------------
-    s32               mapFlags_1D4[2];         //----------------------------------------
-    s32               field_1DC;               // These 3 are one `u32 mapMarkingsFlags[25];` (or maybe `u8 mapMarkingsFlags[100];`?) See Sparagas' `MapMarkingsFlags` struct for details of every bit.
-    s32               field_1E0[22];           //----------------------------------------
+    s32               hasMapsFlags_164;         // See Sparagas' `HasMapsFlags` struct for details of every bit.
+    s32               eventFlags_168[6];        //----------------------------------------
+    s32               eventFlags_180[2];        //
+    s32               eventFlags_188;           //
+    s32               eventFlags_18C;           // Only tested a few, but it seems all are related to events and pick-up flags, grouped by location and not item types.
+    s32               eventFlags_190[4];        //
+    s32               eventFlags_1A0;           //
+    s32               eventFlags_1A4[12];       //----------------------------------------
+    s32               mapMarkingsFlags_1D4[2];  //----------------------------------------
+    s32               mapMarkingsFlags_1DC;     // These 3 are one `u32 mapMarkingsFlags[25];` (or maybe `u8 mapMarkingsFlags[100];`?) See Sparagas' `MapMarkingsFlags` struct for details of every bit.
+    s32               mapMarkingsFlags_1E0[22]; //----------------------------------------
     s32               field_238;
     s16               pickedUpItemCount_23C;
     s8                field_23E;
     s8                field_23F;
-    s32               playerHealth_240;        /** Q20.12, default: 100 */
-    s32               playerPositionX_244;     /** Q20.12 */
-    s16               playerRotationY_248;     /** Q4.12, Range [0, 0.999755859375], Positive Z: 0, clockwise rotation. It can be multiplied by 360 to get degrees. */
+    q19_12            playerHealth_240;         /** Default: 100 */
+    q19_12            playerPositionX_244;
+    q3_12             playerRotationY_248;      /** Range [0, 0.999755859375], Positive Z: 0, clockwise rotation. It can be multiplied by 360 to get degrees. */
     u8                field_24A;
     u8                field_24B;
-    s32               playerPositionZ_24C;     /** Q20.12 */
-    s32               gameplayTimer_250;       /** Q20.12 */
-    s32               runDistance_254;         /** Q20.12 */
-    s32               walkDistance_258;        /** Q20.12 */
-    s32               field_25C;
-    s32               field_260;               /** Packed data. Stores game difficulty and something else. Last byte is -16 on easy, 0 on normal, and 16 on hard. */
-    s16               firedShotCount_264;      /** Missed shot count = firedShotCount - (closeRangeShotCount + midRangeShotCount + longRangeShotCount). */
-    s16               closeRangeShotCount_266; /** Only hits counted. */
-    s16               midRangeShotCount_268;   /** Only hits counted. */
-    s16               longRangeShotCount_26A;  /** Only hits counted. */
+    q19_12            playerPositionZ_24C;
+    q19_12            gameplayTimer_250;
+    q19_12            runDistance_254;
+    q19_12            walkDistance_258;
+    s32               enemyKillCountPacked_25C; // Redo to `rangedKillCount : 8; meleeKillCount : 16; pad : 8` or `u8 pad; u16 meleeKillCount; s8 rangedKillCount;`.
+    s32               field_260;                /** Packed data. Stores game difficulty and something else. Last byte is -16 on easy, 0 on normal, and 16 on hard. */
+    s16               firedShotCount_264;       /** Missed shot count = firedShotCount - (closeRangeShotCount + midRangeShotCount + longRangeShotCount). */
+    s16               closeRangeShotCount_266;  /** Only hits counted. */
+    s16               midRangeShotCount_268;    /** Only hits counted. */
+    s16               longRangeShotCount_26A;   /** Only hits counted. */
     s16               field_26C;
-    s16               field_26E; // Related to enemy kills.
+    s16               field_26E;                // Related to enemy kills.
     s16               field_270;
     s16               field_272;
     s16               field_274;
@@ -488,9 +488,9 @@ typedef struct _ShSaveUserConfig
     s8                   optWalkRunCtrl_2B;         /** Normal: 0, Reverse: 1, default: Normal. */
     s8                   optAutoAiming_2C;          /** On: 0, Off: 1, default: On. */
     s8                   optBulletAdjust_2D;        /** x1-x6: Range [0, 5], default: x1. */
-    u16                  seenGameOverTips_2E[1];    /** Bitfield tracking seen game-over tips. Each bit corresponds to a tip index (0–15), set bits indicate seen tips. */
+    u16                  seenGameOverTips_2E[1];    /** Bitfield tracking seen game-over tips. Each bit corresponds to a tip index (0–14), set bits indicate seen tips. Resets after picking all 15. */
     s8                   unk_30[4];
-    u32                  unk_34[1];
+    u32                  palLanguageId[1];
 } s_ShSaveUserConfig;
 STATIC_ASSERT_SIZEOF(s_ShSaveUserConfig, 56);
 
@@ -565,7 +565,7 @@ STATIC_ASSERT_SIZEOF(s_ModelAnim, 20);
 
 typedef struct _Model
 {
-    s8 chara_type_0; /** `e_ShCharacterId` */
+    s8 charaId_0; /** `e_ShCharacterId` */
     u8 field_1;
     u8 field_2;
     u8 isAnimStateUnchanged_3; // Educated guess. In `s_MainCharacterExtra`, always 1, set to 0 for 1 tick when anim state appears to change.
@@ -577,9 +577,9 @@ STATIC_ASSERT_SIZEOF(s_Model, 24);
 typedef struct _SubCharacter
 {
     s_Model model_0;
-    VECTOR3 position_18;
-    SVECTOR rotation_24;
-    SVECTOR rotationSpeed_2C;
+    VECTOR3 position_18;       /** `Q19.12` */
+    SVECTOR rotation_24;       // maybe `SVECTOR3` instead of `SVECTOR` because 4rd field is a copy of the `.xy` field.
+    SVECTOR rotationSpeed_2C;  /** Range [-0x700, 0x700]. */
     s32     field_34;
     s32     moveSpeed_38;
     s16     headingAngle_3C;
@@ -588,7 +588,7 @@ typedef struct _SubCharacter
     s16     field_44;
     s8      unk_46[2];
     s8      unk_48[104];
-    s32     health_B0; // Bits 3-4 contain `s16` associated with player's rate of heavy breathing, always set to 6. Can't split into `s16`s? Maybe packed data.
+    q19_12  health_B0;
     s8      unk_B4[16];
     u16     dead_timer_C4; // Part of `shBattleInfo` struct in SH2, may use something similar here.
     u16     field_C6;
@@ -627,6 +627,7 @@ typedef struct _MainCharacterExtra
     s32     field_20; // Some kind of anim state related to current action (running, walking, sidestepping, etc.).
     s32     field_24; // Some kind of anim state related to current action (running, walking, sidestepping, etc.). Sometimes same as above, but not always.
     s8      field_28; // Forcefully setting to 1 opens options menu.
+    u8      pad_29[3];
 } s_MainCharacterExtra;
 STATIC_ASSERT_SIZEOF(s_MainCharacterExtra, 44);
 

--- a/include/types.h
+++ b/include/types.h
@@ -17,6 +17,9 @@ typedef unsigned short     u16;
 typedef unsigned int       u32;
 typedef unsigned long long u64;
 
+typedef signed short       q3_12;  // Q3.12 fixed-point
+typedef signed int         q19_12; // Q19.12 fixed-point
+
 #ifndef __cplusplus
 typedef enum { false, true } bool;
 #endif

--- a/src/bodyprog/bodyprog.c
+++ b/src/bodyprog/bodyprog.c
@@ -1234,12 +1234,12 @@ INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_80036420);
 
 s32 func_8003647C() // 0x8003647C
 {
-    return g_SaveGamePtr->field_A5 > g_MapOverlayHeader.field_8;
+    return g_SaveGamePtr->mapRoomIdx_A5 > g_MapOverlayHeader.field_8;
 }
 
 s32 func_80036498() // 80036498
 {
-    return !(g_SaveGamePtr->field_A5 > g_MapOverlayHeader.field_8);
+    return !(g_SaveGamePtr->mapRoomIdx_A5 > g_MapOverlayHeader.field_8);
 }
 
 INCLUDE_ASM("asm/bodyprog/nonmatchings/bodyprog", func_800364BC);

--- a/src/bodyprog/bodyprog_8004A87C.c
+++ b/src/bodyprog/bodyprog_8004A87C.c
@@ -961,7 +961,7 @@ static inline SaveGame_PlayerReset(s_ShSaveGame* save)
     save->walkDistance_258 = 0;
     save->pickedUpItemCount_23C = 0;
     save->field_24A = 0;
-    save->field_25C &= ~6;
+    save->enemyKillCountPacked_25C &= ~6; // Redo to `rangedKillCount : 8; meleeKillCount : 16; pad : 8` or `u8 pad; u16 meleeKillCount; s8 rangedKillCount;`.
 }
 
 void Game_SaveGameResetPlayer() // 0x8007E530

--- a/src/bodyprog/bodyprog_80085D78.c
+++ b/src/bodyprog/bodyprog_80085D78.c
@@ -644,7 +644,7 @@ void func_80086FE8(s32 arg0, s32 arg1, s32 arg2) // 0x80086FE8
         for (i = 0; i < NPC_COUNT_MAX; i++)
         {
             // NPC type is >=24 or health is 0.
-            if ((u32)((u8)g_SysWork.npcs_1A0[i].model_0.chara_type_0 - 1) >= 24 ||
+            if ((u32)((u8)g_SysWork.npcs_1A0[i].model_0.charaId_0 - 1) >= 24 ||
                 g_SysWork.npcs_1A0[i].health_B0 <= 0)
             {
                 continue;

--- a/src/bodyprog/view/vc_main.c
+++ b/src/bodyprog/view/vc_main.c
@@ -295,7 +295,7 @@ void vcSetAllNpcDeadTimer() // 0x8008123C
 
     for (chara = &g_SysWork.npcs_1A0[0]; chara < &g_SysWork.npcs_1A0[NPC_COUNT_MAX]; chara++)
     {
-        if (chara->model_0.chara_type_0 == 0)
+        if (chara->model_0.charaId_0 == 0)
         {
             continue;
         }
@@ -768,7 +768,7 @@ void vcSetNearestEnemyDataInVC_WORK(VC_WORK* w_p) // 0x80081D90
 
     for (sc_p = &g_SysWork.npcs_1A0[0]; sc_p < &g_SysWork.npcs_1A0[NPC_COUNT_MAX]; sc_p++)
     {
-        if ((((u8)sc_p->model_0.chara_type_0 - 2) < 0x17U) &&
+        if ((((u8)sc_p->model_0.charaId_0 - 2) < 0x17U) &&
             (sc_p->dead_timer_C4 <= FP_FLOAT_TO(ENEMY_MAX_DEAD_TIMER, Q12_SHIFT) || sc_p->health_B0 >= 0) &&
             !(sc_p->field_3E & (1 << 4))) // sc_p->battle(ShBattleInfo).status & 0x20 in SH2
         {
@@ -790,8 +790,8 @@ void vcSetNearestEnemyDataInVC_WORK(VC_WORK* w_p) // 0x80081D90
             }
 
             // TODO: Not sure how to move the `set_active_data_f = 1` part out of this if.
-            if (sc_p->model_0.chara_type_0 >= Chara_HangedScratcher ||
-                (set_active_data_f = 1, (sc_p->model_0.chara_type_0 < Chara_Stalker)))
+            if (sc_p->model_0.charaId_0 >= Chara_HangedScratcher ||
+                (set_active_data_f = 1, (sc_p->model_0.charaId_0 < Chara_Stalker)))
             {
                 set_active_data_f = 1;
                 if (sc_p->field_3E & (1 << 1)) // sc_p->battle(ShBattleInfo).status & 4 in SH2
@@ -1486,7 +1486,7 @@ void vcSetDataToVwSystem(VC_WORK* w_p, VC_CAM_MV_TYPE cam_mv_type) // 0x80085884
         vcSelfViewTimer += g_DeltaTime0;
 
         // TODO: in SH2 these FP_ANGLEs are using radian float values, while rest of SH2 used degrees.
-        // Maybe these are meant to be radians encoded as Q4.12 somehow, but haven't found a good way for it yet.
+        // Maybe these are meant to be radians encoded as Q3.12 somehow, but haven't found a good way for it yet.
         noise_ang.vx = vcCamMatNoise(4, FP_ANGLE(500.0f), FP_ANGLE(800.0f), vcSelfViewTimer);
         noise_ang.vy = vcCamMatNoise(2, FP_ANGLE(400.0f), FP_ANGLE(1000.0f), vcSelfViewTimer);
         noise_ang.vz = 0;

--- a/tools/maptool.py
+++ b/tools/maptool.py
@@ -50,9 +50,9 @@ e_ShCharacterId = [
     "Chara_Splithead",
     "Chara_Floatstinger",
     "Chara_PuppetNurse",
-    "Chara_DummyA",
+    "Chara_DummyNurse",
     "Chara_PuppetDoctor",
-    "Chara_DummyB",
+    "Chara_DummyDoctor",
     "Chara_Twinfeeler",
     "Chara_Bloodsucker",
     "Chara_Incubus",
@@ -76,7 +76,7 @@ e_ShCharacterId = [
     "Chara_Flauros",
     "Chara_LittleIncubus",
     "Chara_GhostDoctor",
-    "Chara_IntensiveCareUnit",
+    "Chara_Parasite",
     "Chara_Null"
 ]
 Chara_Count = 45
@@ -87,10 +87,10 @@ def charaName(i, includeNum: bool = True):
         return f"{i:>2} {charName}"
     return charName
 
-def q20_12(value):
+def q19_12(value):
     return round(value / 4096.0, 3)
     
-def q4_12(value):
+def q3_12(value):
     return round(value / 4096.0 * 360, 3)
 
 def count_lines_in_file(file_path):
@@ -412,7 +412,7 @@ MapBasePath = "assets/VIN/"
 class CharaSpawn:
     positionX: float
     positionZ: float
-    chara_type: int
+    charaId: int
     rotationY: int
     anim_unchanged_flag: int
     unk: int
@@ -449,14 +449,14 @@ def MapHeader_Read(filepath: str) -> MapHeader:
         chara_spawns = []
         for i in range(32):
             data = f.read(12)
-            positionX, chara_type, rotationY, anim_flag, unk, positionZ = struct.unpack("<ibBbbi", data)
+            positionX, charaId, rotationY, anim_flag, unk, positionZ = struct.unpack("<ibBbbi", data)
                          
-            # When chara_type is 0 chara ID is taken from the group section, group[0] if current spawn id is 15 or below, group[1] if 16 or above
-            if chara_type == 0:
-                chara_type = group[1] if i >= 16 else group[0]
+            # When charaId is 0 chara ID is taken from the group section, group[0] if current spawn id is 15 or below, group[1] if 16 or above
+            if charaId == 0:
+                charaId = group[1] if i >= 16 else group[0]
             
             chara_spawns.append(
-                CharaSpawn(q20_12(positionX), q20_12(positionZ), chara_type, q4_12(16 * rotationY), anim_flag, unk)
+                CharaSpawn(q19_12(positionX), q19_12(positionZ), charaId, q3_12(16 * rotationY), anim_flag, unk)
             )
 
         return MapHeader(update_funcs=update_funcs, group_charas=group, chara_spawns=chara_spawns)
@@ -493,7 +493,7 @@ def MapHeader_Print(map_header: MapHeader):
 
                 # func_80037F24 only seems to count as valid if anim_unchanged_flag != 0   
                 unused_text = "" if spawn.anim_unchanged_flag != 0 else " (flag == 0, slot unused?)"
-                print(f"  [{index:>2}] {charaName(spawn.chara_type)} = "
+                print(f"  [{index:>2}] {charaName(spawn.charaId)} = "
                       f"({spawn.positionX},{spawn.positionZ}) rotY {spawn.rotationY} "
                       f"flag 0x{spawn.anim_unchanged_flag:X} unk 0x{spawn.unk:X}{unused_text}")
                       
@@ -517,7 +517,7 @@ def MapHeader_SearchForChara(charaId: int):
                     foundIn += "charaGroupIds "
                     break
             for spawn in map_header.chara_spawns:
-                if spawn.chara_type == charaId:
+                if spawn.charaId == charaId:
                     foundIn += "charaSpawns "
                     break
             if foundIn:


### PR DESCRIPTION
- Rename all Q notations from ARM to TI style.
- Add two fixed-point `typedef`.
- Rename `chara_type_4` to `charaId_4`.
- Split `charaSpawnsA_24C[32]` to two `charaSpawnsA_24C[16]`, `charaSpawnsA_30C[16]` arrays.
- Remove `FP_ANGLE_COUNT` and change it to `(FP_TO(1, Q12_SHIFT))`
- Remove unused `SIN_LUT_SIZE` (if needed use `(FP_TO(1, Q12_SHIFT))` instead)
- Update `e_ShCharacterId` names.
- `_ShSaveGame`:
    - Rename `field_A5` to `mapRoomIdx_A5`.
    - Add description for `mapOverlayIdx_A4` and `mapIdx_A9`.
    - Rename a lot of fields to `eventFlags`. -Rename a lot of fields to `mapMarkingsFlags`.
    - Rename `field_25C` to `enemyKillCountPacked_25C`, but it needs to be split.
    - Rename several integer values to fixed-point typedefs.
- Fix `seenGameOverTips_2E` description.
- Rename `unk_34[1]` to `palLanguageId`.
- `s_Model`:
    - Rename `chara_type_0` to `charaId_0`
    - Add comments for vector types (possible issue: SVECTOR -> SVECTOR 3?)
    - Update `health_B0`.
    - Add alignment padding.

- Reflect the same changes to `maptool.py`.

Everything compiles correctly, and output overlays are identical to originals.