### PR TITLE
Additional map header cleanup

### DIFF
--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -240,9 +240,9 @@ typedef struct
 
 typedef struct
 {
-    s32 field_0;
-    s32 field_4;
-    s16 field_8;
+    s32 vx_0;
+    s32 vz_4;
+    s16 vy_8;
     s8  unk_A;
     s8  field_B;
     s8  field_C;

--- a/include/types.h
+++ b/include/types.h
@@ -44,4 +44,6 @@ typedef struct
     short vz;
 } SVECTOR3;
 
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+
 #endif

--- a/src/bodyprog/bodyprog_80054FC0.c
+++ b/src/bodyprog/bodyprog_80054FC0.c
@@ -1796,9 +1796,9 @@ void func_800625F4(VECTOR3* arg0, s16 arg1, s32 arg2, s32 arg3) // 0x800625F4
         return;
     }
 
-    g_MapOverlayHeader.unkTable1_4C[idx].field_0  = arg0->vx;
-    g_MapOverlayHeader.unkTable1_4C[idx].field_8  = arg0->vy;
-    g_MapOverlayHeader.unkTable1_4C[idx].field_4  = arg0->vz;
+    g_MapOverlayHeader.unkTable1_4C[idx].vx_0     = arg0->vx;
+    g_MapOverlayHeader.unkTable1_4C[idx].vy_8     = arg0->vy;
+    g_MapOverlayHeader.unkTable1_4C[idx].vz_4     = arg0->vz;
     g_MapOverlayHeader.unkTable1_4C[idx].field_E  = arg1;
     g_MapOverlayHeader.unkTable1_4C[idx].field_D  = var;
     g_MapOverlayHeader.unkTable1_4C[idx].field_B  = Rng_TestProbabilityBits(2);

--- a/src/maps/map0_s00/map0_s00_header.c
+++ b/src/maps/map0_s00/map0_s00_header.c
@@ -31,9 +31,14 @@
 #define func_800DB94C (void(*)(void))0x800DB94C
 #define func_800DBE00 (void(*)(void))0x800DBE00
 
+#define sharedData_800DFB64_0_s00 (0x800DFB64)
+#define sharedData_800DFB68_0_s00 (0x800DFB68)
+#define sharedData_800DFB6C_0_s00 (0x800DFB6C)
+#define sharedData_800DFB70_0_s00 (0x800DFB70)
+
 extern u8 D_800DF754[];
-extern s_func_800625F4 D_800DFB7C[];
-extern s32 D_800E0B1C[];
+extern s_func_800625F4 D_800DFB7C[200];
+extern s_BloodSplat D_800E0B1C[150];
 
 extern s_AnimInfo g_AnimInfo[];
 void (*g_LoadScreenFuncs[])() = 
@@ -97,9 +102,9 @@ const s_MapOverlayHeader g_MapOverlayHeader =
     .func_44 = NULL,
     .func_48 = func_800DC1E8,
     .unkTable1_4C = D_800DFB7C,
-    .unkTable1Len_50 = 200,
+    .unkTable1Len_50 = ARRAY_SIZE(D_800DFB7C),
     .bloodSplats_54 = D_800E0B1C,
-    .bloodSplatsLen_58 = 150,
+    .bloodSplatsLen_58 = ARRAY_SIZE(D_800E0B1C),
     .always0_5C = 0,
     .always0_60 = 0,
     .always0_64 = 0,
@@ -175,10 +180,10 @@ const s_MapOverlayHeader g_MapOverlayHeader =
     .func_178 = func_800D0E24,
     .func_17C = func_800D0E2C,
     .func_180 = sharedFunc_800D0E04_0_s00,
-    .windSpeedX_184 = 0x800DFB64, // `sharedData_800DFB64_0_s00`
-    .windSpeedZ_188 = 0x800DFB68, // `sharedData_800DFB68_0_s00`
-    .data_18C = 0x800DFB6C, // `sharedData_800DFB6C_0_s00`
-    .data_190 = 0x800DFB70, // `sharedData_800DFB70_0_s00`
+    .windSpeedX_184 = sharedData_800DFB64_0_s00,
+    .windSpeedZ_188 = sharedData_800DFB68_0_s00,
+    .data_18C = sharedData_800DFB6C_0_s00,
+    .data_190 = sharedData_800DFB70_0_s00,
     .charaUpdateFuncs_194 =
     {
         NULL,
@@ -227,7 +232,7 @@ const s_MapOverlayHeader g_MapOverlayHeader =
         NULL,
         NULL
     },
-    .charaGroupIds_248 = {}, // 4 zeros.
+    .charaGroupIds_248 = {},
     .charaSpawns_24C =
     {
         #include "chara_spawns.h"

--- a/src/maps/map0_s01/map0_s01_header.c
+++ b/src/maps/map0_s01/map0_s01_header.c
@@ -17,6 +17,8 @@
 #define func_800CE000 ((void(*)())0x800CE000)
 #define func_800CFFD8 ((void(*)())0x800CFFD8)
 #define func_800D0850 ((void(*)())0x800D0850)
+#define func_800DA980 ((void(*)())0x800DA980)
+#define func_800DB790 ((void(*)())0x800DB790)
 
 #define sharedData_800DFB64_0_s00 (0x800DE254)
 #define sharedData_800DFB68_0_s00 (0x800DE258)
@@ -25,8 +27,8 @@
 
 extern u8 D_800DDFB8[];
 extern s_AnimInfo g_AnimInfo[];
-extern s_func_800625F4 D_800DE270[];
-extern s_BloodSplat D_800DF9E0[];
+extern s_func_800625F4 D_800DE270[300];
+extern s_BloodSplat D_800DF9E0[150];
 extern s32 D_800DFB10[];
 
 void (*g_LoadScreenFuncs[])() =
@@ -44,11 +46,11 @@ s_AreaLoadParams g_MapAreaLoadParams[] =
 
 void (*g_MapEventFuncs[])() = 
 {
-    0x00000000,
-    0x00000000,
+    NULL,
+    NULL,
     Event_HealthItemTake,
-    (void(*)())0x800DA980, // func_800DA980,
-    (void(*)())0x800DB790, // func_800DB790,
+    func_800DA980,
+    func_800DB790,
     func_800DBAA0,
     Event_KitchenKnifeItemTake,
     Event_FlashlightItemTake,
@@ -82,13 +84,13 @@ const s_MapOverlayHeader g_MapOverlayHeader =
     .animInfo_34 = g_AnimInfo,
     .field_38 = (s_UnkStruct3_Mo*)0x800DD6C0,
     .func_3C = func_800DC9C8,
-    .func_40 = (void(*)())0x800DCCF4, // func_800DCCF4,
+    .func_40 = func_800DCCF4,
     .func_44 = NULL,
     .func_48 = NULL,
     .unkTable1_4C = D_800DE270,
-    .unkTable1Len_50 = 300,
+    .unkTable1Len_50 = ARRAY_SIZE(D_800DE270),
     .bloodSplats_54 = D_800DF9E0,
-    .bloodSplatsLen_58 = 150,
+    .bloodSplatsLen_58 = ARRAY_SIZE(D_800DF9E0),
     .always0_5C = 0,
     .always0_60 = 0,
     .always0_64 = 0,
@@ -101,7 +103,7 @@ const s_MapOverlayHeader g_MapOverlayHeader =
     .func_80 = NULL,
     .func_84 = NULL,
     .unk_88 = D_800DFB10,
-    .func_8C = (void(*)())0x800CD1F8, // func_800CD1F8,
+    .func_8C = func_800CD1F8,
     .func_90 = NULL,
     .unk_94 = 0,
     .unk_98 = 0,
@@ -112,8 +114,8 @@ const s_MapOverlayHeader g_MapOverlayHeader =
     .func_AC = NULL,
     .func_B0 = NULL,
     .func_B4 = NULL,
-    .func_B8 = (void(*)())0x800D0C3C, // func_800D0C3C,
-    .func_BC = (void(*)())0x800D16C4, // func_800D16C4,
+    .func_B8 = func_800D0C3C,
+    .func_BC = func_800D16C4,
     .func_C0 = sharedFunc_800D209C_0_s00,
     .func_C4 = sharedFunc_800D20D8_0_s00,
     .freezePlayerControl_C8 = sharedFunc_800D20E4_0_s00,

--- a/src/maps/map0_s02/map0_s02_header.c
+++ b/src/maps/map0_s02/map0_s02_header.c
@@ -25,7 +25,7 @@ extern s_AnimInfo g_AnimInfo[];
 
 void (*g_LoadScreenFuncs[])() =
 {
-    0x00000000,
+    NULL,
     Gfx_LoadingScreen_PlayerRun,
     Gfx_LoadingScreen_BackgroundTexture,
     Gfx_LoadingScreen_StageString
@@ -38,8 +38,8 @@ s_AreaLoadParams g_MapAreaLoadParams[] =
 
 void (*g_MapEventFuncs[])() = 
 {
-    0x00000000,
-    0x00000000,
+    NULL,
+    NULL,
     Event_HealthOrAmmoItemTake,
     Event_EmptyFunction,
     Event_GasolineTankItemTake,
@@ -75,9 +75,9 @@ const s_MapOverlayHeader g_MapOverlayHeader =
     .func_44 = NULL,
     .func_48 = NULL,
     .unkTable1_4C = D_800D03DC,
-    .unkTable1Len_50 = 100,
+    .unkTable1Len_50 = ARRAY_SIZE(D_800D03DC),
     .bloodSplats_54 = D_800D0BAC,
-    .bloodSplatsLen_58 = 50,
+    .bloodSplatsLen_58 = ARRAY_SIZE(D_800D0BAC),
     .always0_5C = 0,
     .always0_60 = 0,
     .always0_64 = 0,


### PR DESCRIPTION
Use ARRAY_SIZE macro to set the array element count members.
Replace remaining hardcoded addresses with #define symbols.
Replace remaining 0x00000000 with NULL in func pointers.