### PR TITLE
SHARED_FUNC_IMPL guard in shared function headers

### DIFF
--- a/include/maps/shared/sharedFunc_800CBBBC_0_s00.h
+++ b/include/maps/shared/sharedFunc_800CBBBC_0_s00.h
@@ -1,4 +1,5 @@
 bool sharedFunc_800CBBBC_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     s32 dist;
     s32 var_v1;
@@ -15,3 +16,6 @@ bool sharedFunc_800CBBBC_0_s00()
 
     return false;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800CDA88_3_s03.h
+++ b/include/maps/shared/sharedFunc_800CDA88_3_s03.h
@@ -1,7 +1,11 @@
 void sharedFunc_800CDA88_3_s03(s_SubCharacter* arg0)
+#ifdef SHARED_FUNC_IMPL
 {
     if (arg0->model_0.stateStep_3 == 0)
     {
         Ai_PuppetNurse_Control(arg0);
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800CDAA8_0_s02.h
+++ b/include/maps/shared/sharedFunc_800CDAA8_0_s02.h
@@ -1,6 +1,7 @@
 #include "bodyprog/player_logic.h"
 
 void sharedFunc_800CDAA8_0_s02(s_SubCharacter* playerChara, s_MainCharacterExtra* extra, GsCOORDINATE2* coord)
+#ifdef SHARED_FUNC_IMPL
 {
     s_func_800699F8 sp10;
     s32             sp20;
@@ -122,3 +123,6 @@ void sharedFunc_800CDAA8_0_s02(s_SubCharacter* playerChara, s_MainCharacterExtra
     coord->flg = 0;
     func_80096E78(&playerChara->rotation_24, &coord->coord);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800CE59C_0_s01.h
+++ b/include/maps/shared/sharedFunc_800CE59C_0_s01.h
@@ -1,4 +1,3 @@
-
 // TODO: Refine comments and names, it's still kind of unclear.
 /** @brief Spawns snow particles. Called once when the map overlay is loaded.
  *
@@ -28,6 +27,7 @@
  * }
  */
 void sharedFunc_800CE59C_0_s01(s_Particle* parts)
+#ifdef SHARED_FUNC_IMPL
 {
     #define SNOW_COUNT_MAX       300
     #define SNOW_SPAWN_COUNT_MAX 150
@@ -155,3 +155,6 @@ void sharedFunc_800CE59C_0_s01(s_Particle* parts)
         }
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800CECFC_3_s02.h
+++ b/include/maps/shared/sharedFunc_800CECFC_3_s02.h
@@ -1,4 +1,5 @@
 void sharedFunc_800CECFC_3_s02(s_SubCharacter* chara, s32 arg1, GsCOORDINATE2* coord)
+#ifdef SHARED_FUNC_IMPL
 {
     if (chara->properties_E4.player.properties_E4[3] == 0)
     {
@@ -6,3 +7,6 @@ void sharedFunc_800CECFC_3_s02(s_SubCharacter* chara, s32 arg1, GsCOORDINATE2* c
         animInfo->funcPtr_0(chara, arg1, coord, animInfo);
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800CED44_3_s02.h
+++ b/include/maps/shared/sharedFunc_800CED44_3_s02.h
@@ -1,4 +1,5 @@
 void sharedFunc_800CED44_3_s02(s_SubCharacter* chara, GsCOORDINATE2* coord)
+#ifdef SHARED_FUNC_IMPL
 {
     VECTOR3 unused;
     VECTOR3 vec;
@@ -30,3 +31,6 @@ void sharedFunc_800CED44_3_s02(s_SubCharacter* chara, GsCOORDINATE2* coord)
     coord->coord.t[1] = FP_FROM(chara->position_18.vy, Q4_SHIFT);
     coord->coord.t[2] = FP_FROM(chara->position_18.vz, Q4_SHIFT);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800CEFD0_1_s02.h
+++ b/include/maps/shared/sharedFunc_800CEFD0_1_s02.h
@@ -1,4 +1,5 @@
 void sharedFunc_800CEFD0_1_s02(s32 arg0, s_sharedFunc_800CEFD0_1_s02* arg1, u16* arg2, s32* deltaTime)
+#ifdef SHARED_FUNC_IMPL
 {
     s_func_800699F8              sp10;
     s32                          temp_v1;
@@ -83,3 +84,6 @@ void sharedFunc_800CEFD0_1_s02(s32 arg0, s_sharedFunc_800CEFD0_1_s02* arg1, u16*
         }
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800CF290_3_s00.h
+++ b/include/maps/shared/sharedFunc_800CF290_3_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800CF290_3_s00(s_SubCharacter* chara, s32 arg1, GsCOORDINATE2* coord)
+#ifdef SHARED_FUNC_IMPL
 {
     if (chara->properties_E4.player.properties_E4[3] == 0)
     {
@@ -6,3 +7,6 @@ void sharedFunc_800CF290_3_s00(s_SubCharacter* chara, s32 arg1, GsCOORDINATE2* c
         animInfo->funcPtr_0(chara, arg1, coord, animInfo);
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800CF2A4_0_s01.h
+++ b/include/maps/shared/sharedFunc_800CF2A4_0_s01.h
@@ -1,5 +1,6 @@
 /** @brief Adds a random offset to a snow particle movement vector. Moves particle vertically, clamps Y to 0. */
 void sharedFunc_800CF2A4_0_s01(s32 arg0, s_Particle* part, u16* rand, s32* deltaTime)
+#ifdef SHARED_FUNC_IMPL
 {
     u16      localRand;
     VECTOR3* pos;
@@ -35,3 +36,6 @@ void sharedFunc_800CF2A4_0_s01(s32 arg0, s_Particle* part, u16* rand, s32* delta
     // Needed for match.
     if (pos->vy >= 0) {}
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800CF2D8_3_s00.h
+++ b/include/maps/shared/sharedFunc_800CF2D8_3_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800CF2D8_3_s00(s_SubCharacter* chara, GsCOORDINATE2* coord)
+#ifdef SHARED_FUNC_IMPL
 {
     VECTOR3 unused;
     VECTOR3 vec;
@@ -30,3 +31,6 @@ void sharedFunc_800CF2D8_3_s00(s_SubCharacter* chara, GsCOORDINATE2* coord)
     coord->coord.t[1] = FP_FROM(chara->position_18.vy, Q4_SHIFT);
     coord->coord.t[2] = FP_FROM(chara->position_18.vz, Q4_SHIFT);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800CF9A8_0_s01.h
+++ b/include/maps/shared/sharedFunc_800CF9A8_0_s01.h
@@ -1,5 +1,6 @@
 /** @brief Reset function for a snow particle */
 void sharedFunc_800CF9A8_0_s01(s32 arg0, s_Particle* part, u16* rand)
+#ifdef SHARED_FUNC_IMPL
 {
     #define SNOW_XZ_SPAWN_RANGE 5
     #define SNOW_Y_START_SPEED  100
@@ -39,3 +40,6 @@ void sharedFunc_800CF9A8_0_s01(s32 arg0, s_Particle* part, u16* rand)
     // Step to active state.
     part->stateStep_1E++;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800CFFF8_0_s00.h
+++ b/include/maps/shared/sharedFunc_800CFFF8_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800CFFF8_0_s00(s32 arg0, s_func_800CFFF8* arg1)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 absX;
     s32 threshold;
@@ -37,3 +38,6 @@ void sharedFunc_800CFFF8_0_s00(s32 arg0, s_func_800CFFF8* arg1)
         arg1->field_C.vz = arg1->field_0.vz;
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D01BC_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D01BC_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D01BC_0_s00(u16* arg0, VECTOR3* arg1, s32 arg2)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 temp_a0;
     s32 temp_s3;
@@ -9,3 +10,6 @@ void sharedFunc_800D01BC_0_s00(u16* arg0, VECTOR3* arg1, s32 arg2)
     temp_s3  = FP_TO(arg2, Q12_SHIFT) - abs(temp_s3);
     arg1->vz = ((*arg0 % temp_s3) + ((s32)Rng_Rand16(temp_a0) % temp_s3)) - temp_s3;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D0700_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D0700_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D0700_0_s00(VECTOR3* point, VECTOR3* lineStart, VECTOR3* lineEnd, s32 flag)
+#ifdef SHARED_FUNC_IMPL
 {
     VECTOR3 offset0;
     VECTOR3 offset1;
@@ -121,3 +122,6 @@ void sharedFunc_800D0700_0_s00(VECTOR3* point, VECTOR3* lineStart, VECTOR3* line
     point->vx -= sharedData_800E323C_0_s00.vx;
     point->vz -= sharedData_800E323C_0_s00.vz;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D08B8_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D08B8_0_s00.h
@@ -5,6 +5,7 @@
 #endif
 
 void sharedFunc_800D08B8_0_s00(s8 arg0, u32 arg1)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 temp_a1;
     s32 shiftAmt;
@@ -94,6 +95,9 @@ void sharedFunc_800D08B8_0_s00(s8 arg0, u32 arg1)
     sharedData_800E0CA8_0_s00 = var_s1;
     sharedData_800E0CAC_0_s00 = var_s0;
 }
+#else
+;
+#endif
 
 #ifdef SET_800E32D0
 #undef SET_800E32D0

--- a/include/maps/shared/sharedFunc_800D0944_3_s04.h
+++ b/include/maps/shared/sharedFunc_800D0944_3_s04.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D0944_3_s04(s_SubCharacter* chara, GsCOORDINATE2* coord)
+#ifdef SHARED_FUNC_IMPL
 {
     VECTOR3 unused;
     VECTOR3 vec;
@@ -30,3 +31,6 @@ void sharedFunc_800D0944_3_s04(s_SubCharacter* chara, GsCOORDINATE2* coord)
     coord->coord.t[1] = FP_FROM(chara->position_18.vy, Q4_SHIFT);
     coord->coord.t[2] = FP_FROM(chara->position_18.vz, Q4_SHIFT);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D0968_3_s03.h
+++ b/include/maps/shared/sharedFunc_800D0968_3_s03.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D0968_3_s03(s_SubCharacter* chara, GsCOORDINATE2* coords)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 posY;
 
@@ -15,3 +16,6 @@ void sharedFunc_800D0968_3_s03(s_SubCharacter* chara, GsCOORDINATE2* coords)
     chara->field_C8 = posY - FP_METER(1.7f);
     chara->field_CE = posY - FP_METER(1.0f);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D0994_3_s00.h
+++ b/include/maps/shared/sharedFunc_800D0994_3_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D0994_3_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     #define TEST_FLAG       (1 << 7)
     #define OVERLAY_VAL_ON  0x10
@@ -9,3 +10,6 @@ void sharedFunc_800D0994_3_s00()
     mapOverlayVal = ((g_SavegamePtr->eventFlags_18C & TEST_FLAG) == 0) ? OVERLAY_VAL_OFF : OVERLAY_VAL_ON;
     func_8003640C(mapOverlayVal);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D09D4_3_s00.h
+++ b/include/maps/shared/sharedFunc_800D09D4_3_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D09D4_3_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     s32         flags;
     s32         var;
@@ -85,3 +86,6 @@ void sharedFunc_800D09D4_3_s00()
 
     func_80035F4C(flags, var, NULL);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D0A60_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D0A60_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D0A60_0_s00(s32 caseArg)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 var0;
     s32 var1;
@@ -49,3 +50,6 @@ void sharedFunc_800D0A60_0_s00(s32 caseArg)
     sharedData_800E0CB0_0_s00 = (u16)sharedData_800E0CB0_0_s00 | ((var0 | (var1 * 16) | (var2 << 8)) << 16);
     sharedData_800E0CB8_0_s00 = (sharedData_800E0CB8_0_s00 & 0xF) | ((sharedData_800E0CB0_0_s00 >> 12) & 0x1110);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D0B18_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D0B18_0_s00.h
@@ -1,4 +1,5 @@
 bool sharedFunc_800D0B18_0_s00(s32 arg0)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 temp_a0_2;
     u16 temp;
@@ -93,3 +94,6 @@ bool sharedFunc_800D0B18_0_s00(s32 arg0)
 
     return false;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D0CB8_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D0CB8_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D0CB8_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     u8 unkValDiv4;
 
@@ -39,3 +40,6 @@ void sharedFunc_800D0CB8_0_s00()
             }
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D0E04_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D0E04_0_s00.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D0E04_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     func_8004690C(Sfx_Unk1360);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D0E20_3_s03.h
+++ b/include/maps/shared/sharedFunc_800D0E20_3_s03.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D0E20_3_s03(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     chara->model_0.anim_4.time_4 = FP_FLOAT_TO(81.0f, Q12_SHIFT) + chara->properties_E4.larvalStalker.properties_E8[0].val32;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D0E80_3_s03.h
+++ b/include/maps/shared/sharedFunc_800D0E80_3_s03.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D0E80_3_s03(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     if (chara->model_0.anim_4.animIdx_0 == ((chara->model_0.stateStep_3 * 2) + 23))
     {
@@ -12,3 +13,6 @@ void sharedFunc_800D0E80_3_s03(s_SubCharacter* chara)
 
     chara->properties_E4.larvalStalker.properties_E8[2].val32 = FP_FLOAT_TO(1.0f, Q12_SHIFT);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D209C_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D209C_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D209C_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     g_SysWork.playerCombatInfo_38.equippedWeapon_F = NO_VALUE;
     g_SavegamePtr->equippedWeapon_AA               = InventoryItemId_Unequipped;
@@ -6,3 +7,6 @@ void sharedFunc_800D209C_0_s00()
     sharedFunc_800D20E4_0_s00();
     sharedFunc_800D2C7C_0_s00(84);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D20D8_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D20D8_0_s00.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D20D8_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     g_SysWork.field_2358 = 0;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D20E4_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D20E4_0_s00.h
@@ -1,4 +1,5 @@
 #include <bodyprog/player_logic.h>
+#ifdef SHARED_FUNC_IMPL
 
 void sharedFunc_800D20E4_0_s00()
 {
@@ -60,3 +61,6 @@ void sharedFunc_800D20E4_0_s00()
         sysWork->playerCombatInfo_38.equippedWeapon_F %= 10;
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2244_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D2244_0_s00.h
@@ -1,4 +1,5 @@
 #include <bodyprog/player_logic.h>
+#ifdef SHARED_FUNC_IMPL
 
 void sharedFunc_800D2244_0_s00(s32 arg0)
 {
@@ -91,3 +92,6 @@ void sharedFunc_800D2244_0_s00(s32 arg0)
     D_800AF212 = 0;
 #endif
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2BF4_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D2BF4_0_s01.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D2BF4_0_s01(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     ModelAnim_AnimInfoSet(&chara->model_0.anim_4, &sharedData_800CAA98_0_s01.animInfo_0);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2C7C_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D2C7C_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D2C7C_0_s00(s32 arg0)
+#ifdef SHARED_FUNC_IMPL
 {
     s_MainCharacterExtra* extra = &g_SysWork.player_4C.extra_128;
     s_SubCharacter*       chara = &g_SysWork.player_4C.chara_0;
@@ -40,3 +41,6 @@ void sharedFunc_800D2C7C_0_s00(s32 arg0)
     g_SysWork.player_4C.extra_128.field_20 = 0;
     g_SysWork.player_4C.extra_128.field_24 = 0;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2D2C_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D2D2C_0_s00.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D2D2C_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     D_800C4606++;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2D44_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D2D44_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D2D44_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     s_MainCharacterExtra* extra = &g_SysWork.player_4C.extra_128;
     s_SubCharacter*       chara = &g_SysWork.player_4C.chara_0;
@@ -9,3 +10,6 @@ void sharedFunc_800D2D44_0_s00()
     extra->model_0.anim_4.flags_2 &= ~AnimFlag_Unk1;
     chara->model_0.anim_4.flags_2 &= ~AnimFlag_Unk1;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2D6C_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D2D6C_0_s00.h
@@ -1,4 +1,8 @@
 s32 sharedFunc_800D2D6C_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     return ~(g_SysWork.player_4C.chara_0.model_0.anim_4.flags_2 & AnimFlag_Unk1);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2D84_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D2D84_0_s00.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D2D84_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     Player_AnimFlag_Set(AnimFlag_Unk1);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2DAC_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D2DAC_0_s00.h
@@ -1,4 +1,5 @@
 s32 sharedFunc_800D2DAC_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     s_Model*    playerModel = &g_SysWork.player_4C.chara_0.model_0;
     s_AnimInfo* animInfo    = &g_MapOverlayHeader.animInfo_34[playerModel->anim_4.animIdx_0 - 76];
@@ -24,3 +25,6 @@ s32 sharedFunc_800D2DAC_0_s00()
         return -1;
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2E04_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D2E04_0_s01.h
@@ -1,4 +1,5 @@
 bool sharedFunc_800D2E04_0_s01(s_SubCharacter* chara, VECTOR3* inVec, s32* outDist, s32* outAngle)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 tmp;
     u8  idxInfo;
@@ -42,3 +43,6 @@ bool sharedFunc_800D2E04_0_s01(s_SubCharacter* chara, VECTOR3* inVec, s32* outDi
 
     return false;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2E50_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D2E50_0_s00.h
@@ -1,4 +1,8 @@
 s32 sharedFunc_800D2E50_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     return g_SysWork.player_4C.chara_0.properties_E4.player.field_126 == 0;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2E60_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D2E60_0_s00.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D2E60_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     g_SysWork.player_4C.chara_0.properties_E4.player.field_126 = 0;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2EA4_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D2EA4_0_s00.h
@@ -1,4 +1,8 @@
 u8 sharedFunc_800D2EA4_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     return g_SysWork.player_4C.chara_0.properties_E4.player.field_10D;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2EB4_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D2EB4_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D2EB4_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     u8 prevVar;
 
@@ -10,3 +11,6 @@ void sharedFunc_800D2EB4_0_s00()
 
     func_8003DD80(1, 17);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D2EF4_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D2EF4_0_s00.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D2EF4_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     g_SysWork.playerCombatInfo_38.equippedWeapon_F = sharedData_800DD59C_0_s00;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D3430_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D3430_0_s01.h
@@ -1,4 +1,5 @@
 s32 sharedFunc_800D3430_0_s01(s_SubCharacter* chara, s32* arg1, s32* arg2)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 ret;
 
@@ -24,3 +25,6 @@ s32 sharedFunc_800D3430_0_s01(s_SubCharacter* chara, s32* arg1, s32* arg2)
 
     return ret;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D3630_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D3630_0_s01.h
@@ -1,4 +1,5 @@
 s32 sharedFunc_800D3630_0_s01(s_SubCharacter* chara, s32* arg1)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 ret;
     s32 angle;
@@ -28,3 +29,6 @@ s32 sharedFunc_800D3630_0_s01(s_SubCharacter* chara, s32* arg1)
 
     return ret;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D3758_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D3758_0_s01.h
@@ -1,4 +1,5 @@
 s32 sharedFunc_800D3758_0_s01(s_SubCharacter* chara, s32* outDist, s32* outAngle, s32 arg3, s32 arg4)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 temp_a0;
     s32 temp_s2;
@@ -28,3 +29,6 @@ s32 sharedFunc_800D3758_0_s01(s_SubCharacter* chara, s32* outDist, s32* outAngle
     return var_v1 | (temp_a0 != 0);
 }
 
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D3814_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D3814_0_s01.h
@@ -1,4 +1,5 @@
 s32 sharedFunc_800D3814_0_s01(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 headingAngleDelta;
     s32 invDist;
@@ -54,3 +55,6 @@ s32 sharedFunc_800D3814_0_s01(s_SubCharacter* chara)
 
     return dist;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D4A74_7_s01.h
+++ b/include/maps/shared/sharedFunc_800D4A74_7_s01.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D4A74_7_s01(s_SubCharacter* chara, GsCOORDINATE2* coord)
+#ifdef SHARED_FUNC_IMPL
 {
     VECTOR3 unused;
     VECTOR3 vec;
@@ -30,3 +31,6 @@ void sharedFunc_800D4A74_7_s01(s_SubCharacter* chara, GsCOORDINATE2* coord)
     coord->coord.t[1] = FP_FROM(chara->position_18.vy, Q4_SHIFT);
     coord->coord.t[2] = FP_FROM(chara->position_18.vz, Q4_SHIFT);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D5098_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D5098_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D5098_0_s00(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     s16 temp_3;
     s32 temp_s5;
@@ -147,3 +148,6 @@ void sharedFunc_800D5098_0_s00(s_SubCharacter* chara)
         chara->moveSpeed_38 = newMoveSpeed1;
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D5274_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D5274_0_s01.h
@@ -1,4 +1,8 @@
 s32 sharedFunc_800D5274_0_s01()
+#ifdef SHARED_FUNC_IMPL
 {
     return MIN(FP_METER(-3.0f), g_SysWork.player_4C.chara_0.position_18.vy - FP_METER(2.0f));
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D595C_7_s01.h
+++ b/include/maps/shared/sharedFunc_800D595C_7_s01.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D595C_7_s01(s_SubCharacter* chara, s32 arg1, GsCOORDINATE2* coord)
+#ifdef SHARED_FUNC_IMPL
 {
     if (chara->properties_E4.player.properties_E4[3] == 0)
     {
@@ -6,3 +7,6 @@ void sharedFunc_800D595C_7_s01(s_SubCharacter* chara, s32 arg1, GsCOORDINATE2* c
         animInfo->funcPtr_0(chara, arg1, coord, animInfo);
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D59A4_7_s01.h
+++ b/include/maps/shared/sharedFunc_800D59A4_7_s01.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D59A4_7_s01(s_SubCharacter* chara, GsCOORDINATE2* coord)
+#ifdef SHARED_FUNC_IMPL
 {
     VECTOR3 unused;
     VECTOR3 vec;
@@ -30,3 +31,6 @@ void sharedFunc_800D59A4_7_s01(s_SubCharacter* chara, GsCOORDINATE2* coord)
     coord->coord.t[1] = FP_FROM(chara->position_18.vy, Q4_SHIFT);
     coord->coord.t[2] = FP_FROM(chara->position_18.vz, Q4_SHIFT);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D5B3C_7_s01.h
+++ b/include/maps/shared/sharedFunc_800D5B3C_7_s01.h
@@ -1,5 +1,6 @@
 
 void sharedFunc_800D5B3C_7_s01(s_SubCharacter* chara, GsCOORDINATE2* coords)
+#ifdef SHARED_FUNC_IMPL
 {
     s_func_800699F8 sp18;
     s32             sp28;
@@ -53,3 +54,6 @@ void sharedFunc_800D5B3C_7_s01(s_SubCharacter* chara, GsCOORDINATE2* coords)
 
     func_80096E78(&chara->rotation_24, &coords->coord);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D5B48_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D5B48_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D5B48_0_s00(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 moveSpeed;
     s32 newMoveSpeed;
@@ -38,3 +39,6 @@ void sharedFunc_800D5B48_0_s00(s_SubCharacter* chara)
         }
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D62D8_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D62D8_0_s01.h
@@ -1,4 +1,5 @@
 // Returns index. Called in `Ai_AirScreamer_Update`.
+#ifdef SHARED_FUNC_IMPL
 bool sharedFunc_800D62D8_0_s01(s_SubCharacter* chara)
 {
     if (sharedFunc_800D4A80_0_s01(chara) != 0 && !(sharedData_800E21D0_0_s01 & (1 << 29)))
@@ -11,3 +12,6 @@ bool sharedFunc_800D62D8_0_s01(s_SubCharacter* chara)
     sharedFunc_800D7560_0_s01(chara);
     return true;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D63D0_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D63D0_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D63D0_0_s00(s_SubCharacter* chara, s32 arg1)
+#ifdef SHARED_FUNC_IMPL
 {
     u16* flags;
     s32  moveSpeed;
@@ -61,3 +62,6 @@ void sharedFunc_800D63D0_0_s00(s_SubCharacter* chara, s32 arg1)
         }
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D6554_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D6554_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D6554_0_s00(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     s32  someDist;
     s16  someRotY;
@@ -56,3 +57,6 @@ void sharedFunc_800D6554_0_s00(s_SubCharacter* chara)
         sharedFunc_800D7E04_0_s00(chara, 0x553);
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D670C_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D670C_0_s00.h
@@ -1,5 +1,6 @@
 
 void sharedFunc_800D670C_0_s00(s_SubCharacter* arg0)
+#ifdef SHARED_FUNC_IMPL
 {
     if (arg0->model_0.stateStep_3 == 1)
     {
@@ -31,3 +32,6 @@ void sharedFunc_800D670C_0_s00(s_SubCharacter* arg0)
         }
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D67FC_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D67FC_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D67FC_0_s00(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     s32* sp10[7]; // Type assumed.
     s16  newRotY;
@@ -76,3 +77,6 @@ void sharedFunc_800D67FC_0_s00(s_SubCharacter* chara)
 
     *(u16*)&chara->properties_E4.player.properties_E4[1] = newFlags;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D7560_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D7560_0_s01.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D7560_0_s01(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     s32      headingAngle;
     s32      sinHeadingAngle;
@@ -44,3 +45,6 @@ void sharedFunc_800D7560_0_s01(s_SubCharacter* chara)
     mat->t[1] = FP_FROM(chara->position_18.vy, Q4_SHIFT);
     mat->t[2] = FP_FROM(chara->position_18.vz + offsetZ, Q4_SHIFT);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D7758_1_s00.h
+++ b/include/maps/shared/sharedFunc_800D7758_1_s00.h
@@ -1,5 +1,6 @@
 
 u8 sharedFunc_800D7758_1_s00(s32 arg0, s32 arg1)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 unk1 = 0xFFFB0000;
     s32 unk2 = 0x13FFFFU;
@@ -13,3 +14,6 @@ u8 sharedFunc_800D7758_1_s00(s32 arg0, s32 arg1)
     arg0 = (arg0 + 0xA0000) / 163840;
     return sharedData_800DCC14_1_s00[(arg0 * 7) + arg1];
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D7E04_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D7E04_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D7E04_0_s00(s_SubCharacter* chara, s32 caseArg)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 var_s1;
 
@@ -56,3 +57,6 @@ void sharedFunc_800D7E04_0_s00(s_SubCharacter* chara, s32 caseArg)
         *((u16*)&chara->properties_E4.player.properties_E4[7] + 1) = var_s1;
     }
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D81B0_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D81B0_0_s01.h
@@ -1,5 +1,9 @@
 bool sharedFunc_800D81B0_0_s01(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     sharedFunc_800D82B8_0_s01(chara);
     return true;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D8244_1_s02.h
+++ b/include/maps/shared/sharedFunc_800D8244_1_s02.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D8244_1_s02(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     switch (chara->model_0.state_2)
     {
@@ -28,3 +29,6 @@ void sharedFunc_800D8244_1_s02(s_SubCharacter* chara)
 
     chara->properties_E4.player.properties_E4[0] &= ~(1 << 8);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D88AC_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D88AC_0_s00.h
@@ -1,7 +1,11 @@
 void sharedFunc_800D88AC_0_s00(s_SubCharacter* playerChara)
+#ifdef SHARED_FUNC_IMPL
 {
     playerChara->properties_E4.player.properties_E4[PlayerProperty_Unk4]      = 0;
     playerChara->properties_E4.player.properties_E4[PlayerProperty_Unk3]      = 0;
     playerChara->properties_E4.player.properties_E4[PlayerProperty_PositionY] = 0;
     playerChara->properties_E4.player.field_126                               = 0;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D88C0_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D88C0_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D88C0_0_s00(s_SubCharacter* playerChara, s32 arg1)
+#ifdef SHARED_FUNC_IMPL
 {
     playerChara->properties_E4.player.properties_E4[PlayerProperty_Unk4] = 1;
 
@@ -18,3 +19,6 @@ void sharedFunc_800D88C0_0_s00(s_SubCharacter* playerChara, s32 arg1)
 
     playerChara->model_0.anim_4.flags_2 |= AnimFlag_Unk1;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D88D0_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D88D0_0_s01.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D88D0_0_s01(s_SubCharacter* chara, GsCOORDINATE2* coord)
+#ifdef SHARED_FUNC_IMPL
 {
     VECTOR3 unused;
     VECTOR3 vec;
@@ -30,3 +31,6 @@ void sharedFunc_800D88D0_0_s01(s_SubCharacter* chara, GsCOORDINATE2* coord)
     coord->coord.t[1] = FP_FROM(chara->position_18.vy, Q4_SHIFT);
     coord->coord.t[2] = FP_FROM(chara->position_18.vz, Q4_SHIFT);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D8904_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D8904_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D8904_0_s00(s_SubCharacter* playerChara, s32 afkTime)
+#ifdef SHARED_FUNC_IMPL
 {
     playerChara->properties_E4.player.field_126                               = 0;
     playerChara->properties_E4.player.properties_E4[PlayerProperty_RunTimer0] = 0;
@@ -7,3 +8,6 @@ void sharedFunc_800D8904_0_s00(s_SubCharacter* playerChara, s32 afkTime)
 
     playerChara->model_0.stateStep_3 = 0;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D891C_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D891C_0_s00.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D891C_0_s00(s_SubCharacter* playerChara)
+#ifdef SHARED_FUNC_IMPL
 {
     playerChara->properties_E4.player.properties_E4[PlayerProperty_RunTimer0] = 1;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D8928_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D8928_0_s00.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D8928_0_s00(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     chara->model_0.anim_4.flags_2 &= ~AnimFlag_Unk1;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D893C_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D893C_0_s00.h
@@ -1,4 +1,8 @@
 s32 sharedFunc_800D893C_0_s00(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     return ~(chara->model_0.anim_4.flags_2 & AnimFlag_Unk1);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D8950_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D8950_0_s00.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D8950_0_s00(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     chara->model_0.anim_4.flags_2 |= AnimFlag_Unk1;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D8964_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D8964_0_s00.h
@@ -1,4 +1,5 @@
 s32 sharedFunc_800D8964_0_s00(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
 #if defined(MAP6_S01)
     extern s_AnimInfo D_800D35A0[];
@@ -138,3 +139,6 @@ s32 sharedFunc_800D8964_0_s00(s_SubCharacter* chara)
 
     return -1;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D9064_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D9064_0_s00.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D9064_0_s00(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     chara->model_0.anim_4.flags_2 |= AnimFlag_Visible;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D9078_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D9078_0_s00.h
@@ -1,4 +1,8 @@
 void sharedFunc_800D9078_0_s00(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     chara->model_0.anim_4.flags_2 &= ~AnimFlag_Visible;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D908C_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D908C_0_s00.h
@@ -1,4 +1,5 @@
 bool sharedFunc_800D908C_0_s00(s32 arg0, s_SubCharacter* chara, s32 arg2, s32 arg3, s32 arg4, s32 arg5)
+#ifdef SHARED_FUNC_IMPL
 {
     if (chara->model_0.anim_4.animIdx_0 != arg0)
     {
@@ -35,3 +36,6 @@ bool sharedFunc_800D908C_0_s00(s32 arg0, s_SubCharacter* chara, s32 arg2, s32 ar
 
     return false;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D9188_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D9188_0_s00.h
@@ -1,4 +1,5 @@
 bool sharedFunc_800D9188_0_s00(s32 arg0, s_SubCharacter* arg1, s32 arg2, s32 sfx)
+#ifdef SHARED_FUNC_IMPL
 {
     // TODO: Should probably be using properties_E4.npc struct instead.
     if (arg1->model_0.anim_4.animIdx_0 == arg0)
@@ -97,3 +98,6 @@ bool sharedFunc_800D9188_0_s00(s32 arg0, s_SubCharacter* arg1, s32 arg2, s32 sfx
 
     return false;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D921C_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D921C_0_s00.h
@@ -1,4 +1,5 @@
 s16 sharedFunc_800D921C_0_s00(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     // TODO: Not sure if any of these match sharedData_800DF174_0_s00 in other maps.
 #if defined(MAP6_S01)
@@ -128,3 +129,6 @@ s16 sharedFunc_800D921C_0_s00(s_SubCharacter* chara)
 
     return animInfo->keyframeIdx0_C;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D923C_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D923C_0_s00.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D923C_0_s00(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     chara->model_0.stateStep_3 = 0;
 
@@ -22,3 +23,6 @@ void sharedFunc_800D923C_0_s00(s_SubCharacter* chara)
 
     chara->field_E0_8 = 3;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D929C_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D929C_0_s00.h
@@ -1,4 +1,8 @@
 s32 sharedFunc_800D929C_0_s00()
+#ifdef SHARED_FUNC_IMPL
 {
     return D_800A999C;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D92AC_0_s00.h
+++ b/include/maps/shared/sharedFunc_800D92AC_0_s00.h
@@ -55,6 +55,7 @@ static inline s32 GetYIndex(s32 x, u32 y)
 }
 
 u8 sharedFunc_800D92AC_0_s00(s32 x, s32 y)
+#ifdef SHARED_FUNC_IMPL
 {
     extern u8 sharedData_800DF2DC_0_s00[];
     extern u8 sharedData_800DF1FC_0_s00[];
@@ -111,3 +112,6 @@ u8 sharedFunc_800D92AC_0_s00(s32 x, s32 y)
 
     return res;
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800D983C_1_s02.h
+++ b/include/maps/shared/sharedFunc_800D983C_1_s02.h
@@ -1,4 +1,5 @@
 void sharedFunc_800D983C_1_s02(s_SubCharacter* chara)
+#ifdef SHARED_FUNC_IMPL
 {
     s32 unk[7]; // Type assumed.
     s32 newMoveSpeed;
@@ -46,3 +47,6 @@ void sharedFunc_800D983C_1_s02(s_SubCharacter* chara)
 
     chara->rotation_24.vy = func_8005BF38(chara->rotation_24.vy);
 }
+#else
+;
+#endif

--- a/include/maps/shared/sharedFunc_800DA8E8_0_s01.h
+++ b/include/maps/shared/sharedFunc_800DA8E8_0_s01.h
@@ -1,4 +1,5 @@
 void sharedFunc_800DA8E8_0_s01(s32* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4, s32 arg5) // 0x800DA8E8
+#ifdef SHARED_FUNC_IMPL
 {
     if (*arg0 < arg2)
     {
@@ -21,3 +22,6 @@ void sharedFunc_800DA8E8_0_s01(s32* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4
         }
     }
 }
+#else
+;
+#endif

--- a/src/maps/map0_s00/map0_s00.c
+++ b/src/maps/map0_s00/map0_s00.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map0_s00/map0_s00_2.c
+++ b/src/maps/map0_s00/map0_s00_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map0_s00/map0_s00_header.c
+++ b/src/maps/map0_s00/map0_s00_header.c
@@ -2,12 +2,11 @@
 #include "bodyprog/math.h"
 #include "maps/shared.h"
 #include "maps/map0/map0_s00.h"
-
-s32 sharedFunc_800D929C_0_s00();
-s32 sharedFunc_800D2DAC_0_s00();
-s32 sharedFunc_800D8964_0_s00(s_SubCharacter* chara);
-bool sharedFunc_800D9188_0_s00(s32 arg0, s_SubCharacter* arg1, s32 arg2, s32 sfx);
-void sharedFunc_800D08B8_0_s00(s8 arg0, u32 arg1);
+#include "maps/shared/sharedFunc_800D929C_0_s00.h"
+#include "maps/shared/sharedFunc_800D2DAC_0_s00.h"
+#include "maps/shared/sharedFunc_800D8964_0_s00.h"
+#include "maps/shared/sharedFunc_800D9188_0_s00.h"
+#include "maps/shared/sharedFunc_800D08B8_0_s00.h"
 
 // Undefined functions, unknown signature.
 #define func_800D94F8 (void(*)(void))0x800D94F8

--- a/src/maps/map0_s01/map0_s01.c
+++ b/src/maps/map0_s01/map0_s01.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map0_s02/map0_s02.c
+++ b/src/maps/map0_s02/map0_s02.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map1_s00/map1_s00.c
+++ b/src/maps/map1_s00/map1_s00.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map1_s00/map1_s00_2.c
+++ b/src/maps/map1_s00/map1_s00_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map1_s01/map1_s01.c
+++ b/src/maps/map1_s01/map1_s01.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map1_s01/map1_s01_2.c
+++ b/src/maps/map1_s01/map1_s01_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map1_s02/map1_s02.c
+++ b/src/maps/map1_s02/map1_s02.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map1_s02/map1_s02_2.c
+++ b/src/maps/map1_s02/map1_s02_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map1_s03/map1_s03.c
+++ b/src/maps/map1_s03/map1_s03.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map1_s03/map1_s03_2.c
+++ b/src/maps/map1_s03/map1_s03_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map1_s04/map1_s04.c
+++ b/src/maps/map1_s04/map1_s04.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map1_s05/map1_s05.c
+++ b/src/maps/map1_s05/map1_s05.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map1_s06/map1_s06.c
+++ b/src/maps/map1_s06/map1_s06.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map2_s00/map2_s00.c
+++ b/src/maps/map2_s00/map2_s00.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map2_s01/map2_s01.c
+++ b/src/maps/map2_s01/map2_s01.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map2_s02/map2_s02.c
+++ b/src/maps/map2_s02/map2_s02.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map2_s03/map2_s03.c
+++ b/src/maps/map2_s03/map2_s03.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map2_s04/map2_s04.c
+++ b/src/maps/map2_s04/map2_s04.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map3_s00/map3_s00.c
+++ b/src/maps/map3_s00/map3_s00.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map3_s01/map3_s01.c
+++ b/src/maps/map3_s01/map3_s01.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map3_s02/map3_s02.c
+++ b/src/maps/map3_s02/map3_s02.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map3_s03/map3_s03.c
+++ b/src/maps/map3_s03/map3_s03.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map3_s03/map3_s03_2.c
+++ b/src/maps/map3_s03/map3_s03_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map3_s04/map3_s04.c
+++ b/src/maps/map3_s04/map3_s04.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map3_s04/map3_s04_2.c
+++ b/src/maps/map3_s04/map3_s04_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map3_s05/map3_s05.c
+++ b/src/maps/map3_s05/map3_s05.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map3_s05/map3_s05_2.c
+++ b/src/maps/map3_s05/map3_s05_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map3_s06/map3_s06.c
+++ b/src/maps/map3_s06/map3_s06.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map4_s00/map4_s00.c
+++ b/src/maps/map4_s00/map4_s00.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map4_s01/map4_s01.c
+++ b/src/maps/map4_s01/map4_s01.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map4_s02/map4_s02.c
+++ b/src/maps/map4_s02/map4_s02.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map4_s03/map4_s03.c
+++ b/src/maps/map4_s03/map4_s03.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map4_s04/map4_s04.c
+++ b/src/maps/map4_s04/map4_s04.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map4_s05/map4_s05.c
+++ b/src/maps/map4_s05/map4_s05.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map4_s06/map4_s06.c
+++ b/src/maps/map4_s06/map4_s06.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map5_s00/map5_s00.c
+++ b/src/maps/map5_s00/map5_s00.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map5_s00/map5_s00_2.c
+++ b/src/maps/map5_s00/map5_s00_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map5_s01/map5_s01.c
+++ b/src/maps/map5_s01/map5_s01.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map5_s02/map5_s02.c
+++ b/src/maps/map5_s02/map5_s02.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map5_s02/map5_s02_2.c
+++ b/src/maps/map5_s02/map5_s02_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map5_s03/map5_s03.c
+++ b/src/maps/map5_s03/map5_s03.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map6_s00/map6_s00.c
+++ b/src/maps/map6_s00/map6_s00.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map6_s01/map6_s01.c
+++ b/src/maps/map6_s01/map6_s01.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map6_s02/map6_s02.c
+++ b/src/maps/map6_s02/map6_s02.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map6_s03/map6_s03.c
+++ b/src/maps/map6_s03/map6_s03.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map6_s03/map6_s03_2.c
+++ b/src/maps/map6_s03/map6_s03_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map6_s03/map6_s03_3.c
+++ b/src/maps/map6_s03/map6_s03_3.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map6_s04/map6_s04.c
+++ b/src/maps/map6_s04/map6_s04.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map6_s04/map6_s04_2.c
+++ b/src/maps/map6_s04/map6_s04_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map6_s05/map6_s05.c
+++ b/src/maps/map6_s05/map6_s05.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map7_s00/map7_s00.c
+++ b/src/maps/map7_s00/map7_s00.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map7_s01/map7_s01.c
+++ b/src/maps/map7_s01/map7_s01.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map7_s01/map7_s01_2.c
+++ b/src/maps/map7_s01/map7_s01_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map7_s02/map7_s02.c
+++ b/src/maps/map7_s02/map7_s02.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map7_s02/map7_s02_2.c
+++ b/src/maps/map7_s02/map7_s02_2.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"

--- a/src/maps/map7_s03/map7_s03.c
+++ b/src/maps/map7_s03/map7_s03.c
@@ -1,3 +1,4 @@
+#define SHARED_FUNC_IMPL
 #include "bodyprog/bodyprog.h"
 #include "bodyprog/math.h"
 #include "main/rng.h"


### PR DESCRIPTION
sharedFunc_xxx.h header files include code that is included in other .c files to be compiled. However, some other files require just the declaration of these functions. Guard the implementation in SHARED_FUNC_IMPL #ifdef block