### PR TITLE
readme: replace Psy-Q with bodyprog, remove Psy-Q from objdiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
         </tr>
         <tr>
             <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?category=engine"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=fuzzy_match&category=engine"/></a></td>
-            <td colspan=2>Main game logic</td>
+            <td colspan=2>Main game logic.</td>
         </tr>
         <tr>
             <th colspan=3>🎮 Game System Overlays 🎮</th>

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Purpose</td>
         </tr>
         <tr>
-            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?category=sdk"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=fuzzy_match&category=sdk"/></a></td>
-            <td colspan=2>Psy-Q libraries.</td>
+            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?category=engine"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=fuzzy_match&category=engine"/></a></td>
+            <td colspan=2>Main game logic</td>
         </tr>
         <tr>
             <th colspan=3>🎮 Game System Overlays 🎮</th>
@@ -44,17 +44,6 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
 <!-- Github incorrectly parses it if it's indented... -->
 <table>
     <tbody>
-        <tr>
-          <th colspan=3>🧟‍♂️⚔⚙🎮 BODYPROG.BIN 🎮⚙⚔🧟‍♂️</th>
-        </tr>
-        <tr>
-            <td>Progress</td>
-            <td colspan=2>Purpose</td>
-        </tr>
-        <tr>
-            <td align=center><a href="https://decomp.dev/Vatuu/silent-hill-decomp?category=engine"><img src="https://decomp.dev/Vatuu/silent-hill-decomp.svg?mode=shield&measure=fuzzy_match&category=engine"/></a></td>
-            <td colspan=2>Main game logic.</td>
-        </tr>
         <tr>
           <th colspan=3>👨‍💼 B_KONAMI.BIN 👨‍💼</th>
         </tr>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Progress bars powered by [decomp.dev](https://decomp.dev)
             <td colspan=2>Main executable.</td>
         </tr>
         <tr>
+            <th colspan=3>🧟‍♂️⚔⚙🎮 BODYPROG.BIN 🎮⚙⚔🧟‍♂️</th>
+        </tr>
+        <tr>
             <td>Progress</td>
             <td colspan=2>Purpose</td>
         </tr>

--- a/tools/objdiff/config.yaml
+++ b/tools/objdiff/config.yaml
@@ -3,10 +3,6 @@ categories:
     name: Engine
     paths:
       - bodyprog
-  - id: sdk
-    name: Psy-Q SDK
-    paths:
-      - main/psyq
   - id: main
     name: Main Executable
     paths:

--- a/tools/objdiff/config.yaml
+++ b/tools/objdiff/config.yaml
@@ -22,5 +22,6 @@ expected_paths:
 
 ignored_files:
   - main/header
+  - main/psyq/libsn/snmain
 
 output: ./objdiff.json


### PR DESCRIPTION
Removed Psy-Q decomp badge from the readme and from objdiff config, since the only Psy-Q thing remaining is the asm entrypoint code which can't be decompiled anyway.

I think having engine in its place in readme would be nicer since all the other overlays depend on that anyway, and we could see the progress for it without needing to expand it.
@IWILLCRAFT-M0d does this look fine to you? https://github.com/Vatuu/silent-hill-decomp/blob/c76b8b3e21cce387ed690269f8dcebbc5086f365/README.md

todo: need to make sure there's nothing else objdiff related which mentions Psy-Q too.

E: hm, I think the snmain.obj might still show up at https://decomp.dev/Vatuu/silent-hill-decomp?category=main after this though, not really sure how to remove that yet.