### PR TITLE
Use user in docker container, install some packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,27 @@
 FROM python:3.12-slim-bookworm
-
+ARG USERNAME=user
+ARG UID=1000
+ARG GID=1000
 # Install packages with minimal overhead
 RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
+    gcc \
     binutils-mips-linux-gnu \
     cpp-mips-linux-gnu \
     bchunk \
     p7zip-full \
+    progress \
+    sudo \
     && apt-get autoremove -y \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -g $GID $USERNAME \
+    && useradd -m -u $UID -g $GID -s /bin/bash $USERNAME \
+    && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
+USER $USERNAME
 WORKDIR /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ toml
 splat64[mips]>=0.33.2,<1.0.0
 clang-format
 clang-tidy
+pycparser


### PR DESCRIPTION
    Use user in docker container, install some packages

    Create a user with the id, group id and name of the host. This way
    the files produced by this container will be owned by the user.
    Otherwise all the files produced by the conainer would be owner
    by root which is annoying to work with.

    Install gcc (needed by permuter) and progress (needed by objdiff)
    Install pycparser (needed by permuter)