### PR TITLE
correct MapOverlayHeader.func_168 signature, move some data to C

### DIFF
--- a/configs/maps/map0_s01.yaml
+++ b/configs/maps/map0_s01.yaml
@@ -67,7 +67,7 @@ segments:
 
       # .data section
       - [0x13EB8, .data, map0_s01_anim_info]
-      - [0x14214, data, map0_s01]
+      - [0x14220, data, map0_s01]
       - [0x1481C, .data, map0_s01_header]
       - [0x14910, .data, map0_s01_msg]
       - [0x14A40, data]

--- a/include/bodyprog/bodyprog.h
+++ b/include/bodyprog/bodyprog.h
@@ -1584,7 +1584,7 @@ typedef struct _MapOverlayHeader
     void              (*func_15C)(); // func(?) only map5_s01.
     void              (*func_160)(); // func(?) only map5_s01.
     void              (*func_164)(); // func(?) only map5_s01.
-    void              (*func_168)(void*, void*, void*);
+    void              (*func_168)(s32, s32, s32);
     void              (*func_16C)(VECTOR3*, s16);
     void              (*func_170)(); // func(?).
     void              (*func_174)(); // func(?).

--- a/src/bodyprog/bodyprog_80032D1C.c
+++ b/src/bodyprog/bodyprog_80032D1C.c
@@ -1366,7 +1366,7 @@ void func_80034F18() // 0x80034F18
     if (g_SysWork.field_234A != 0)
     {
         g_MapOverlayHeader.func_16C(g_SysWork.field_2349, 0x7F);
-        g_MapOverlayHeader.func_168(NULL, g_SavegamePtr->mapOverlayId_A4, NULL);
+        g_MapOverlayHeader.func_168(0, g_SavegamePtr->mapOverlayId_A4, 0);
     }
 
     func_80034EC8();
@@ -1388,7 +1388,7 @@ void Game_InGameInit() // 0x80034FB8
     func_8003D95C();
     func_8003EBA0();
 
-    g_MapOverlayHeader.func_168(NULL, (void*)mapOvlId, (void*)NO_VALUE);
+    g_MapOverlayHeader.func_168(0, mapOvlId, NO_VALUE);
 
     func_80034EC8();
 

--- a/src/maps/map0_s01/map0_s01_anim_info.c
+++ b/src/maps/map0_s01/map0_s01_anim_info.c
@@ -111,3 +111,8 @@ u8 g_LoadableItems[35] =
 };
 
 u8 D_800DD78B = 0;
+s32 sharedData_800DD78C_0_s01[2] = {};
+s8 D_800DD794 = 0;
+u8 sharedData_800DD591_0_s00 = 0;
+u8 sharedData_800DD796_0_s01 = 1;
+u8 __padding = 0;


### PR DESCRIPTION
Based on work in progress decomp of func_800CE000
(https://decomp.me/scratch/lLJ1i) 
the signature of func_168 has been corrected.
Some more map0_s01 data was moved to C