### PR TITLE
Matched func_800D2DAC (MAP0_S00)

### DIFF
--- a/src/maps/map0_s00/map0_s00.c
+++ b/src/maps/map0_s00/map0_s00.c
@@ -88,7 +88,34 @@ INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D23EC);
 
 #include "maps/shared/sharedFunc_800D2D84_0_s00.h" // 0x800D2D84
 
-INCLUDE_ASM("asm/maps/map0_s00/nonmatchings/map0_s00", func_800D2DAC);
+s32 func_800D2DAC()
+{
+    s32 var_v0;
+    s16 var_v0_2;
+    s_AnimInfo* temp_s0;
+    void (*temp_a0)(s_Model*, s_Skeleton*, GsCOORDINATE2*, s_AnimInfo*);
+    s32 base_ptr;
+    s32 offset;
+    s_Model* model_ptr = &g_SysWork.player_4C.chara_0.model_0;
+    
+    base_ptr = *(s32*)((char*)&g_MapOverlayHeader + 0x34);
+    offset = (model_ptr->anim_4.animIdx_0 * 0x10) - 0x4C0;
+    temp_s0 = (s_AnimInfo*)(base_ptr + offset);
+    temp_a0 = temp_s0->funcPtr_0;
+    if (temp_a0 == Anim_Update0) {
+        if (func_800449AC(model_ptr, temp_s0) > 0) {
+            return model_ptr->anim_4.keyframeIdx0_8 == temp_s0->keyframeIdx1_E;
+        } else {
+            return model_ptr->anim_4.keyframeIdx0_8 == temp_s0->keyframeIdx0_C;
+        }
+    }
+
+    if (temp_a0 == Anim_Update2) {
+        return -2;
+    } else {
+        return -1;
+    }
+}
 
 #include "maps/shared/sharedFunc_800D2E50_0_s00.h" // 0x800D2E50
 


### PR DESCRIPTION
```
make check      
mips-linux-gnu-cpp -P -MMD -MP -MT build/src/maps/map0_s00/map0_s00.i -MF build/src/maps/map0_s00/map0_s00.i.d -Iinclude -I build -Iinclude/psyq -D_LANGUAGE_C -DUSE_INCLUDE_ASM -P -MMD -MP -undef -Wall -lang-c -nostdinc -DMAP0_S00 -o build/src/maps/map0_s00/map0_s00.i src/maps/map0_s00/map0_s00.c
tools/gcc-2.8.1-psx/cc1 -O2 -G0 -mips1 -mcpu=3000 -w -funsigned-char -fpeephole -ffunction-cse -fpcc-struct-return -fcommon -fverbose-asm -msoft-float -mgas -fgnu-linker -quiet -o build/src/maps/map0_s00/map0_s00.c.s build/src/maps/map0_s00/map0_s00.i
python3 tools/maspsx/maspsx.py --aspsx-version=2.77 --run-assembler -EL -Iinclude -I build -Iinclude/psyq -O2 -G0 -march=r3000 -mtune=r3000 -no-pad-sections -o build/src/maps/map0_s00/map0_s00.c.o build/src/maps/map0_s00/map0_s00.c.s
mips-linux-gnu-objdump --disassemble-all --reloc --disassemble-zeroes -Mreg-names=32 build/src/maps/map0_s00/map0_s00.c.o > build/src/maps/map0_s00/map0_s00.c.dump.s
mips-linux-gnu-ld -EL -O2 -nostdlib --no-check-sections -Map build/out/VIN/MAP0_S00.BIN.map -T linkers/maps/map0_s00.ld -T linkers/maps/undefined_syms_auto.map0_s00.txt -T linkers/maps/undefined_funcs_auto.map0_s00.txt -o build/out/VIN/MAP0_S00.BIN.elf
mips-linux-gnu-objcopy -O binary build/out/VIN/MAP0_S00.BIN.elf build/out/VIN/MAP0_S00.BIN
build/out/SLUS_007.07: OK
build/out/1ST/BODYPROG.BIN: OK
build/out/VIN/STREAM.BIN: OK
build/out/1ST/B_KONAMI.BIN: OK
build/out/VIN/STF_ROLL.BIN: OK
build/out/VIN/OPTION.BIN: OK
build/out/VIN/SAVELOAD.BIN: OK
build/out/VIN/MAP0_S00.BIN: OK
build/out/VIN/MAP0_S01.BIN: OK
build/out/VIN/MAP0_S02.BIN: OK
build/out/VIN/MAP1_S00.BIN: OK
build/out/VIN/MAP1_S01.BIN: OK
build/out/VIN/MAP1_S02.BIN: OK
build/out/VIN/MAP1_S03.BIN: OK
build/out/VIN/MAP1_S04.BIN: OK
build/out/VIN/MAP1_S05.BIN: OK
build/out/VIN/MAP1_S06.BIN: OK
build/out/VIN/MAP2_S00.BIN: OK
build/out/VIN/MAP2_S01.BIN: OK
build/out/VIN/MAP2_S02.BIN: OK
build/out/VIN/MAP2_S03.BIN: OK
build/out/VIN/MAP2_S04.BIN: OK
build/out/VIN/MAP3_S00.BIN: OK
build/out/VIN/MAP3_S01.BIN: OK
build/out/VIN/MAP3_S02.BIN: OK
build/out/VIN/MAP3_S03.BIN: OK
build/out/VIN/MAP3_S04.BIN: OK
build/out/VIN/MAP3_S05.BIN: OK
build/out/VIN/MAP3_S06.BIN: OK
build/out/VIN/MAP4_S00.BIN: OK
build/out/VIN/MAP4_S01.BIN: OK
build/out/VIN/MAP4_S02.BIN: OK
build/out/VIN/MAP4_S03.BIN: OK
build/out/VIN/MAP4_S04.BIN: OK
build/out/VIN/MAP4_S05.BIN: OK
build/out/VIN/MAP4_S06.BIN: OK
build/out/VIN/MAP5_S00.BIN: OK
build/out/VIN/MAP5_S01.BIN: OK
build/out/VIN/MAP5_S02.BIN: OK
build/out/VIN/MAP5_S03.BIN: OK
build/out/VIN/MAP6_S00.BIN: OK
build/out/VIN/MAP6_S01.BIN: OK
build/out/VIN/MAP6_S02.BIN: OK
build/out/VIN/MAP6_S03.BIN: OK
build/out/VIN/MAP6_S04.BIN: OK
build/out/VIN/MAP6_S05.BIN: OK
build/out/VIN/MAP7_S00.BIN: OK
build/out/VIN/MAP7_S01.BIN: OK
build/out/VIN/MAP7_S02.BIN: OK
build/out/VIN/MAP7_S03.BIN: OK
```