### PR TITLE
map0_s01: matched func_800D3814

### DIFF
--- a/include/bodyprog/math.h
+++ b/include/bodyprog/math.h
@@ -42,6 +42,10 @@
 #define ABS_DIFF(a, b) \
     ABS((a) - (b))
 
+/** @brief Computes the absolute value of a 32bit value by shifting. */
+#define ABS_32(x) \
+    ((x ^ (x >> 31)) - (x >> 31))
+
 /** @brief Checks if two values have different signs. */
 #define DIFF_SIGN(a, b) \
     (((a) >= 0 && (b) < 0) || ((a) < 0 && (b) >= 0))
@@ -105,10 +109,6 @@
 /** @brief Wraps fixed-point degrees in Q3.12 format to the range of a single turn. */
 #define FP_ANGLE_TRUNCATE(angle) \
     (((angle) << 20) >> 20)
-
-/** @brief Wraps fixed-point degrees in Q3.12 format to the range of a single turn and computes the absolute value. */
-#define FP_ANGLE_TRUNCATE_ABS(angle) \
-    ((FP_ANGLE_TRUNCATE(angle) ^ ((angle) >> 31)) - ((angle) >> 31))
 
 /** @brief Converts floating-point radians in the range `[-PI, PI]` to fixed-point radians in the range `[0, 0x5000]`. */
 #define FP_RADIAN(rad)                                                                \

--- a/include/maps/shared/sharedFunc_800D3814_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D3814_0_s01.h
@@ -1,0 +1,52 @@
+s32 sharedFunc_800D3814_0_s01(s_SubCharacter* chara)
+{
+    s32 angleFacingOffset;
+    s32 distResult;
+    s32 distProp8;
+
+    s32 angleTowards = func_80080478(&g_SysWork.player_4C.chara_0.position_18, &chara->position_18);
+    s32 playerFacing = g_SysWork.player_4C.chara_0.rotation_24.vy;
+    s32 distInverse = FP_METER(8.0f) - Math_Distance2d(&g_SysWork.player_4C.chara_0.position_18, &chara->position_18);
+    if (distInverse < 0)
+    {
+        distInverse = 0;
+    }
+    else
+    {
+        distInverse = distInverse >> 3;
+    }
+
+    angleFacingOffset = ABS_32(FP_ANGLE_TRUNCATE(angleTowards - playerFacing));
+
+    if (distInverse >= angleFacingOffset)
+    {
+        distResult = (distInverse - angleFacingOffset) * 4;
+    }
+    else
+    {
+        distResult = 0;
+    }
+    
+    if (D_800C457E != 0)
+    {
+        distProp8 = func_8007FD2C(distInverse);
+        if (distProp8 > FP_METER(2.0))
+        {
+            distResult += FP_METER(2.0);
+        }
+        else
+        {
+            distResult += distProp8;
+        }
+
+        if (chara == &g_SysWork.npcs_1A0[g_SysWork.field_2353])
+        {
+            distResult += FP_METER(1.0);
+        }
+    }
+    else
+    {
+        distResult += FP_METER(0.5);
+    }
+    return distResult;
+}

--- a/src/maps/map0_s01/map0_s01.c
+++ b/src/maps/map0_s01/map0_s01.c
@@ -147,7 +147,7 @@ INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", sharedFunc_800D3508_0_s01
 
 #include "maps/shared/sharedFunc_800D3758_0_s01.h" // 0x800D3758
 
-INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", sharedFunc_800D3814_0_s01); // 0x800D3814
+#include "maps/shared/sharedFunc_800D3814_0_s01.h" // 0x800D3814
 
 INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", sharedFunc_800D3928_0_s01); // 0x800D3928
 

--- a/src/maps/map2_s00/map2_s00.c
+++ b/src/maps/map2_s00/map2_s00.c
@@ -136,7 +136,7 @@ INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", sharedFunc_800D3508_0_s01
 
 #include "maps/shared/sharedFunc_800D3758_0_s01.h" // 0x800D3534
 
-INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", sharedFunc_800D3814_0_s01); // 0x800D35F0
+#include "maps/shared/sharedFunc_800D3814_0_s01.h" // 0x800D35F0
 
 INCLUDE_ASM("asm/maps/map2_s00/nonmatchings/map2_s00", sharedFunc_800D3928_0_s01); // 0x800D3704
 

--- a/src/maps/map2_s02/map2_s02.c
+++ b/src/maps/map2_s02/map2_s02.c
@@ -139,7 +139,7 @@ INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", sharedFunc_800D3508_0_s01
 
 #include "maps/shared/sharedFunc_800D3758_0_s01.h" // 0x800D1D1C
 
-INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", sharedFunc_800D3814_0_s01); // 0x800D1DD8
+#include "maps/shared/sharedFunc_800D3814_0_s01.h" // 0x800D1DD8
 
 INCLUDE_ASM("asm/maps/map2_s02/nonmatchings/map2_s02", sharedFunc_800D3928_0_s01); // 0x800D1EEC
 

--- a/src/maps/map4_s02/map4_s02.c
+++ b/src/maps/map4_s02/map4_s02.c
@@ -143,7 +143,7 @@ INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", sharedFunc_800D3508_0_s01
 
 #include "maps/shared/sharedFunc_800D3758_0_s01.h" // 0x800D2118
 
-INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", sharedFunc_800D3814_0_s01); // 0x800D21D4
+#include "maps/shared/sharedFunc_800D3814_0_s01.h" // 0x800D21D4
 
 INCLUDE_ASM("asm/maps/map4_s02/nonmatchings/map4_s02", sharedFunc_800D3928_0_s01); // 0x800D22E8
 

--- a/src/maps/map5_s01/map5_s01.c
+++ b/src/maps/map5_s01/map5_s01.c
@@ -165,7 +165,7 @@ INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", sharedFunc_800D3508_0_s01
 
 #include "maps/shared/sharedFunc_800D3758_0_s01.h" // 0x800D3850
 
-INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", sharedFunc_800D3814_0_s01); // 0x800D390C
+#include "maps/shared/sharedFunc_800D3814_0_s01.h" // 0x800D390C
 
 INCLUDE_ASM("asm/maps/map5_s01/nonmatchings/map5_s01", sharedFunc_800D3928_0_s01); // 0x800D3A20
 

--- a/src/maps/map6_s00/map6_s00.c
+++ b/src/maps/map6_s00/map6_s00.c
@@ -143,7 +143,7 @@ INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", sharedFunc_800D3508_0_s01
 
 #include "maps/shared/sharedFunc_800D3758_0_s01.h" // 0x800D2EF0
 
-INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", sharedFunc_800D3814_0_s01); // 0x800D2FAC
+#include "maps/shared/sharedFunc_800D3814_0_s01.h" // 0x800D2FAC
 
 INCLUDE_ASM("asm/maps/map6_s00/nonmatchings/map6_s00", sharedFunc_800D3928_0_s01); // 0x800D30C0
 


### PR DESCRIPTION
@Sezzary I walked back `FP_ANGLE_TRUNCATE_ABS()` - it stopped matching when I moved it from an inline method to a define

I've replaced it with `ABS_32(x)` ...feel free to call it something else, maybe `ABS_SHIFT_32(x)` or `ABS_SHIFT(x, 32)`?

The ASM for it is just `Math_PreservedSignSubtract()` but without being a function

There are only two uses (`func_800D3814` and `func_800D4E84` of the ASM pattern but it seems too clunky to not wrap it in a macro