### PR TITLE
feat: decompile func_8009E198, completing libkpad (24/24)

### DIFF
--- a/include/libkpad.h
+++ b/include/libkpad.h
@@ -171,6 +171,8 @@ typedef struct _func_8009ECCC
     u16                    field_1E;
 } s_func_8009ECCC;
 
+s32 func_8009E198(s_SysWork_2514* work, u32 flags);
+
 s32 func_8009E230(s_SysWork_2514* arg0);
 
 s32 func_8009E268(s_SysWork_2514* arg0);

--- a/src/bodyprog/libkpad/libkpad.c
+++ b/src/bodyprog/libkpad/libkpad.c
@@ -50,7 +50,44 @@ s_SysWork_2510 D_800B142C = {
     .func_C  = func_8009E9D0,
 };
 
-INCLUDE_ASM("bodyprog/nonmatchings/libkpad/libkpad", func_8009E198);
+s32 func_8009E198(s_SysWork_2514* work, u32 flags) // 0x8009E198
+{
+    // @hack `register` binding is required: 2.7.2's allocator otherwise assigns $v0
+    // to `status` (highest priority) and parks the return value in $a3 across the
+    // block. Only a call or an explicit binding keeps $v0 live through the bitfield
+    // chain, and this function makes no calls, so the original allocation is not
+    // reachable from plain C under this compiler.
+    register bool ret __asm__("$2");
+
+    ret = work != NULL;
+
+    if (ret)
+    {
+        s32 scale = 0x80;
+        s_SysWork_2514_0 status = {
+            .field_0_8   = scale,
+            .field_0_16  = 1,
+            .field_0_17  = 1,
+            .field_0_18  = 1,
+            .field_0_19  = 0,
+            .field_0_22  = 0,
+            .field_0_23  = 0,
+            .field_0_24  = 0,
+            .padPort_0_0 = 0,
+        };
+        flags = flags & 0x13;
+        status.padPort_0_0 = flags;
+
+        work->actuatorData_4 = 0;
+        // @hack Single-word store; `field_8`/`field_A`/`unk_B` written as one `s32`.
+        *(s32*)&work->field_8 = 0;
+        work->field_C  = NULL;
+        work->field_10 = NULL;
+        work->field_0  = status;
+    }
+
+    return ret;
+}
 
 s32 func_8009E230(s_SysWork_2514* arg0) // 0x8009E230
 {


### PR DESCRIPTION
## Summary
- Decompiles `func_8009E198`, the last `INCLUDE_ASM` in libkpad (24/24 functions matching) and the last one in the USA build
- Based on emoose's matching scratch (https://decomp.me/scratch/xAED2), adapted to the repo's struct definitions
- Adds the missing declaration to `include/libkpad.h`
- One `register ... asm("$2")` binding, with a comment documenting the allocator behavior that requires it

## Verification
- Output through the repo cc272 pipeline is byte-identical to the retail disc: the 38 instructions, encrypted with the overlay cipher, occur at exactly one place on a redump USA image (sector 449 = BODYPROG.BIN offset 0x79638)
- No codegen change to the other 30 functions in the TU (full pre/post diff of the compiled unit)
- Caller TU (`bodyprog_80089090.c`, gcc 2.8.1) codegen unchanged by the new prototype
- Compiler provenance (repo CC1PSX.EXE is sha256-identical to the PsyQ 4.1 SDK disc's) and the analysis of why the register binding is the minimum possible: https://github.com/Vatuu/silent-hill-decomp/issues/482#issuecomment-5010419122

Reproduction scripts: https://github.com/Vatuu/silent-hill-decomp/issues/482#issuecomment-5010422145
