### PR TITLE
Match sharedFunc_800D8888_0_s01

### DIFF
--- a/include/maps/shared.h
+++ b/include/maps/shared.h
@@ -2327,6 +2327,7 @@ extern s32 sharedData_800DD78C_0_s01[2];
 extern u8 sharedData_800E2156_0_s01;
 
 extern s_AnimInfo KAUFMANN_ANIM_INFOS[]; // Used by `Anim_StartKeyframeIdxGet`, `Ai_Kaufmann` related?
+extern s_AnimInfo CYBIL_ANIM_INFOS[];
 
 extern s_AnimInfo BLOODY_LISA_ANIM_INFOS[]; // `Ai_BloodyLisa` related?
 

--- a/include/maps/shared/sharedFunc_800D8888_0_s01.h
+++ b/include/maps/shared/sharedFunc_800D8888_0_s01.h
@@ -1,0 +1,14 @@
+void sharedFunc_800D8888_0_s01(s_SubCharacter* arg0, s_AnmHeader* arg1, GsCOORDINATE2* arg2)
+{
+    s_AnimInfo* temp_a3;
+
+    if (arg0->properties_E4.player.field_F0 == 0)
+    {
+    #if defined(MAP6_S01) || defined(MAP7_S03)
+        temp_a3 = &CYBIL_ANIM_INFOS[arg0->model_0.anim_4.status_0];
+    #else
+        temp_a3 = &KAUFMANN_ANIM_INFOS[arg0->model_0.anim_4.status_0];
+    #endif
+        temp_a3->updateFunc_0(&arg0->model_0, arg1, arg2, temp_a3);
+    }
+}

--- a/src/maps/map0_s01/map0_s01.c
+++ b/src/maps/map0_s01/map0_s01.c
@@ -871,7 +871,7 @@ INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", func_800D8804);
 
 #include "maps/shared/Ai_Cybil_Update.h" // 0x800D8814
 
-INCLUDE_ASM("asm/maps/map0_s01/nonmatchings/map0_s01", sharedFunc_800D8888_0_s01); // 0x800D8888
+#include "maps/shared/sharedFunc_800D8888_0_s01.h"
 
 #include "maps/shared/sharedFunc_800D88D0_0_s01.h" // 0x800D88D0
 

--- a/src/maps/map4_s01/map4_s01.c
+++ b/src/maps/map4_s01/map4_s01.c
@@ -87,7 +87,7 @@ void func_800CFD84(void) {}
 
 #include "maps/shared/Ai_Cybil_Update.h" // 0x800CFDF0
 
-INCLUDE_ASM("asm/maps/map4_s01/nonmatchings/map4_s01", sharedFunc_800D8888_0_s01); // 0x800CFE64
+#include "maps/shared/sharedFunc_800D8888_0_s01.h"
 
 #include "maps/shared/sharedFunc_800D88D0_0_s01.h" // 0x800CFEAC
 

--- a/src/maps/map6_s01/map6_s01.c
+++ b/src/maps/map6_s01/map6_s01.c
@@ -83,7 +83,7 @@ void func_800CE490(void) {}
 
 #include "maps/shared/Ai_Cybil_Update.h" // 0x800CE4FC
 
-INCLUDE_ASM("asm/maps/map6_s01/nonmatchings/map6_s01", sharedFunc_800D8888_0_s01); // 0x800CE570
+#include "maps/shared/sharedFunc_800D8888_0_s01.h"
 
 #include "maps/shared/sharedFunc_800D88D0_0_s01.h" // 0x800CE5B8
 

--- a/src/maps/map7_s03/map7_s03.c
+++ b/src/maps/map7_s03/map7_s03.c
@@ -100,7 +100,7 @@ void func_800D102C() {}
 
 #include "maps/shared/Ai_Cybil_Update.h" // 0x800D1098
 
-INCLUDE_ASM("asm/maps/map7_s03/nonmatchings/map7_s03", sharedFunc_800D8888_0_s01); // 0x800D110C
+#include "maps/shared/sharedFunc_800D8888_0_s01.h"
 
 #include "maps/shared/sharedFunc_800D88D0_0_s01.h" // 0x800D1154
 


### PR DESCRIPTION
This function is not placed in its own header like all other shared functions because different maps use a different global symbol (KAUFMAN / CYBIL _ANIM_INFOS). I think these symbols should be renamed. KAUFMAN also appeared in map0_s00 recently. I think these anim tables contain different animations on each map and we can't give a specific character name to them. 