### PR TITLE
Unpack `sShSaveGame.enemyKillCountPacked_25C`

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -137,7 +137,7 @@ typedef enum _SysState
 /** @brief Inventory command IDs. */
 typedef enum _InventoryCommandId
 {
-    InventoryCommandId_UseHealth     = 0,  /** Text is "Use", but this one is used explusively on health items. */
+    InventoryCommandId_UseHealth     = 0,  /** Text is "Use", but this one is used exclusively on health items. */
     InventoryCommandId_Use           = 1,
     InventoryCommandId_Equip         = 2,
     InventoryCommandId_Unequip       = 3,
@@ -412,7 +412,7 @@ typedef enum _GameDifficulty
     GameDifficulty_Easy   = -1,
     GameDifficulty_Normal = 0,
     GameDifficulty_Hard	  = 1,
-    // TODO: Does this increase further on NG+?
+    // TODO: Does this increase further on NG+? No
 } e_GameDifficulty;
 
 typedef struct _ShSaveGame
@@ -446,14 +446,20 @@ typedef struct _ShSaveGame
     s8                field_23F;
     q19_12            playerHealth_240;         /** Default: 100 */
     q19_12            playerPositionX_244;
-    q3_12             playerRotationY_248;      /** Range [0, 0.999755859375], Positive Z: 0, clockwise rotation. It can be multiplied by 360 to get degrees. */
-    u8                field_24A;
+    q3_12             playerRotationY_248;      /** Range [0, 0.999755859375], positive Z: 0, clockwise rotation. It can be multiplied by 360 to get degrees. */
+    u8                clearGameCount_24A;       /** Range [0, 99]. */
     u8                field_24B;
     q19_12            playerPositionZ_24C;
-    q19_12            gameplayTimer_250;
+    q20_12            gameplayTimer_250;
     q19_12            runDistance_254;
     q19_12            walkDistance_258;
-    s32               enemyKillCountPacked_25C; // Redo to `rangedKillCount : 8; meleeKillCount : 16; pad : 8` or `u8 pad; u16 meleeKillCount; s8 rangedKillCount;`.
+    u8                isTitleYellowFlag_25C_0 : 1;  // Is title in save-load screen is yellow (next fear mode).
+    u8                add290Hours_25C_1       : 2;  // adds 290 hours per 1 bit. So 290, 580, 870
+    u8                unknwon_25C_3           : 3;
+    u8                hyperBlasterColor_25C_6 : 2;  // Red/None: 0, Yellow: 1, Green: 2, Rainbow: 4 (imposible to obtain)
+    u8                meleeKillCount_25D;
+    u8                meleeKillCountB_25E;          // can't be packed if used as `u16`
+    u8                rangedKillCount_25F;
     s32               field_260 : 28;
     s32               gameDifficulty_260 : 4;   /** `e_GameDifficulty`. */
     s16               firedShotCount_264;       /** Missed shot count = firedShotCount - (closeRangeShotCount + midRangeShotCount + longRangeShotCount). */
@@ -770,7 +776,7 @@ typedef struct _SysWork
     s8              pad_E30[400];  // Might be part of previous array for 5 exra coords which go unused.
     s8              unk_FC0[4800]; // Start is tightly-packed buffer for NPC bone coords. Size unclear, appears to be enough for 60 before what might be AI data.
     s8              unk_2280;
-    s8              field_2281; // Set by `Chara_PositionUpdateFromParams`.
+    s8              field_2281;    // Set by `Chara_PositionUpdateFromParams`.
     s8              field_2282;
     s8              unk_2283[7];
     u16             field_228A;

--- a/include/types.h
+++ b/include/types.h
@@ -19,6 +19,7 @@ typedef unsigned long long u64;
 
 typedef signed short       q3_12;  // Q3.12 fixed-point.
 typedef signed int         q19_12; // Q19.12 fixed-point.
+typedef unsigned int       q20_12; // Q20.12 fixed-point.
 
 #ifndef __cplusplus
 typedef enum { false, true } bool;

--- a/src/bodyprog/bodyprog_8004A87C.c
+++ b/src/bodyprog/bodyprog_8004A87C.c
@@ -131,7 +131,7 @@ s32 func_8004C45C() // 0x8004C45C
         }
 
         // Game completed with some condition met?
-        if (g_SaveGamePtr->field_24A != 0 && (g_SaveGamePtr->field_24B & (1 << 4)) != 0)
+        if (g_SaveGamePtr->clearGameCount_24A != 0 && (g_SaveGamePtr->field_24B & (1 << 4)) != 0)
         {
             return 1;
         }
@@ -970,8 +970,8 @@ static inline SaveGame_PlayerReset(s_ShSaveGame* save)
     save->runDistance_254 = 0;
     save->walkDistance_258 = 0;
     save->pickedUpItemCount_23C = 0;
-    save->field_24A = 0;
-    save->enemyKillCountPacked_25C &= ~6; // Redo to `rangedKillCount : 8; meleeKillCount : 16; pad : 8` or `u8 pad; u16 meleeKillCount; s8 rangedKillCount;`.
+    save->clearGameCount_24A = 0;
+    save->add290Hours_25C_1 = 0;
 }
 
 void Game_SaveGameResetPlayer() // 0x8007E530


### PR DESCRIPTION
Add `q20_12` typedef and use it on `s_ShSaveGame.gameplayTimer`.

Rename `s_ShSaveGame.field_24A` to
`s_ShSaveGame.clearGameCount_24A` (max is 99)

change `s32 enemyKillCountPacked_25C` to separate values. Looks like `unknwon_25C_3` is still used, and is not padding.

Side Note:
`meleeKillCount` is a weird one. Logically it should be the same size as `rangedKillCount`. But for some reason in the RAM it can be modified as `u16`. But it can't be packed as `u16`, because the struct will we bigger with added padding.

Need more research.

Also in the future all these 4 `u8` bit field values should be packed to a struct, because it is used again in save-load screen.