### PR TITLE
bodyprog: decompile func_8005CD38

### DIFF
--- a/include/bodyprog/player.h
+++ b/include/bodyprog/player.h
@@ -511,7 +511,7 @@ extern VECTOR3 D_800C4610;
 // ==========
 
 /** Used for enemy target locking. */
-void func_8005CD38(s32*, s32*, s_PlayerCombat*, s32, s32, s32);
+void func_8005CD38(s32*, s16*, s_PlayerCombat*, s32, s32, s32);
 
 /** Used for player run displacement.
  *

--- a/src/bodyprog/bodyprog_combat_8005BF38.c
+++ b/src/bodyprog/bodyprog_combat_8005BF38.c
@@ -165,8 +165,365 @@ s32 func_8005CB20(s_SubCharacter* chara, s_CollisionResult* arg1, q3_12 offsetX,
     return ret;
 }
 
-// Important for combat.
+#ifndef NON_MATCHING
 INCLUDE_ASM("bodyprog/nonmatchings/bodyprog_combat_8005BF38", func_8005CD38); // 0x8005CD38
+#else
+// Important for combat.
+void func_8005CD38(s32* outNpcIdx, s16* outAngle, s_PlayerCombat* combat, s32 angleConstraint, s32 range, s32 mode) // 0x8005CD38
+{
+    s32 _pad[4];
+    VECTOR3 rayFrom;
+    s_RayData ray;
+    VECTOR3 rayDir;
+    s32 projX;
+    s32 projZ;
+    VECTOR3 npcPos;
+    s32 npcIndices[6];
+    s16 elevAngles[6];
+    s16 horizAngles[6];
+    s32 distances[6];
+    s32 combatY;
+    s32 rangeSqQ6;
+    s32 combatX;
+    s32 combatZ;
+    s32 candidateCount;
+    s32 npcOffset;
+    u8* new_var;
+    s_SysWork* sysWork;
+    s32 i;
+    s_SysWork* npcPtr;
+    s16 angleCon;
+    s_SubCharacter* new_var2;
+    asm volatile("" : "+m" (mode), "+m" (_pad));
+    combatX = combat->field_0.vx;
+    combatY = combat->field_0.vy;
+    combatZ = combat->field_0.vz;
+    rangeSqQ6 = ((range) >> 6) * ((range) >> 6);
+    candidateCount = 0;
+    i = candidateCount;
+    angleCon = (s16)angleConstraint;
+    sysWork = &g_SysWork;
+    npcPtr = sysWork;
+    npcOffset = candidateCount;
+    rayFrom.vx = combatX;
+    rayFrom.vy = combatY;
+    rayFrom.vz = combatZ;
+    *outNpcIdx = -1;
+    do
+    {
+        if (npcPtr->npcs_1A0[0].model_0.charaId_0 == Chara_None)
+        {
+            goto next_npc;
+        }
+        if (npcPtr->npcs_1A0[0].health_B0 < 0)
+        {
+            goto next_npc;
+        }
+        npcPos.vx = npcPtr->npcs_1A0[0].position_18.vx + npcPtr->npcs_1A0[0].field_D8.offsetX_0;
+        npcPos.vy = npcPtr->npcs_1A0[0].position_18.vy + npcPtr->npcs_1A0[0].field_C8.field_6;
+        npcPos.vz = npcPtr->npcs_1A0[0].position_18.vz + npcPtr->npcs_1A0[0].field_D8.offsetZ_2;
+        if (mode < 3)
+        {
+            s32 dx = ((combatX - npcPos.vx) >> 6);
+            s32 dy = ((combatY - npcPos.vy) >> 6);
+            s32 dz = ((combatZ - npcPos.vz) >> 6);
+            if (rangeSqQ6 < dx * dx + dy * dy + dz * dz)
+            {
+                goto next_npc;
+            }
+            {
+                s16* hPtr = (s16*)((u8*)horizAngles + npcOffset);
+                *(u16*)hPtr = ratan2(npcPos.vx - combatX, npcPos.vz - combatZ);
+                {
+                    s16 angleDiff;
+                    s16 wrapped;
+                    wrapped = func_8005BF38((s16)((u16)sysWork->playerWork_4C.player_0.rotation_24.vy - *(u16*)hPtr));
+                    if ((s32)(wrapped << 16) < 0)
+                    {
+                        angleDiff = -func_8005BF38((s16)((u16)sysWork->playerWork_4C.player_0.rotation_24.vy - *(u16*)hPtr));
+                    }
+                    else
+                    {
+                        angleDiff = func_8005BF38((s16)((u16)sysWork->playerWork_4C.player_0.rotation_24.vy - *(u16*)hPtr));
+                    }
+                    if (angleCon < angleDiff)
+                    {
+                        goto next_npc;
+                    }
+                }
+            }
+            if (mode != 0)
+            {
+                if (sysWork->targetNpcIdx_2353 == i)
+                {
+                    goto next_npc;
+                }
+                {
+                    s16* hPtr = (s16*)((u8*)horizAngles + npcOffset);
+                    s16 relAngle;
+                    relAngle = func_8005BF38((s16)(*(u16*)hPtr - (u16)sysWork->playerWork_4C.player_0.field_2A));
+                    *(u16*)hPtr = relAngle;
+                    if (mode == 1)
+                    {
+                        if ((s32)(relAngle << 16) < 0)
+                        {
+                            goto next_npc;
+                        }
+                    }
+                    if (mode == 2)
+                    {
+                        if ((s32)(relAngle << 16) > 0)
+                        {
+                            i += 1;
+                            goto loop_end;
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            projX = combatX + (((angleCon) * (Math_Sin((s32)sysWork->playerWork_4C.player_0.rotation_24.vy))) >> (12));
+            new_var = (u8*)(&horizAngles[0]);
+            {
+                s32 dx = ((projX - npcPos.vx) >> 6);
+                s32 cosVal = (((angleCon) * (Math_Cos((s32)sysWork->playerWork_4C.player_0.rotation_24.vy))) >> (12));
+                s32 dz;
+                projZ = combatZ + cosVal;
+                dz = ((projZ - npcPos.vz) >> 6);
+                if (rangeSqQ6 < dx * dx + dz * dz)
+                {
+                    goto next_npc;
+                }
+            }
+            {
+                s16* hPtr = (s16*)(new_var + npcOffset);
+                *hPtr = func_8005BF38((s16)(ratan2(npcPos.vx - combatX, npcPos.vz - combatZ) - (u16)sysWork->playerWork_4C.player_0.rotation_24.vy));
+            }
+            if (mode != 3)
+            {
+                s32 hx = ((npcPos.vx - combatX) >> 6);
+                s32 hz = ((npcPos.vz - combatZ) >> 6);
+                distances[candidateCount] = ((SquareRoot0(hx * hx + hz * hz)) << 6);
+            }
+        }
+        {
+            s32 hx = ((npcPos.vx - combatX) >> 6);
+            s32 hz = ((npcPos.vz - combatZ) >> 6);
+            s16 elevAngle;
+            s16* elevPtr;
+            elevAngle = ratan2(((SquareRoot0(hx * hx + hz * hz)) << 6), npcPos.vy - combatY);
+            elevPtr = (s16*)((u8*)elevAngles + npcOffset);
+            *elevPtr = elevAngle;
+            if (elevAngle < 0)
+            {
+                goto next_npc;
+            }
+            if (elevAngle >= 0x801)
+            {
+                goto next_npc;
+            }
+            if ((u32)(mode - 1) < 2u)
+            {
+            }
+            else if (sysWork->targetNpcIdx_2353 == i)
+            {
+                *outNpcIdx = i;
+                *outAngle = (u16)*elevPtr;
+                goto end;
+            }
+            npcIndices[candidateCount] = i;
+            npcOffset += 2;
+            candidateCount += 1;
+        }
+    next_npc:
+        i += 1;
+    loop_end:
+        npcPtr = (s_SysWork*)((u8*)npcPtr + 0x128);
+    } while (i < 6);
+    if (candidateCount == 0)
+    {
+        goto end;
+    }
+    if (candidateCount <= 0)
+    {
+        goto end;
+    }
+    {
+        s32 outerIdx;
+        s32* outerNpcPtr;
+        s32 outerIdxX4;
+        outerIdx = 0;
+        sysWork = (s_SysWork*)((u8*)&g_SysWork + 0x1A0);
+        outerNpcPtr = &npcIndices[0];
+        outerIdxX4 = 0;
+        do
+        {
+            s32 j = outerIdx + 1;
+            new_var2 = g_SysWork.npcs_1A0;
+            if (j < candidateCount)
+            {
+                s16* outerHorizAngle = &horizAngles[outerIdx];
+                s32* outerDist = (s32*)((u8*)distances + outerIdxX4);
+                s32 innerIdxX2 = outerIdx * 2;
+                s32* innerNpcPtr = &npcIndices[j];
+                s16* innerHorizAngle = &horizAngles[j];
+                s32 innerIdxTimes2 = j * 2;
+                s32* innerDist = &distances[j];
+                do
+                {
+                    if (!((u16)g_SysWork.npcs_1A0[*outerNpcPtr].flags_3E & 2))
+                    {
+                        if ((u16)g_SysWork.npcs_1A0[*innerNpcPtr].flags_3E & 2)
+                        {
+                            goto no_swap;
+                        }
+                    }
+                    else if (!((u16)g_SysWork.npcs_1A0[*innerNpcPtr].flags_3E & 2))
+                    {
+                        goto do_swap;
+                    }
+                    switch (mode)
+                    {
+                    case 0:
+                    case 3:
+                    {
+                        s16 outerVal = *outerHorizAngle;
+                        s16 innerVal = *innerHorizAngle;
+                        s16 outerAbs = outerVal;
+                        if (outerVal < 0)
+                        {
+                            outerAbs = -outerAbs;
+                        }
+                        if (innerVal >= 0)
+                        {
+                            if (innerVal < outerAbs)
+                            {
+                                goto do_swap;
+                            }
+                            goto no_swap;
+                        }
+                        else
+                        {
+                            if (-innerVal < outerAbs)
+                            {
+                                goto do_swap;
+                            }
+                            goto no_swap;
+                        }
+                    }
+                    case 1:
+                    {
+                        s32 cmp = *innerHorizAngle < *outerHorizAngle;
+                        if (cmp == 0)
+                        {
+                            goto no_swap;
+                        }
+                        goto do_swap;
+                    }
+                    case 2:
+                    {
+                        s32 cmp = *outerHorizAngle < *innerHorizAngle;
+                        if (cmp == 0)
+                        {
+                            goto no_swap;
+                        }
+                        goto do_swap;
+                    }
+                    case 4:
+                    {
+                        s32 outerDistQ6 = ((*outerDist) >> 6);
+                        s32 outerAngleAbs;
+                        s32 innerDistQ6;
+                        s32 innerAngleAbs;
+                        outerAngleAbs = *outerHorizAngle;
+                        if (outerAngleAbs < 0)
+                        {
+                            outerAngleAbs = -outerAngleAbs;
+                        }
+                        innerDistQ6 = ((*innerDist) >> 6);
+                        innerAngleAbs = *innerHorizAngle;
+                        if (innerAngleAbs < 0)
+                        {
+                            innerAngleAbs = -innerAngleAbs;
+                        }
+                        if (innerDistQ6 * innerDistQ6 * innerAngleAbs < outerDistQ6 * outerDistQ6 * outerAngleAbs)
+                        {
+                            goto do_swap;
+                        }
+                        goto no_swap;
+                    }
+                    case 5:
+                        if (*innerDist < *outerDist)
+                        {
+                            goto do_swap;
+                        }
+                        goto no_swap;
+                    }
+                do_swap:
+                    if ((u32)(mode - 4) < 2u)
+                    {
+                        s32 tmpDist = *outerDist;
+                        *outerDist = *innerDist;
+                        *innerDist = tmpDist;
+                    }
+                    {
+                        s16 tmpAngle = *outerHorizAngle;
+                        *outerHorizAngle = *innerHorizAngle;
+                        {
+                            s16* outerElevPtr = (s16*)((u8*)elevAngles + innerIdxX2);
+                            s16* innerElevPtr = (s16*)((u8*)elevAngles + innerIdxTimes2);
+                            *innerHorizAngle = tmpAngle;
+                            {
+                                s16 tmpElev = *outerElevPtr;
+                                *outerElevPtr = *innerElevPtr;
+                                *innerElevPtr = tmpElev;
+                            }
+                        }
+                        {
+                            s32 tmpIdx = *outerNpcPtr;
+                            *outerNpcPtr = *innerNpcPtr;
+                            *innerNpcPtr = tmpIdx;
+                        }
+                    }
+                no_swap:
+                    innerNpcPtr += 1;
+                    innerHorizAngle += 1;
+                    innerIdxTimes2 += 2;
+                    j += 1;
+                    innerDist += 1;
+                } while (j < candidateCount);
+            }
+            {
+                s32 npcIdx = *outerNpcPtr;
+                rayDir.vx = (new_var2[npcIdx].position_18.vx + g_SysWork.npcs_1A0[npcIdx].field_D8.offsetX_0) - combatX;
+                rayDir.vy = (g_SysWork.npcs_1A0[npcIdx].position_18.vy + g_SysWork.npcs_1A0[npcIdx].field_C8.field_6) - combatY;
+                rayDir.vz = (g_SysWork.npcs_1A0[npcIdx].position_18.vz + g_SysWork.npcs_1A0[npcIdx].field_D8.offsetZ_2) - combatZ;
+                if (func_8006DA08(&ray, &rayFrom, &rayDir, &g_SysWork.playerWork_4C.player_0) &&
+                    ray.chara_10 == &g_SysWork.npcs_1A0[npcIdx])
+                {
+                    goto found;
+                }
+            }
+            outerNpcPtr += 1;
+            outerIdx += 1;
+            outerIdxX4 += 4;
+            if (outerIdx >= candidateCount)
+            {
+                goto check_result;
+            }
+        } while (1);
+    found:
+    check_result:
+        if (outerIdx < candidateCount)
+        {
+            *outNpcIdx = npcIndices[outerIdx];
+            *outAngle = (u16)elevAngles[outerIdx];
+        }
+    }
+end:;
+}
+#endif
 
 bool func_8005D50C(s32* targetNpcIdx, q3_12* outAngle0, q3_12* outAngle1, VECTOR3* unkOffset, u32 npcIdx, q19_12 angleConstraint) // 0x8005D50C
 {


### PR DESCRIPTION
## Summary

- Decompile `func_8005CD38` (combat targeting / enemy lock-on) in `bodyprog_combat_8005BF38.c` as `NON_MATCHING`
- Fix `func_8005CD38` declaration in `player.h`: `s32*` → `s16*` for `outAngle` parameter (all 14 call sites pass `s16`/`q3_12`)
- This was the last `INCLUDE_ASM` in `bodyprog_combat_8005BF38.c`

## NON_MATCHING rationale

The function has an `s8` register allocation mismatch — the compiler assigns a different register than what appears in the original binary. This is a fundamental compiler heuristic issue confirmed across 8 GCC versions (2.6.3 through 2.95.2). The decompiled C is functionally equivalent and produces identical logic, just with different register usage.

## Test plan

- [x] `make ENG=1 build -j4` passes checksum (`build/USA/out/1ST/BODYPROG.BIN: OK`)