### PR TITLE
Add dockerized build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim-bookworm
+
+# Install packages with minimal overhead
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    make \
+    binutils-mips-linux-gnu \
+    cpp-mips-linux-gnu \
+    bchunk \
+    p7zip-full \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+WORKDIR /app

--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Build the Docker image
+docker build --platform linux/amd64 -f Dockerfile -t sh-decomp-buildenv .

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Check if a command was provided
+if [ $# -eq 0 ]; then
+    echo "Error: No command provided."
+    echo "Usage: $0 <command> (e.g., make, make clean)"
+    exit 1
+fi
+
+docker run --platform linux/amd64 -it --rm -v "$(pwd)":/app -w /app sh-decomp-buildenv "$@"


### PR DESCRIPTION
Added a Docker-based build environment to ensure consistent builds across platforms, including macOS/arm64, since the project includes `linux/amd64` binaries. The resulting Docker image is approximately 350MB in size.

# Changes:
- `Dockerfile`: based on `python:3.12-slim-bookworm` with all required dependencies installed
- `build_image.sh`: Builds the docker image
- `docker_run.sh`: Runs the container, mounts the project folder, and executes commands (e.g., make).

# Usage:
```
./build_image.sh
./docker_run.sh make setup
./docker_run.sh make
./docker_run.sh check
```